### PR TITLE
feat: Add OFF absence type (paid time off)

### DIFF
--- a/app/core/schedule/summary.py
+++ b/app/core/schedule/summary.py
@@ -138,6 +138,8 @@ def summarize_month_for_person(
         totals["vab_hours"] = absence_info["vab_hours"]
         totals["leave_days"] = absence_info["leave_days"]
         totals["leave_hours"] = absence_info["leave_hours"]
+        totals["off_days"] = absence_info["off_days"]
+        totals["off_hours"] = absence_info["off_hours"]
         absence_details = absence_info["details"]
 
         # Dra av frånvaroavdrag från bruttolön
@@ -290,11 +292,14 @@ def _build_year_summary(months: list[dict]) -> dict:
     total_vab_hours = sum(m.get("vab_hours", 0.0) for m in months)
     total_leave_days = sum(m.get("leave_days", 0) for m in months)
     total_leave_hours = sum(m.get("leave_hours", 0.0) for m in months)
+    total_off_days = sum(m.get("off_days", 0) for m in months)
+    total_off_hours = sum(m.get("off_hours", 0.0) for m in months)
 
     # Calculate deductions per type from monthly details
     sick_deduction = 0.0
     vab_deduction = 0.0
     leave_deduction = 0.0
+    off_deduction = 0.0
 
     for m in months:
         details = m.get("absence_details", [])
@@ -305,6 +310,8 @@ def _build_year_summary(months: list[dict]) -> dict:
                 vab_deduction += detail["deduction"]
             elif detail["type"] == "LEAVE":
                 leave_deduction += detail["deduction"]
+            elif detail["type"] == "OFF":
+                off_deduction += detail["deduction"]
 
     # OB per kod
     ob_codes = ["OB1", "OB2", "OB3", "OB4", "OB5"]
@@ -334,9 +341,12 @@ def _build_year_summary(months: list[dict]) -> dict:
         "total_vab_hours": total_vab_hours,
         "total_leave_days": total_leave_days,
         "total_leave_hours": total_leave_hours,
+        "total_off_days": total_off_days,
+        "total_off_hours": total_off_hours,
         "sick_deduction": sick_deduction,
         "vab_deduction": vab_deduction,
         "leave_deduction": leave_deduction,
+        "off_deduction": off_deduction,
         "avg_netto": total_netto / month_count,
         "avg_brutto": total_brutto / month_count,
         "avg_shifts": total_shifts / month_count,

--- a/app/database/database.py
+++ b/app/database/database.py
@@ -40,6 +40,7 @@ class AbsenceType(str, enum.Enum):
     SICK = "SICK"  # Sjukfrånvaro - ger sjuklön efter dag 1
     VAB = "VAB"  # Vård av barn - ingen extra ersättning
     LEAVE = "LEAVE"  # Ledigt/Permission - ingen extra ersättning
+    OFF = "OFF"  # Ledig - inget löneavdrag
 
 
 class User(Base):

--- a/app/templates/day.html
+++ b/app/templates/day.html
@@ -306,7 +306,9 @@
                                     {% elif absence.absence_type.value == 'VAB' %}
                                         VAB (Vård av barn)
                                     {% elif absence.absence_type.value == 'LEAVE' %}
-                                        Ledigt
+                                        Ledigt (obetald)
+                                    {% elif absence.absence_type.value == 'OFF' %}
+                                        Ledig (betald)
                                     {% else %}
                                         {{ absence.absence_type.value }}
                                     {% endif %}
@@ -318,6 +320,8 @@
                                         <span class="badge" style="background: #f97316; color: white;">VAB</span>
                                     {% elif absence.absence_type.value == 'LEAVE' %}
                                         <span class="badge" style="background: #a855f7; color: white;">Ledigt</span>
+                                    {% elif absence.absence_type.value == 'OFF' %}
+                                        <span class="badge" style="background: #888888; color: white;">Ledig</span>
                                     {% endif %}
                                 </td>
                                 <td>
@@ -376,7 +380,8 @@
                                 <option value="">-- Välj typ --</option>
                                 <option value="SICK">Sjuk</option>
                                 <option value="VAB">VAB (Vård av barn)</option>
-                                <option value="LEAVE">Ledigt</option>
+                                <option value="LEAVE">Ledigt (obetald)</option>
+                                <option value="OFF">Ledig (betald)</option>
                             </select>
                         </div>
                     </div>
@@ -391,7 +396,9 @@
                     <br>
                     <strong>VAB:</strong> Vård av barn (orange färg)
                     <br>
-                    <strong>Ledigt:</strong> Permission eller annan ledighet (lila färg)
+                    <strong>Ledigt (obetald):</strong> Permission eller annan ledighet med löneavdrag (lila färg)
+                    <br>
+                    <strong>Ledig (betald):</strong> Ledig dag utan löneavdrag (grå färg)
                 </p>
             {% endif %}
         </section>

--- a/app/templates/year.html
+++ b/app/templates/year.html
@@ -259,17 +259,23 @@
                     <td class="num" data-label="Avdrag" style="color: #f97316;">-{{ "%.0f"|format(year_summary.vab_deduction or 0) }} kr</td>
                 </tr>
                 <tr class="shift-row">
-                    <td data-label="Typ">Leave (Ledigt)</td>
+                    <td data-label="Typ">Leave (Ledigt obetald)</td>
                     <td class="num" data-label="Dagar">{{ year_summary.total_leave_days or 0 }}</td>
                     <td class="num" data-label="Timmar">{{ "%.1f"|format(year_summary.total_leave_hours or 0) }}</td>
                     <td class="num" data-label="Avdrag" style="color: #a855f7;">-{{ "%.0f"|format(year_summary.leave_deduction or 0) }} kr</td>
+                </tr>
+                <tr class="shift-row">
+                    <td data-label="Typ">OFF (Ledig betald)</td>
+                    <td class="num" data-label="Dagar">{{ year_summary.total_off_days or 0 }}</td>
+                    <td class="num" data-label="Timmar">{{ "%.1f"|format(year_summary.total_off_hours or 0) }}</td>
+                    <td class="num" data-label="Avdrag" style="color: #888888;">{{ "%.0f"|format(year_summary.off_deduction or 0) }} kr</td>
                 </tr>
             </tbody>
             <tfoot>
                 <tr>
                     <td data-label="Typ"><strong>Total</strong></td>
-                    <td class="num" data-label="Dagar"><strong>{{ (year_summary.total_sick_days or 0) + (year_summary.total_vab_days or 0) + (year_summary.total_leave_days or 0) }}</strong></td>
-                    <td class="num" data-label="Timmar"><strong>{{ "%.1f"|format((year_summary.total_sick_hours or 0) + (year_summary.total_vab_hours or 0) + (year_summary.total_leave_hours or 0)) }}</strong></td>
+                    <td class="num" data-label="Dagar"><strong>{{ (year_summary.total_sick_days or 0) + (year_summary.total_vab_days or 0) + (year_summary.total_leave_days or 0) + (year_summary.total_off_days or 0) }}</strong></td>
+                    <td class="num" data-label="Timmar"><strong>{{ "%.1f"|format((year_summary.total_sick_hours or 0) + (year_summary.total_vab_hours or 0) + (year_summary.total_leave_hours or 0) + (year_summary.total_off_hours or 0)) }}</strong></td>
                     <td class="num" data-label="Avdrag" style="color: #ef4444;"><strong>-{{ "%.0f"|format(year_summary.total_absence_deduction or 0) }} kr</strong></td>
                 </tr>
             </tfoot>

--- a/migrate_absence_add_off_type.py
+++ b/migrate_absence_add_off_type.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""
+Migration script to add OFF absence type support.
+
+This migration is a no-op for the database schema since AbsenceType is stored as a string.
+The OFF type is already supported in the code, this script just validates the setup.
+
+Run with: python migrate_absence_add_off_type.py
+"""
+
+import sqlite3
+from pathlib import Path
+
+
+def migrate():
+    """Validate database is ready for OFF absence type."""
+    db_path = Path("app/database/schedule.db")
+
+    if not db_path.exists():
+        print(f"❌ Database not found at {db_path}")
+        print("   Run migrate_to_db.py first to create the database.")
+        return False
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    try:
+        # Check if absences table exists
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='absences'")
+        if not cursor.fetchone():
+            print("❌ Absences table not found")
+            print("   Run migrate_absence.py first to create the absences table.")
+            return False
+
+        # Check table structure
+        cursor.execute("PRAGMA table_info(absences)")
+        columns = {col[1]: col[2] for col in cursor.fetchall()}
+
+        print("✅ Absences table found")
+        print(f"   Columns: {', '.join(columns.keys())}")
+
+        # Verify absence_type column exists
+        if "absence_type" not in columns:
+            print("❌ absence_type column not found")
+            return False
+
+        print("✅ absence_type column exists")
+
+        # Check if there are any existing OFF absences
+        cursor.execute("SELECT COUNT(*) FROM absences WHERE absence_type = 'OFF'")
+        off_count = cursor.fetchone()[0]
+
+        print(f"ℹ️  Current OFF absences: {off_count}")
+
+        print("\n✅ Database is ready for OFF absence type!")
+        print("\nOFF absence type features:")
+        print("- Can be manually registered on any day")
+        print("- Uses gray color (#888888) from shift_types.json")
+        print("- 0% wage deduction (paid time off)")
+        print("- Appears in year summary statistics")
+        print("\nNo database changes needed - OFF type is already supported!")
+        return True
+
+    except sqlite3.Error as e:
+        print(f"❌ Validation failed: {e}")
+        return False
+
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("OFF Absence Type Migration")
+    print("=" * 60)
+    print()
+    migrate()


### PR DESCRIPTION
Adds new absence type for paid time off without wage deduction
 **Features:**
 - New OFF absence type for paid days off
 - 0% wage deduction (unlike LEAVE which has 100% deduction)
 - Uses gray color (#888888) from existing shift_types.json
 - Appears in year summary statistics separately
 - Can be manually registered on any day

 **Changes:**
 - Add OFF to AbsenceType enum
 - Update wage deduction calculation (0% for OFF)
 - Add OFF option to absence form
 - Update year view to display OFF statistics
 - Update summary calculations to track OFF separately

 **Testing:**
 ✅ Tested manually - OFF type registers correctly
 ✅ No wage deduction applied
 ✅ Displays with gray color
 ✅ Appears in statistics