### PR TITLE
Add coworker display in personal schedule views

### DIFF
--- a/app/static/css/calendar.css
+++ b/app/static/css/calendar.css
@@ -53,6 +53,7 @@
 .calendar-day-body { flex: 1; display: flex; flex-direction: column; gap: 4px; }
 .calendar-badge { font-size: 0.75rem; padding: 3px 7px; align-self: flex-start; }
 .calendar-time { font-size: 0.7rem; color: var(--muted); margin-top: 2px; }
+.coworkers-list { font-size: 0.7rem; color: var(--muted); margin-top: 2px; font-style: italic; line-height: 1.2; }
 .calendar-hours { font-size: 0.75rem; color: var(--accent-2); font-weight: 600; }
 .calendar-pay { font-size: 0.75rem; color: var(--accent); font-weight: 600; margin-top: auto; }
 
@@ -98,7 +99,7 @@
   .calendar-day-content { padding: 4px; }
   .day-number { font-size: 1rem; }
   .calendar-badge { font-size: 0.65rem; padding: 2px 5px; }
-  .calendar-time, .calendar-hours, .calendar-pay { font-size: 0.65rem; }
+  .calendar-time, .coworkers-list, .calendar-hours, .calendar-pay { font-size: 0.65rem; }
   
   .week-grid-single .calendar-day { height: 100px; }
   .calendar-rotation-week { font-size: 0.65rem; }

--- a/app/static/css/tables.css
+++ b/app/static/css/tables.css
@@ -34,6 +34,14 @@ td.num, th.num { text-align: right; font-family: ui-monospace, SFMono-Regular, M
 .today-row { background: rgba(64, 169, 255, 0.08); }
 .today-row:hover { background: rgba(64, 169, 255, 0.14); }
 
+.coworkers-row {
+  background: rgba(255,255,255,0.02);
+  font-size: 0.9rem;
+  color: var(--muted);
+  font-style: italic;
+}
+.coworkers-row:hover { background: rgba(255,255,255,0.03); }
+
 /* Responsive Tables */
 @media (max-width: 800px) {
   thead { display: none; }

--- a/app/templates/day.html
+++ b/app/templates/day.html
@@ -90,6 +90,13 @@
                         </td>
                         <td>{{ "%.2f"|format(hours) if hours else "0.00" }}</td>
                     </tr>
+                    {% if coworkers %}
+                    <tr>
+                        <td colspan="5" class="coworkers-row">
+                            <strong>Arbetar med:</strong> {{ coworkers | join(', ') }}
+                        </td>
+                    </tr>
+                    {% endif %}
                 </tbody>
             </table>
                 <!-- <section class="day-section"> -->

--- a/app/templates/month.html
+++ b/app/templates/month.html
@@ -146,6 +146,10 @@
                                             <div class="calendar-time">{{ day_data.shift.start_time }} - {{ day_data.shift.end_time }}</div>
                                         {% endif %}
                                     {% endif %}
+
+                                    {% if day_data.coworkers %}
+                                        <div class="coworkers-list">Med: {{ day_data.coworkers | join(', ') }}</div>
+                                    {% endif %}
                                 </div>
                             </div>
                         </td>

--- a/app/templates/week.html
+++ b/app/templates/week.html
@@ -81,6 +81,10 @@
                                     <div class="calendar-time">{{ day.shift.start_time }} - {{ day.shift.end_time }}</div>
                                 {% endif %}
                             {% endif %}
+
+                            {% if day.coworkers %}
+                                <div class="coworkers-list">Med: {{ day.coworkers | join(', ') }}</div>
+                            {% endif %}
                         </div>
                     </div>
                 </td>


### PR DESCRIPTION
## Summary
Visar vilka kollegor man arbetar med i personliga dag-, vecko- och månadsvyer. Kollegnamn visas under skiftinformation.

## Funktionalitet
- **Dagsvy**: Visar "Arbetar med: [namn]" i shift-tabellen
- **Vecko-/Månadsvy**: Visar "Med: [namn]" under skifttider
- **Intelligent matchning**:
  - Schemalagda pass (N1, N2, N3): Matchar per skifttyp
  - Övertidspass (OT): Matchar via ursprungligt schemalagt pass eller tidsöverlappning (≥4 timmar)
  - Exkluderar icke-arbetande status (OFF, SICK, VAB, LEAVE, SEM, OC)

## Implementationsdetaljer
- Ny funktion `get_coworkers_for_day()` med tidsbaserad överlappningsdetektering
- Spårar `original_shift` för OT/frånvaro för korrekt matchning
- Använder batch loading för att undvika N+1 queries
- Konsekvent styling över alla vyer

## Edge cases
- ✅ Person har OT som ersätter schemalagt pass → matchar via original_shift
- ✅ Person har OT på OFF-dag → matchar via tidsöverlappning
- ✅ Person är frånvarande/sjuk → visas inte som kollega
- ✅ Flera personer på samma skift → visar alla

## Test plan
- [x] Manuellt testat på dag-, vecko- och månadsvyer
- [x] Verifierat matchning för schemalagda pass
- [x] Verifierat matchning för OT-pass
- [x] Verifierat att OFF/SICK inte visas som kollegor
- [x] Verifierat tidsbaserad matchning fungerar