### PR TITLE
Fix: Add error handling for settings.json file I/O

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -126,7 +126,48 @@ async def admin_settings_update(
 
     # Update settings.json (for default monthly_salary only)
     settings_path = Path("data/settings.json")
-    settings_data = json.loads(settings_path.read_text(encoding="utf-8"))
+    try:
+        settings_data = json.loads(settings_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return templates.TemplateResponse(
+            "admin_settings.html",
+            {
+                "request": request,
+                "user": current_user,
+                "settings": settings,
+                "persons": [],
+                "tax_brackets": tax_brackets,
+                "error": "Konfigurationsfil saknas. Kontakta administratör.",
+            },
+            status_code=500,
+        )
+    except json.JSONDecodeError as e:
+        return templates.TemplateResponse(
+            "admin_settings.html",
+            {
+                "request": request,
+                "user": current_user,
+                "settings": settings,
+                "persons": [],
+                "tax_brackets": tax_brackets,
+                "error": f"Korrupt konfigurationsfil: {e}. Kontakta administratör.",
+            },
+            status_code=500,
+        )
+    except OSError as e:
+        return templates.TemplateResponse(
+            "admin_settings.html",
+            {
+                "request": request,
+                "user": current_user,
+                "settings": settings,
+                "persons": [],
+                "tax_brackets": tax_brackets,
+                "error": f"Kunde inte läsa konfigurationsfil: {e}. Kontakta administratör.",
+            },
+            status_code=500,
+        )
+
     settings_data["monthly_salary"] = monthly_salary
     write_json_safely(settings_path, settings_data)
 


### PR DESCRIPTION
## Summary
Adds comprehensive error handling for file I/O operations when reading `settings.json` in the admin settings update route.

## Changes
- Wrapped `settings.json` read operation in try/except block in `app/routes/admin.py:129-169`
- Added handling for three error cases:
  - **FileNotFoundError**: Returns user-friendly error message
  - **JSONDecodeError**: Returns error with details about file corruption
  - **OSError**: Catches general I/O errors (permissions, disk issues, etc.)
- All errors return HTTP 500 with contextual error messages in Swedish

## Impact
- **Before**: Application would crash if settings.json was missing or corrupted
- **After**: Graceful error handling with user-friendly messages
- Improves system resilience and user experience

## Testing
- ✅ Python syntax validation passed (py_compile)
- ✅ Pre-commit hooks passed (ruff check & format)
- Follows existing error handling patterns in the same file

## Code Quality Analysis
During the fix, I audited all file I/O operations in the codebase:
- ✅ `app/core/storage.py` already has excellent error handling via `_load_json()` helper
- ✅ `app/main.py` has proper JSON validation at startup
- ✅ `app/routes/admin.py:129` was the only location lacking error handling in production code

Closes #34