### PR TITLE
Convert week views to grid calendar layout

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -793,3 +793,177 @@ td.num, th.num {
         font-size: 0.65rem;
     }
 }
+
+/* ========== Week Grid Layouts ========== */
+
+/* Single person week view - horizontal grid */
+.week-grid-single {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 20px;
+}
+
+.week-grid-single thead th {
+    background: var(--panel);
+    padding: 12px 8px;
+    text-align: center;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text);
+    border: 1px solid var(--table-border);
+}
+
+.week-grid-single .calendar-day {
+    height: 140px;
+    width: 14.28%; /* 100% / 7 days */
+}
+
+.calendar-rotation-week {
+    font-size: 0.7rem;
+    color: var(--muted);
+    margin-top: 4px;
+}
+
+/* All persons week view - person x day grid */
+.week-grid-wrapper {
+    overflow-x: auto;
+    margin-top: 20px;
+}
+
+.week-grid-all {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 800px;
+}
+
+.week-grid-all thead th {
+    background: var(--panel);
+    padding: 12px 8px;
+    text-align: center;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text);
+    border: 1px solid var(--table-border);
+    position: sticky;
+    top: 0;
+    z-index: 10;
+}
+
+.week-grid-all .person-header-column {
+    position: sticky;
+    left: 0;
+    z-index: 20;
+    min-width: 120px;
+    background: var(--panel);
+}
+
+.week-grid-all .day-column {
+    min-width: 100px;
+}
+
+.week-grid-all .day-column.today-column {
+    background: rgba(64, 169, 255, 0.15);
+}
+
+.week-grid-all .date-small {
+    font-size: 0.75rem;
+    color: var(--muted);
+    font-weight: normal;
+    margin-top: 2px;
+}
+
+.week-grid-all .person-row {
+    border-bottom: 1px solid var(--table-border);
+}
+
+.week-grid-all .person-name-cell {
+    position: sticky;
+    left: 0;
+    background: var(--panel);
+    padding: 6px 12px;
+    text-align: left;
+    font-weight: 500;
+    border-right: 2px solid var(--table-border);
+    z-index: 10;
+}
+
+.week-grid-all .person-name-cell a {
+    color: var(--text);
+    text-decoration: none;
+}
+
+.week-grid-all .person-name-cell a:hover {
+    color: var(--accent);
+}
+
+.week-grid-all .person-name-cell small {
+    color: var(--muted);
+    font-size: 0.75rem;
+}
+
+.week-grid-all .shift-cell {
+    padding: 6px 8px;
+    text-align: center;
+    background: var(--panel);
+    border: 1px solid var(--table-border);
+    position: relative;
+}
+
+.week-grid-all .shift-cell.today-cell {
+    background: rgba(64, 169, 255, 0.08);
+}
+
+.week-grid-all .shift-link {
+    text-decoration: none;
+    display: inline-block;
+}
+
+.week-grid-all .shift-link:hover .badge {
+    opacity: 0.9;
+    transform: scale(1.05);
+    transition: all 0.15s ease;
+}
+
+/* Responsive week grids */
+@media (max-width: 1024px) {
+    .week-grid-single .calendar-day {
+        height: 120px;
+    }
+
+    .week-grid-all .day-column {
+        min-width: 80px;
+    }
+
+    .week-grid-all .person-name-cell {
+        min-width: 100px;
+        font-size: 0.85rem;
+    }
+}
+
+@media (max-width: 768px) {
+    .week-grid-single .calendar-day {
+        height: 100px;
+    }
+
+    .calendar-rotation-week {
+        font-size: 0.65rem;
+    }
+
+    .week-grid-all {
+        min-width: 600px;
+    }
+
+    .week-grid-all .day-column {
+        min-width: 70px;
+    }
+
+    .week-grid-all .person-name-cell {
+        min-width: 80px;
+        font-size: 0.8rem;
+        padding: 8px;
+    }
+
+    .week-grid-all .shift-cell {
+        padding: 6px 4px;
+    }
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -5,7 +5,7 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Periodical</title>
-        <link rel="stylesheet" href="/static/style.css?v=6">
+        <link rel="stylesheet" href="/static/style.css?v=8">
     </head>
     <body>
         <header>

--- a/app/templates/week.html
+++ b/app/templates/week.html
@@ -28,45 +28,63 @@
 
 <h2 class="page-title">Week {{ week }} {{ year }} - Person {{ person_id }}</h2>
 
-    <table>
-        <thead>
-            <tr>
-                <th>Day</th>
-                <th>Date</th>
-                <th>Rotation week</th>
-                <th>Shift</th>
-                <th>Time</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for day in days %}
-                <tr class="shift-row {% if today is defined and day.date == today %}today-row{% endif %}"
-                    style="border-left:6px solid {% if day.shift %}{{ day.shift.color }}{% else %}transparent{% endif %};">
-                    <td class="day-cell">{{ day.weekday_name }}</td>
-                    <td class="date-cell">
-                        <a href="/day/{{ person_id }}/{{ day.date.year }}/{{ day.date.month }}/{{ day.date.day }}">
-                            {{ day.date }}
-                        </a>
-                    </td>
-                    <td>{{ day.rotation_week }}</td>
-                    <td>
-                        {% if day.shift %}
-                            <span class="badge"
-                                  style="background: {{ day.shift.color }}; color: {{ day.shift.color | contrast }};">
-                                {{ day.shift.code }}
-                            </span>
-                        {% else %}
-                            <span class="badge badge-off">OFF</span>
-                        {% endif %}
-                    </td>
-                    {% if day.shift and day.shift.start_time is not none %}
-                        <td>{{ day.shift.start_time }} to {{ day.shift.end_time }}</td>
-                    {% else %}
-                        <td>No shift</td>
-                    {% endif %}
-                </tr>
+{# Calendar grid view for week #}
+{% set weekday_names_short = ['Mån', 'Tis', 'Ons', 'Tor', 'Fre', 'Lör', 'Sön'] %}
+
+<table class="calendar-grid week-grid-single">
+    <thead>
+        <tr>
+            {% for day_name in weekday_names_short %}
+                <th>{{ day_name }}</th>
             {% endfor %}
-        </tbody>
-    </table>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            {% for day in days %}
+                {% set is_today = today is defined and day.date == today %}
+
+                <td class="calendar-day {% if is_today %}today-cell{% endif %}"
+                    style="border-top: 4px solid {% if day.shift %}{{ day.shift.color }}{% else %}#333{% endif %};">
+
+                    <div class="calendar-day-content">
+                        <div class="calendar-day-header">
+                            <a href="/day/{{ person_id }}/{{ day.date.year }}/{{ day.date.month }}/{{ day.date.day }}"
+                               class="day-number">
+                                {{ day.date.day }}/{{ day.date.month }}
+                            </a>
+                            {# Show rotation week on each day for easy reference #}
+                            <div class="calendar-rotation-week">Rot. v{{ day.rotation_week }}</div>
+                            {% if day.date.weekday() == 0 %}
+                                <span class="rotation-week-small">v{{ day.date.isocalendar()[1] }}</span>
+                            {% endif %}
+                            
+                        </div>
+                        
+
+                        <div class="calendar-day-body">
+                            {% if day.shift %}
+                                <span class="badge calendar-badge"
+                                      style="background: {{ day.shift.color }}; color: {{ day.shift.color | contrast }};">
+                                    {{ day.shift.code }}
+                                </span>
+                            {% else %}
+                                <span class="badge badge-off calendar-badge">OFF</span>
+                            {% endif %}
+
+                            {% if day.shift and day.shift.code != 'OC' %}
+                                {% if day.shift.code == 'OT' and day.start and day.end %}
+                                    <div class="calendar-time">{{ day.start.strftime('%H:%M') }} - {{ day.end.strftime('%H:%M') }}</div>
+                                {% elif day.shift.start_time is not none %}
+                                    <div class="calendar-time">{{ day.shift.start_time }} - {{ day.shift.end_time }}</div>
+                                {% endif %}
+                            {% endif %}
+                        </div>
+                    </div>
+                </td>
+            {% endfor %}
+        </tr>
+    </tbody>
+</table>
 
 {% endblock %}

--- a/app/templates/week_all.html
+++ b/app/templates/week_all.html
@@ -28,65 +28,93 @@
 
 <h2 class="page-title">Week {{ week }} {{ year }} - All persons</h2>
 
-<table class="month-schedule table-sticky">
+{# Grid calendar view: persons as rows, days as columns #}
+{% set weekday_names_short = ['Mån', 'Tis', 'Ons', 'Tor', 'Fre', 'Lör', 'Sön'] %}
+
+<div class="week-grid-wrapper">
+    <table class="week-grid-all">
         <thead>
             <tr>
-                <th style="min-width:120px">Day</th>
-                <th style="min-width:140px">Date</th>
-                {% if days and days|length > 0 %}
-                    {% for p in days[0].persons %}
-                        <th class="person-header">
-                            {# Länka bara till egen sida eller om admin #}
-                            {% if user and (user.role.value == 'admin' or user.id == p.person_id) %}
-                                <a href="/week/{{ p.person_id }}?year={{ year }}&week={{ week }}">
-                                    {{ p.person_name }}<br>
-                                    <small>(#{{ p.person_id }})</small>
-                                </a>
-                            {% else %}
-                                {{ p.person_name }}<br>
-                                <small>(#{{ p.person_id }})</small>
-                            {% endif %}
-                        </th>
-                    {% endfor %}
-                {% endif %}
+                <th class="person-header-column">Person</th>
+                {% for day in days %}
+                    <th class="day-column {% if today is defined and day.date == today %}today-column{% endif %}">
+                        <div>{{ weekday_names_short[day.date.weekday()] }}</div>
+                        <div class="date-small">{{ day.date.day }}/{{ day.date.month }}</div>
+                    </th>
+                {% endfor %}
             </tr>
         </thead>
         <tbody>
-            {% for day in days %}
-                <tr class="shift-row {% if today is defined and day.date == today %}today-row{% endif %}">
-                    <td class="day-cell" data-label="Dag">{{ day.weekday_name }}</td>
-                    <td class="date-cell" data-label="Datum">{{ day.date }}</td>
-                    {% for person in day.persons %}
-                        <td data-label="{{ person.person_name }}" style="border-left:6px solid {% if person.shift %}{{ person.shift.color }}{% else %}transparent{% endif %}; padding-left:8px;">
-                            {% if person.shift %}
+            {# Build rows for each person (1-10) #}
+            {% for person_id in range(1, 11) %}
+                <tr class="person-row">
+                    {# Person name column (sticky left) #}
+                    <td class="person-name-cell">
+                        {% if days and days|length > 0 and days[0].persons|length >= person_id %}
+                            {% set person_data = days[0].persons[person_id - 1] %}
+                            {% if user and (user.role.value == 'admin' or user.id == person_id) %}
+                                <a href="/week/{{ person_id }}?year={{ year }}&week={{ week }}">
+                                    {{ person_data.person_name }}<br>
+                                    <small>(#{{ person_id }})</small>
+                                </a>
+                            {% else %}
+                                {{ person_data.person_name }}<br>
+                                <small>(#{{ person_id }})</small>
+                            {% endif %}
+                        {% else %}
+                            Person {{ person_id }}
+                        {% endif %}
+                    </td>
+
+                    {# Day cells for this person #}
+                    {% for day in days %}
+                        {# Find this person's shift for this day #}
+                        {% set ns = namespace(person=none) %}
+                        {% for p in day.persons %}
+                            {% if p.person_id == person_id %}
+                                {% set ns.person = p %}
+                            {% endif %}
+                        {% endfor %}
+
+                        {% set is_today = today is defined and day.date == today %}
+
+                        <td class="shift-cell {% if is_today %}today-cell{% endif %}"
+                            style="border-left: 4px solid {% if ns.person and ns.person.shift %}{{ ns.person.shift.color }}{% else %}#ddd{% endif %};">
+
+                            {% if ns.person and ns.person.shift %}
                                 {# Länka till day-sida bara om admin eller egen #}
-                                {% if user and (user.role.value == 'admin' or user.id == person.person_id) %}
-                                    <a href="/day/{{ person.person_id }}/{{ day.date.year }}/{{ day.date.month }}/{{ day.date.day }}"
-                                       style="text-decoration:none;">
+                                {% if user and (user.role.value == 'admin' or user.id == person_id) %}
+                                    <a href="/day/{{ person_id }}/{{ day.date.year }}/{{ day.date.month }}/{{ day.date.day }}"
+                                       class="shift-link"
+                                       style="color: var(--text); text-decoration: none;">
                                 {% endif %}
-                                    {% if person.shift.code == 'SEM' %}
-                                        <span class="badge badge-sem"
-                                              title="Semester"
-                                              style="background: {{ person.shift.color }}; color: {{ person.shift.color | contrast }};">
-                                            SEM
-                                        </span>
-                                    {% elif person.shift.code == 'OT' %}
-                                        <span class="badge"
-                                              title="{% if person.start and person.end %}Övertid: {{ person.start.strftime('%H:%M') }} - {{ person.end.strftime('%H:%M') }}{% else %}Övertid (tider saknas){% endif %}"
-                                              style="background: {{ person.shift.color }}; color: {{ person.shift.color | contrast }};">
-                                            OT
-                                        </span>
+
+                                <div class="shift-name" style="color: {{ ns.person.shift.color }}; font-weight: 500; font-size: 0.85rem;">
+                                    {% if ns.person.shift.code == 'SEM' %}
+                                        Semester
+                                    {% elif ns.person.shift.code == 'OT' %}
+                                        Övertid
+                                    {% elif ns.person.shift.code == 'OC' %}
+                                        Beredskap
+                                    {% elif ns.person.shift.code == 'OFF' %}
+                                        Ledig
                                     {% else %}
-                                        <span class="badge"
-                                              style="background: {{ person.shift.color }}; color: {{ person.shift.color | contrast }};">
-                                            {{ person.shift.code }}
-                                        </span>
+                                        {{ ns.person.shift.label or ns.person.shift.code }}
                                     {% endif %}
-                                {% if user and (user.role.value == 'admin' or user.id == person.person_id) %}
+                                </div>
+
+                                {# Show times for OT shifts #}
+                                {% if ns.person.shift.code == 'OT' and ns.person.start and ns.person.end %}
+                                    <div class="shift-time" style="color: var(--muted); font-size: 0.7rem; margin-top: 2px;">
+                                        {{ ns.person.start.strftime('%H:%M') }}-{{ ns.person.end.strftime('%H:%M') }}
+                                    </div>
+                                {% endif %}
+
+                                {% if user and (user.role.value == 'admin' or user.id == person_id) %}
                                     </a>
                                 {% endif %}
                             {% else %}
-                                <span class="badge badge-off">OFF</span>
+                                <span class="shift-name" style="color: var(--muted); font-size: 0.85rem;">Ledig</span>
                             {% endif %}
                         </td>
                     {% endfor %}
@@ -94,5 +122,6 @@
             {% endfor %}
         </tbody>
     </table>
+</div>
 
 {% endblock %}


### PR DESCRIPTION
Single person week view (/week/{person_id}):
- Convert from vertical table to horizontal grid calendar (7 columns)
- Show day/month, rotation week indicators, shift badge, and times
- Color-coded shift borders for visual identification
- Fix OT (overtime) shift display with correct start/end times
- Highlight current day with today-cell styling
- Reuse calendar-grid styling from month view

All persons week view (/week):
- Transform from day-per-row to person-per-row layout
- Grid: 10 rows (persons) x 7 columns (days Mon-Sun)
- Sticky person names column (left) and weekday headers (top)
- Show full shift names (Dagpass, Kvällspass, Nattpass, Beredskap, etc.)
- Display overtime shift times below shift name (e.g., 14:00-22:30)
- Color-coded shift text matching shift colors
- Highlight current day column for all persons
- Compact row height (6px vertical padding) for better overview

CSS improvements:
- Add .week-grid-single for single person horizontal layout
- Add .week-grid-all for person x day grid with sticky positioning
- Today column highlighting with accent color background
- Responsive breakpoints for mobile devices (1024px, 768px)
- Hover effects on clickable shift links
- Compact spacing for maximum information density

Benefits:
- See entire week schedule for all 10 persons at a glance
- Consistent visual language with month/year views
- Better information density and readability
- Easier to spot shift patterns and coverage gaps
- Overtime shifts clearly show when they occur
- Mobile-friendly with horizontal scroll
- Transposed layout answers 'who works when' instantly

Closes #37