### PR TITLE
Fix: Remove exception swallowing in contrast_color helper

### DIFF
--- a/app/core/helpers.py
+++ b/app/core/helpers.py
@@ -24,7 +24,7 @@ def contrast_color(hex_color: str) -> str:
         r = int(h[0:2], 16)
         g = int(h[2:4], 16)
         b = int(h[4:6], 16)
-    except Exception:
+    except ValueError:
         return "#fff"
     lum = (0.299 * r + 0.587 * g + 0.114 * b) / 255
     return "#000" if lum > 0.5 else "#fff"


### PR DESCRIPTION
## Summary
Fixes overly broad exception handling in `contrast_color()` function that could hide actual bugs.

## Problem
The function was catching **all exceptions** with `except Exception:`, which could mask real bugs:
```python
except Exception:  # ❌ Too broad!
    return "#fff"
```

## Solution
Changed to catch only the specific exception that can occur during hex color parsing:
```python
except ValueError:  # ✅ Specific and correct
    return "#fff"
```

## Why This Matters
- **Before**: Any unexpected exception (including bugs) would silently return `#fff`
- **After**: Only invalid hex color values are caught; other exceptions propagate correctly for debugging
- **Behavior**: Same fallback behavior for invalid colors, but better error visibility

## Technical Details
The `int(hex, 16)` operation only raises `ValueError` when parsing invalid hex strings. Other exceptions would indicate actual bugs that should be surfaced, not hidden.

## Testing
- ✅ Python syntax validation passed
- ✅ Pre-commit hooks passed (ruff check & format)
- Function still returns `#fff` for invalid hex colors
- Other exceptions now propagate correctly

Closes #72