### PR TITLE
Config security and UX improvements (#84, #90, #69)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,8 @@
 SECRET_KEY=CHANGE-ME-TO-RANDOM-SECRET-KEY-MINIMUM-32-CHARACTERS
 
 # PRODUCTION - Set to 'true' in production (enables secure cookies, HTTPS-only)
-PRODUCTION=true
+# Default: false for safe local development
+PRODUCTION=false
 
 # Database URL (optional, defaults to SQLite)
 # DATABASE_URL=sqlite:///./app/database/schedule.db

--- a/app/main.py
+++ b/app/main.py
@@ -65,7 +65,11 @@ app = FastAPI(
 
 # CORS Configuration
 IS_PRODUCTION = os.getenv("PRODUCTION", "false").lower() == "true"
-CORS_ORIGINS = os.getenv("CORS_ORIGINS", "").split(",") if os.getenv("CORS_ORIGINS") else []
+CORS_ORIGINS = (
+    [origin.strip() for origin in os.getenv("CORS_ORIGINS", "").split(",") if origin.strip()]
+    if os.getenv("CORS_ORIGINS")
+    else []
+)
 
 if IS_PRODUCTION:
     # Production: Strict CORS - only allow specified origins
@@ -118,6 +122,4 @@ async def health_check():
 
     Returns 200 OK if application is running.
     """
-    return JSONResponse(
-        status_code=200, content={"status": "healthy", "service": "periodical", "version": "0.0.20"}
-    )
+    return JSONResponse(status_code=200, content={"status": "healthy", "service": "periodical", "version": "0.0.20"})

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -45,10 +45,6 @@
             <button type="submit" class="btn" style="width: 100%;">Logga in</button>
         </form>
     </div>
-    <div><br><br></div>
-    <div class="card">
-        <p>Råkade nolla databasen 😅, logga in med standard lösenord och byt första gången</p>
-    </div>
 </div>
 
 {% endblock %}


### PR DESCRIPTION
## Summary
Three small but important fixes for production safety and user experience:

1. **Safe production defaults** - Changed `.env.example` to default to development mode
2. **Professional login page** - Removed developer message from login screen
3. **Robust CORS parsing** - Fixed whitespace handling in CORS origins configuration

## Changes

### 🔒 Security: Fix .env.example production default (#84)
**File:** `.env.example`
- Changed `PRODUCTION=true` → `PRODUCTION=false`
- Added clarifying comment about safe local development default
- **Impact:** Prevents new developers from accidentally running in production mode

### 🎨 UX: Remove dev message from login page (#90)
**File:** `app/templates/login.html`
- Removed "Råkade nolla databasen 😅" development message
- Cleaner, more professional login experience
- **Impact:** Better first impression for production users

### 🐛 Bug: Fix CORS whitespace parsing (#69)
**File:** `app/main.py`
- Strip whitespace from each CORS origin entry
- Filter out empty strings after splitting
- Multi-line format for better readability (ruff formatted)
- **Impact:** Prevents CORS rejection when environment variable contains spaces like `"https://example.com, https://other.com"`

## Technical Details

**Before (CORS parsing):**
```python
CORS_ORIGINS = os.getenv("CORS_ORIGINS", "").split(",") if os.getenv("CORS_ORIGINS") else []
# Problem: " https://other.com" includes leading space → CORS fails
```

**After:**
```python
CORS_ORIGINS = (
    [origin.strip() for origin in os.getenv("CORS_ORIGINS", "").split(",") if origin.strip()]
    if os.getenv("CORS_ORIGINS")
    else []
)
# Solution: strip() removes whitespace, if origin.strip() filters empties
```

## Testing
- ✅ All 77 existing tests pass
- ✅ Python syntax check OK
- ✅ Ruff linting & formatting pass
- ✅ No breaking changes

## Risk Assessment
**Low risk** - All changes are:
- Configuration defaults (safer direction)
- UI text removal (no logic changes)
- Defensive parsing (more permissive, not restrictive)

Fixes #84, #90, #69