### PR TITLE
Fix storhelg badge to be date-based instead of shift-based

### DIFF
--- a/app/routes/public.py
+++ b/app/routes/public.py
@@ -21,6 +21,7 @@ from app.core.helpers import (
 from app.core.logging_config import get_logger
 from app.core.oncall import (
     _cached_oncall_rules,
+    _get_storhelg_dates_for_year,
     calculate_oncall_pay,
     calculate_oncall_pay_for_period,
 )
@@ -540,6 +541,10 @@ async def show_day_for_person(
 
     show_salary = can_see_salary(current_user, person_id)
 
+    # Check if this date is a storhelg (major holiday)
+    storhelg_dates = _get_storhelg_dates_for_year(year)
+    is_storhelg = date_obj in storhelg_dates
+
     # Fetch absence for this person and date
     absence = db.query(Absence).filter(Absence.user_id == person_id, Absence.date == date_obj).first()
 
@@ -598,6 +603,7 @@ async def show_day_for_person(
             "iso_year": iso_year,
             "iso_week": iso_week,
             "show_salary": show_salary,
+            "is_storhelg": is_storhelg,  # Whether this date is a major holiday
             "ot_shift": ot_details if show_salary and ot_details else None,
             "ot_shift_id": ot_shift_id,
             "absence": absence,  # Pass absence data to template

--- a/app/templates/day.html
+++ b/app/templates/day.html
@@ -40,7 +40,7 @@
     <div class="day-header">
         <h2>
             {{ weekday_name }} {{ date }} - {{ person_name }} ({{ person_id }})
-            {% if show_salary and ob_hours.get("OB5", 0) > 0 %}
+            {% if show_salary and is_storhelg %}
                 <span class="badge-ob5">Storhelg</span>
             {% endif %}
         </h2>


### PR DESCRIPTION
## Description
This PR fixes the issue where the 'Storhelg' (major holiday) badge disappears when adding overtime (OT) to an on-call (OC) shift. The badge is now based on the date itself rather than whether the shift has OB5 hours.

## Problem
Previously, the storhelg badge was displayed based on the condition:
```jinja
{% if show_salary and ob_hours.get("OB5", 0) > 0 %}
```

This caused the badge to disappear when:
- Adding overtime to an on-call shift (OT shifts don't have OB hours)
- The shift was replaced or modified in any way that removed OB5 hours

## Solution
The badge is now displayed based on whether the date is a storhelg:
```jinja
{% if show_salary and is_storhelg %}
```

### Changes Made
1. **app/routes/public.py**:
   - Import `_get_storhelg_dates_for_year` from `app.core.oncall`
   - Check if `date_obj` is in the set of storhelg dates for the year
   - Pass `is_storhelg` boolean to the template

2. **app/templates/day.html**:
   - Update badge condition from `ob_hours.get("OB5", 0) > 0` to `is_storhelg`
   - Badge now displays based on date, not shift type

## Testing
- ✅ Verified that 2026-06-21 (Midsommar) is correctly identified as storhelg
- ✅ Python syntax validation passed
- ✅ Pre-commit hooks (ruff) passed
- ✅ Badge now persists when adding overtime to on-call shifts

## Benefits
- **Correct behavior**: Badge shows for all storhelg dates regardless of shift type
- **Consistent UX**: Users can always see when a date is a major holiday
- **Accurate information**: Badge reflects the date's holiday status, not the shift's OB calculation

## Example
Before: Storhelg badge on 2026-06-21 → Add OT → Badge disappears ❌
After: Storhelg badge on 2026-06-21 → Add OT → Badge remains ✅

Closes #55