### PR TITLE
Add all working persons display to day view

### DIFF
--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -114,3 +114,44 @@ def get_navigation_dates(
         }
 
     raise ValueError(f"Unsupported view_type: {view_type}")
+
+
+def get_ot_shift_display_code(start_time: datetime.datetime | str | None) -> str:
+    """
+    Maps an overtime shift start time to a display code.
+
+    Returns a shift code that indicates which regular shift the OT aligns with:
+    - "N1-OT" for OT starting at 06:00 (aligns with N1 shift)
+    - "N2-OT" for OT starting at 14:00 (aligns with N2 shift)
+    - "N3-OT" for OT starting at 22:00 (aligns with N3 shift)
+    - "OT" for all other start times
+
+    Args:
+        start_time: The start time of the OT shift (datetime, string, or None)
+
+    Returns:
+        str: The shift code for display purposes
+    """
+    if not start_time:
+        return "OT"
+
+    # Extract hour from start time
+    hour = None
+    if isinstance(start_time, datetime.datetime):
+        hour = start_time.hour
+    elif isinstance(start_time, str):
+        try:
+            # Try to parse hour from string (assumes format contains HH at position 11-13)
+            hour = int(str(start_time)[11:13])
+        except (ValueError, IndexError):
+            pass
+
+    # Map hour to shift code
+    if hour == 6:
+        return "N1-OT"
+    elif hour == 14:
+        return "N2-OT"
+    elif hour == 22:
+        return "N3-OT"
+    else:
+        return "OT"

--- a/app/static/css/tables.css
+++ b/app/static/css/tables.css
@@ -8,13 +8,18 @@ table {
 }
 
 thead th {
-  text-align: center;
+  text-align: left;
   padding: 0.625rem 0.75rem;
   color: var(--muted);
   font-weight: 600;
   font-size: 0.85rem;
   border-bottom: 1px solid var(--table-border);
 }
+
+th.th_right, td.td_right { text-align: right; }
+th.th_center, td.td_center { text-align: center; }
+th.th_left, td.td_left { text-align: left; }
+td.foot_left { padding-left: 0.75rem;}
 
 tbody td {
   padding: 0.625rem 0.75rem;
@@ -24,7 +29,8 @@ tbody td {
 }
 
 tr:hover td { background: rgba(255,255,255,0.01); }
-td.num, th.num { text-align: center; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+td.num, th.num { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+
 
 /* Sticky tables */
 .table-sticky { border-collapse: separate; border-spacing: 0; }

--- a/app/templates/day.html
+++ b/app/templates/day.html
@@ -99,7 +99,7 @@
                     {% endif %}
                 </tbody>
             </table>
-                <!-- <section class="day-section"> -->
+
             <h3>Övertidspass (OT)</h3>
 
             {% if ot_shift %}
@@ -166,11 +166,9 @@
                     Övertidslön beräknas som månadslön / 72 per timme.
                 </p>
             {% endif %}
-        <!-- </section> -->
 
         {# Frånvarosection - endast för egen sida när inloggad #}
         {% if user and user.id == person_id or user.id == 0 %}
-        <!-- <section class="day-section"> -->
             <h3>Frånvaro</h3>
             
             {% if absence %}
@@ -287,7 +285,26 @@
                     <strong>Ledig (betald):</strong> Ledig dag utan löneavdrag (grå färg)
                 </p>
             {% endif %}
-        <!-- </section> -->
+        {% endif %}
+
+        <h3>Alla som arbetar denna dag</h3>
+        {% if all_working_persons and all_working_persons|length > 0 %}
+            <table>
+                <thead>
+                    <tr>
+                        <th>Namn</th>
+                        <th>Skift</th>
+                    </tr>
+                </thead>
+                <tbody>
+                {% for p in all_working_persons %}
+                    <tr>
+                        <td>{{ p[0] }}</td>
+                        <td>{{ p[1] }}</td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
         {% endif %}
         </section>
 
@@ -301,25 +318,25 @@
                     <table>
                         <thead>
                             <tr>
-                                <th>Type</th>
-                                <th>Hours</th>
-                                <th>Pay</th>
+                                <th class="th_left">Type</th>
+                                <th class="th_center">Hours</th>
+                                <th class="th_center">Pay</th>
                             </tr>
                         </thead>
                         <tbody>
                             {% for code, details in oncall.breakdown.items() %}
                                 <tr>
-                                    <td>{{ details.label }}</td>
-                                    <td>{{ "%.2f"|format(details.hours) }}</td>
-                                    <td>{{ "%.2f"|format(details.pay) }} kr</td>
+                                    <td class="td_left">{{ details.label }}</td>
+                                    <td class="td_center">{{ "%.2f"|format(details.hours) }}</td>
+                                    <td class="td_center">{{ "%.2f"|format(details.pay) }} kr</td>
                             </tr>
                             {% endfor %}
                         </tbody>
                         <tfoot>
                             <tr>
-                                <th>Total</th>
-                                <th>{{ "%.2f"|format(oncall.total_hours) }}</th>
-                                <th>{{ "%.2f"|format(oncall_pay) }} kr</th>
+                                <td class="td_left foot_left"><strong>Total</strong></td>
+                                <td class="td_center"><strong>{{ "%.2f"|format(oncall.total_hours) }}</strong></td>
+                                <td class="td_center"><strong>{{ "%.2f"|format(oncall_pay) }} kr</strong></td>
                             </tr>
                         </tfoot>
                     </table>
@@ -342,21 +359,21 @@
                         <thead>
                             <tr>
                                 <th>OB type</th>
-                                <th>Hours</th>
+                                <th class="th_center">Hours</th>
                             </tr>
                         </thead>
                         <tbody>
                             {% for code in ob_codes %}
                                 <tr>
-                                    <td>{{ ob_labels.get(code, code) }}</td>
-                                    <td>{{ "%.2f"|format(ob_hours.get(code, 0.0)) }}</td>
+                                    <td class="num">{{ ob_labels.get(code, code) }}</td>
+                                    <td class="td_center num">{{ "%.2f"|format(ob_hours.get(code, 0.0)) }}</td>
                                 </tr>
                             {% endfor %}
                         </tbody>
                         <tfoot>
                             <tr>
-                                <th>Total OB hours</th>
-                                <th>{{ "%.2f"|format(total_ob_hours) }}</th>
+                                <td class="foot_left"><strong>Total OB hours</strong></td>
+                                <td class="td_center num"><strong>{{ "%.2f"|format(total_ob_hours) }}</strong></td>
                             </tr>
                         </tfoot>
                     </table>
@@ -377,22 +394,22 @@
                 <table>
                     <thead>
                         <tr>
-                            <th>OB type</th>
-                            <th>Amount (SEK)</th>
+                            <th class="th_left">OB type</th>
+                            <th class="th_center">Amount (SEK)</th>
                         </tr>
                     </thead>
                     <tbody>
                         {% for code in ob_codes %}
                             <tr>
-                                <td>{{ ob_labels.get(code, code) }}</td>
-                                <td>{{ "%.2f"|format(ob_pay.get(code, 0.0)) }}</td>
+                                <td class="num">{{ ob_labels.get(code, code) }}</td>
+                                <td class="td_center num">{{ "%.2f"|format(ob_pay.get(code, 0.0)) }}</td>
                             </tr>
                         {% endfor %}
                     </tbody>
                     <tfoot>
                         <tr>
-                            <th>Total OB pay</th>
-                            <th>{{ "%.2f"|format(total_ob_pay) }}</th>
+                            <td class="foot_left num"><strong>Total OB pay</strong></td>
+                            <td class="td_center num"><strong>{{ "%.2f"|format(total_ob_pay) }}</strong></td>
                         </tr>
                     </tfoot>
                 </table>
@@ -405,19 +422,19 @@
                 <table>
                     <thead>
                         <tr>
-                            <th>Code</th>
-                            <th>Label</th>
-                            <th>Time</th>
-                            <th>Rate</th>
+                            <th class="th_left">Code</th>
+                            <th class="th_left">Label</th>
+                            <th class="th_left">Time</th>
+                            <th class="th_right">Rate</th>
                         </tr>
                     </thead>
                     <tbody>
                         {% for rule in active_special_rules %}
                             <tr>
-                                <td>{{ rule.code }}</td>
-                                <td>{{ rule.label }}</td>
-                                <td>{{ rule.start_time }} to {{ rule.end_time }}</td>
-                                <td>{{ rule.rate }}</td>
+                                <td class="td_left num">{{ rule.code }}</td>
+                                <td class="td_left num">{{ rule.label }}</td>
+                                <td class="td_left num">{{ rule.start_time }} to {{ rule.end_time }}</td>
+                                <td class="td_right num">{{ rule.rate }}</td>
                             </tr>
                         {% endfor %}
                     </tbody>

--- a/app/templates/year.html
+++ b/app/templates/year.html
@@ -35,17 +35,17 @@
         <table class="summary">
             <thead>
                 <tr>
-                    <th>Person</th>
-                    <th>Total</th>
-                    <th>N1</th>
-                    <th>N2</th>
-                    <th>N3</th>
+                    <th class="th_left">Person</th>
+                    <th class="th_center">Total</th>
+                    <th class="th_center">N1</th>
+                    <th class="th_center">N2</th>
+                    <th class="th_center">N3</th>
                 </tr>
             </thead>
             <tbody>
                 {% for r in cowork_rows %}
                 <tr class="shift-row">
-                    <td data-label="Person">
+                    <td class="td_left" data-label="Person">
                         {# Länka till cowork-detaljer endast om det är ens egen sida #}
                         {% if show_salary %}
                             <a href="/year/{{ person_id }}?year={{ year }}&with_person_id={{ r.other_id }}">
@@ -55,10 +55,10 @@
                             {{ r.other_name }} (#{{ r.other_id }})
                         {% endif %}
                     </td>
-                    <td class="num" data-label="Totalt">{{ r.total }}</td>
-                    <td class="num" data-label="N1">{{ r.by_shift["N1"] }}</td>
-                    <td class="num" data-label="N2">{{ r.by_shift["N2"] }}</td>
-                    <td class="num" data-label="N3">{{ r.by_shift["N3"] }}</td>
+                    <td class="td_center num" data-label="Totalt">{{ r.total }}</td>
+                    <td class="td_center num" data-label="N1">{{ r.by_shift["N1"] }}</td>
+                    <td class="td_center num" data-label="N2">{{ r.by_shift["N2"] }}</td>
+                    <td class="td_center num" data-label="N3">{{ r.by_shift["N3"] }}</td>
                 </tr>
                 {% endfor %}
             </tbody>
@@ -67,21 +67,21 @@
         <table class="summary">
             <thead>
                 <tr>
-                    <th>Type</th>
-                    <th>Hours</th>
-                    <th>Amount (SEK)</th>
+                    <th class="th_left">Type</th>
+                    <th class="th_center">Hours</th>
+                    <th class="th_center">Amount (SEK)</th>
                 </tr>
             </thead>
             <tbody>
                 <tr class="shift-row">
-                    <td data-label="Typ">Total on-call</td>
-                    <td class="num" data-label="Timmar">{{ "%.2f"|format(year_summary.total_oncall_hours or 0) }}</td>
-                    <td class="num" data-label="Belopp">{{ "%.2f"|format(year_summary.total_oncall or 0) }} kr</td>
+                    <td class="td_left" data-label="Typ">Total on-call</td>
+                    <td class="td_center num" data-label="Timmar">{{ "%.2f"|format(year_summary.total_oncall_hours or 0) }}</td>
+                    <td class="td_center num" data-label="Belopp">{{ "%.2f"|format(year_summary.total_oncall or 0) }} kr</td>
                 </tr>
                 <tr class="shift-row">
-                    <td data-label="Typ">Average on-call/month</td>
-                    <td class="num" data-label="Timmar">{{ "%.2f"|format(year_summary.avg_oncall_hours or 0) }}</td>
-                    <td class="num" data-label="Belopp">{{ "%.2f"|format(year_summary.avg_oncall or 0) }} kr</td>
+                    <td class="td_left" data-label="Typ">Average on-call/month</td>
+                    <td class="td_center num" data-label="Timmar">{{ "%.2f"|format(year_summary.avg_oncall_hours or 0) }}</td>
+                    <td class="td_center num" data-label="Belopp">{{ "%.2f"|format(year_summary.avg_oncall or 0) }} kr</td>
                 </tr>
             </tbody>
         </table>
@@ -91,17 +91,17 @@
             <thead>
                 <tr>
                     <th>Type</th>
-                    <th>Amount (SEK)</th>
+                    <th class="th_center">Amount (SEK)</th>
                 </tr>
             </thead>
             <tbody>
                 <tr class="shift-row">
                     <td data-label="Typ">Total OT pay</td>
-                    <td class="num" data-label="Belopp">{{ "%.2f"|format(year_summary.total_ot or 0) }} kr</td>
+                    <td class="td_center num" data-label="Belopp">{{ "%.2f"|format(year_summary.total_ot or 0) }} kr</td>
                 </tr>
                 <tr class="shift-row">
                     <td data-label="Typ">Average OT pay/month</td>
-                    <td class="num" data-label="Belopp">{{ "%.2f"|format(year_summary.avg_ot or 0) }} kr</td>
+                    <td class="td_center num" data-label="Belopp">{{ "%.2f"|format(year_summary.avg_ot or 0) }} kr</td>
                 </tr>
             </tbody>
         </table>
@@ -110,44 +110,44 @@
         <table class="summary">
             <thead>
                 <tr>
-                    <th>Type</th>
-                    <th>Days</th>
-                    <th>Hours</th>
-                    <th>Deduction (SEK)</th>
+                    <th class="th_left">Type</th>
+                    <th class="th_center">Days</th>
+                    <th class="th_center">Hours</th>
+                    <th class="th_center">Deduction (SEK)</th>
                 </tr>
             </thead>
             <tbody>
                 <tr class="shift-row">
-                    <td data-label="Typ">Sick leave (Sjuk)</td>
-                    <td class="num" data-label="Dagar">{{ year_summary.total_sick_days or 0 }}</td>
-                    <td class="num" data-label="Timmar">{{ "%.1f"|format(year_summary.total_sick_hours or 0) }}</td>
-                    <td class="num" data-label="Avdrag" style="color: #ef4444;">-{{ "%.0f"|format(year_summary.sick_deduction or 0) }} kr</td>
+                    <td class="td_left" data-label="Typ">Sick leave (Sjuk)</td>
+                    <td class="td_center num" data-label="Dagar">{{ year_summary.total_sick_days or 0 }}</td>
+                    <td class="td_center num" data-label="Timmar">{{ "%.1f"|format(year_summary.total_sick_hours or 0) }}</td>
+                    <td class="td_center num" data-label="Avdrag" style="color: #ef4444;">-{{ "%.0f"|format(year_summary.sick_deduction or 0) }} kr</td>
                 </tr>
                 <tr class="shift-row">
-                    <td data-label="Typ">VAB (Vård av barn)</td>
-                    <td class="num" data-label="Dagar">{{ year_summary.total_vab_days or 0 }}</td>
-                    <td class="num" data-label="Timmar">{{ "%.1f"|format(year_summary.total_vab_hours or 0) }}</td>
-                    <td class="num" data-label="Avdrag" style="color: #f97316;">-{{ "%.0f"|format(year_summary.vab_deduction or 0) }} kr</td>
+                    <td class="td_left" data-label="Typ">VAB (Vård av barn)</td>
+                    <td class="td_center num" data-label="Dagar">{{ year_summary.total_vab_days or 0 }}</td>
+                    <td class="td_center num" data-label="Timmar">{{ "%.1f"|format(year_summary.total_vab_hours or 0) }}</td>
+                    <td class="td_center num" data-label="Avdrag" style="color: #f97316;">-{{ "%.0f"|format(year_summary.vab_deduction or 0) }} kr</td>
                 </tr>
                 <tr class="shift-row">
-                    <td data-label="Typ">Leave (Ledigt obetald)</td>
-                    <td class="num" data-label="Dagar">{{ year_summary.total_leave_days or 0 }}</td>
-                    <td class="num" data-label="Timmar">{{ "%.1f"|format(year_summary.total_leave_hours or 0) }}</td>
-                    <td class="num" data-label="Avdrag" style="color: #a855f7;">-{{ "%.0f"|format(year_summary.leave_deduction or 0) }} kr</td>
+                    <td class="td_left" data-label="Typ">Leave (Ledigt obetald)</td>
+                    <td class="td_center num" data-label="Dagar">{{ year_summary.total_leave_days or 0 }}</td>
+                    <td class="td_center num" data-label="Timmar">{{ "%.1f"|format(year_summary.total_leave_hours or 0) }}</td>
+                    <td class="td_center num" data-label="Avdrag" style="color: #a855f7;">-{{ "%.0f"|format(year_summary.leave_deduction or 0) }} kr</td>
                 </tr>
                 <tr class="shift-row">
-                    <td data-label="Typ">OFF (Ledig betald)</td>
-                    <td class="num" data-label="Dagar">{{ year_summary.total_off_days or 0 }}</td>
-                    <td class="num" data-label="Timmar">{{ "%.1f"|format(year_summary.total_off_hours or 0) }}</td>
-                    <td class="num" data-label="Avdrag" style="color: #888888;">{{ "%.0f"|format(year_summary.off_deduction or 0) }} kr</td>
+                    <td class="td_left" data-label="Typ">OFF (Ledig betald)</td>
+                    <td class="td_center num" data-label="Dagar">{{ year_summary.total_off_days or 0 }}</td>
+                    <td class="td_center num" data-label="Timmar">{{ "%.1f"|format(year_summary.total_off_hours or 0) }}</td>
+                    <td class="td_center num" data-label="Avdrag" style="color: #888888;">{{ "%.0f"|format(year_summary.off_deduction or 0) }} kr</td>
                 </tr>
             </tbody>
             <tfoot>
                 <tr>
-                    <td data-label="Typ"><strong>Total</strong></td>
-                    <td class="num" data-label="Dagar"><strong>{{ (year_summary.total_sick_days or 0) + (year_summary.total_vab_days or 0) + (year_summary.total_leave_days or 0) + (year_summary.total_off_days or 0) }}</strong></td>
-                    <td class="num" data-label="Timmar"><strong>{{ "%.1f"|format((year_summary.total_sick_hours or 0) + (year_summary.total_vab_hours or 0) + (year_summary.total_leave_hours or 0) + (year_summary.total_off_hours or 0)) }}</strong></td>
-                    <td class="num" data-label="Avdrag" style="color: #ef4444;"><strong>-{{ "%.0f"|format(year_summary.total_absence_deduction or 0) }} kr</strong></td>
+                    <td class="td_left foot_left" data-label="Typ"><strong>Total</strong></td>
+                    <td class="td_center num" data-label="Dagar"><strong>{{ (year_summary.total_sick_days or 0) + (year_summary.total_vab_days or 0) + (year_summary.total_leave_days or 0) + (year_summary.total_off_days or 0) }}</strong></td>
+                    <td class="td_center num" data-label="Timmar"><strong>{{ "%.1f"|format((year_summary.total_sick_hours or 0) + (year_summary.total_vab_hours or 0) + (year_summary.total_leave_hours or 0) + (year_summary.total_off_hours or 0)) }}</strong></td>
+                    <td class="td_center num" data-label="Avdrag" style="color: #ef4444;"><strong>-{{ "%.0f"|format(year_summary.total_absence_deduction or 0) }} kr</strong></td>
                 </tr>
             </tfoot>
         </table>
@@ -179,7 +179,7 @@
                 {% for m in months_list %}
                 {% set mnum = loop.index %}
                 <tr class="shift-row">
-                    <td data-label="Månad">
+                    <td class="td_center" data-label="Månad">
                         {# Länka till month endast om behörighet #}
                         {% if show_salary %}
                             <a href="/month/{{ person_id }}?year={{ year }}&month={{ mnum }}">{{ mnum }}</a>
@@ -188,16 +188,16 @@
                         {% endif %}
                     </td>
                     {% if show_salary %}
-                    <td class="num" data-label="Netto">{{ "%.0f"|format(m.netto_pay or 0) }}</td>
-                    <td class="num" data-label="Brutto">{{ "%.0f"|format(m.brutto_pay or 0) }}</td>
+                    <td class="td_center num" data-label="Netto">{{ "%.0f"|format(m.netto_pay or 0) }}</td>
+                    <td class="td_center num" data-label="Brutto">{{ "%.0f"|format(m.brutto_pay or 0) }}</td>
                     {% endif %}
-                    <td class="num" data-label="Pass">{{ m.num_shifts }}</td>
-                    <td class="num" data-label="Timmar">{{ "%.0f"|format(m.total_hours or 0) }}</td>
+                    <td class="td_center num" data-label="Pass">{{ m.num_shifts }}</td>
+                    <td class="td_center num" data-label="Timmar">{{ "%.0f"|format(m.total_hours or 0) }}</td>
                     {% if show_salary %}
-                    <td class="num" data-label="OB">{{ "%.0f"|format(m.total_ob or 0) }}</td>
-                    <td class="num" data-label="On-call">{{ "%.0f"|format(m.oncall_pay or 0) }}</td>
-                    <td class="num" data-label="OT pay">{{ "%.0f"|format(m.ot_pay or 0) }}</td>
-                    <td class="num" data-label="Absence" style="color: #ef4444;">
+                    <td class="td_center num" data-label="OB">{{ "%.0f"|format(m.total_ob or 0) }}</td>
+                    <td class="td_center num" data-label="On-call">{{ "%.0f"|format(m.oncall_pay or 0) }}</td>
+                    <td class="td_center num" data-label="OT pay">{{ "%.0f"|format(m.ot_pay or 0) }}</td>
+                    <td class="td_center num" data-label="Absence" style="color: #ef4444;">
                         {% if m.absence_deduction and m.absence_deduction > 0 %}
                             -{{ "%.0f"|format(m.absence_deduction) }}
                         {% else %}
@@ -210,18 +210,18 @@
             </tbody>
             <tfoot>
             <tr>
-                <td data-label="Typ"><strong>Total</strong></td>
+                <td class="foot_left" data-label="Typ"><strong>Total</strong></td>
                 {% if show_salary %}
-                <td class="num" data-label="Netto">{{ "%.0f"|format(year_summary.total_netto or 0) }}</td>
-                <td class="num" data-label="Brutto">{{ "%.0f"|format(year_summary.total_brutto or 0) }}</td>
+                <td class="td_center num" data-label="Netto">{{ "%.0f"|format(year_summary.total_netto or 0) }}</td>
+                <td class="td_center num" data-label="Brutto">{{ "%.0f"|format(year_summary.total_brutto or 0) }}</td>
                 {% endif %}
-                <td class="num" data-label="Pass">{{ "%.0f"|format(year_summary.total_shifts or 0) }}</td>
-                <td class="num" data-label="Timmar">{{ "%.0f"|format(year_summary.total_hours or 0) }}</td>
+                <td class="td_center num" data-label="Pass">{{ "%.0f"|format(year_summary.total_shifts or 0) }}</td>
+                <td class="td_center num" data-label="Timmar">{{ "%.0f"|format(year_summary.total_hours or 0) }}</td>
                 {% if show_salary %}
-                <td class="num" data-label="OB">{{ "%.0f"|format(year_summary.total_ob or 0) }}</td>
-                <td class="num" data-label="On-call">{{ "%.0f"|format(year_summary.total_oncall or 0) }}</td>
-                <td class="num" data-label="OT pay">{{ "%.0f"|format(year_summary.total_ot or 0) }}</td>
-                <td class="num" data-label="Absence" style="color: #ef4444;">
+                <td class="td_center num" data-label="OB">{{ "%.0f"|format(year_summary.total_ob or 0) }}</td>
+                <td class="td_center num" data-label="On-call">{{ "%.0f"|format(year_summary.total_oncall or 0) }}</td>
+                <td class="td_center num" data-label="OT pay">{{ "%.0f"|format(year_summary.total_ot or 0) }}</td>
+                <td class="td_center num" data-label="Absence" style="color: #ef4444;">
                     {% if year_summary.total_absence_deduction and year_summary.total_absence_deduction > 0 %}
                         -{{ "%.0f"|format(year_summary.total_absence_deduction) }}
                     {% else %}
@@ -231,18 +231,18 @@
                 {% endif %}
             </tr>
             <tr>
-                <td data-label="Typ"><strong>Snitt</strong></td>
+                <td class="foot_left" data-label="Typ"><strong>Snitt</strong></td>
                 {% if show_salary %}
-                <td class="num" data-label="Netto">{{ "%.0f"|format(year_summary.avg_netto or 0) }}</td>
-                <td class="num" data-label="Brutto">{{ "%.0f"|format(year_summary.avg_brutto or 0) }}</td>
+                <td class="td_center num" data-label="Netto">{{ "%.0f"|format(year_summary.avg_netto or 0) }}</td>
+                <td class="td_center num" data-label="Brutto">{{ "%.0f"|format(year_summary.avg_brutto or 0) }}</td>
                 {% endif %}
-                <td class="num" data-label="Pass">{{ "%.0f"|format(year_summary.avg_shifts or 0) }}</td>
-                <td class="num" data-label="Timmar">{{ "%.0f"|format(year_summary.avg_hours or 0) }}</td>
+                <td class="td_center num" data-label="Pass">{{ "%.0f"|format(year_summary.avg_shifts or 0) }}</td>
+                <td class="td_center num" data-label="Timmar">{{ "%.0f"|format(year_summary.avg_hours or 0) }}</td>
                 {% if show_salary %}
-                <td class="num" data-label="OB">{{ "%.0f"|format(year_summary.avg_ob or 0) }}</td>
-                <td class="num" data-label="On-call">{{ "%.0f"|format(year_summary.avg_oncall or 0) }}</td>
-                <td class="num" data-label="OT pay">{{ "%.0f"|format(year_summary.avg_ot or 0) }}</td>
-                <td class="num" data-label="Absence" style="color: #ef4444;">
+                <td class="td_center num" data-label="OB">{{ "%.0f"|format(year_summary.avg_ob or 0) }}</td>
+                <td class="td_center num" data-label="On-call">{{ "%.0f"|format(year_summary.avg_oncall or 0) }}</td>
+                <td class="td_center num" data-label="OT pay">{{ "%.0f"|format(year_summary.avg_ot or 0) }}</td>
+                <td class="td_center num" data-label="Absence" style="color: #ef4444;">
                     {% if year_summary.avg_absence_deduction and year_summary.avg_absence_deduction > 0 %}
                         -{{ "%.0f"|format(year_summary.avg_absence_deduction) }}
                     {% else %}
@@ -268,24 +268,24 @@
             <thead>
                 <tr>
                     <th>OB type</th>
-                    <th>OB hours</th>
-                    <th>OB pay (SEK)</th>
+                    <th class="th_center">OB hours</th>
+                    <th class="th_center">OB pay (SEK)</th>
                 </tr>
             </thead>
             <tbody>
                 {% for code, hours in year_summary.ob_hours_by_code.items() %}
                 <tr class="shift-row">
                     <td data-label="OB-typ">{{ ob_labels.get(code, code) }}</td>
-                    <td class="num" data-label="Timmar">{{ "%.2f"|format(hours or 0) }}</td>
-                    <td class="num" data-label="Belopp">{{ "%.0f"|format(year_summary.ob_pay_by_code.get(code, 0) or 0) }}</td>
+                    <td class="td_center num" data-label="Timmar">{{ "%.2f"|format(hours or 0) }}</td>
+                    <td class="td_center num" data-label="Belopp">{{ "%.0f"|format(year_summary.ob_pay_by_code.get(code, 0) or 0) }}</td>
                 </tr>
                 {% endfor %}
             </tbody>
             <tfoot>
                 <tr>
-                    <td data-label="Typ"><strong>Total</strong></td>
-                    <td class="num" data-label="Timmar">{{ "%.2f"|format(year_summary.total_ob_hours or 0) }}</td>
-                    <td class="num" data-label="Belopp">{{ "%.0f"|format(year_summary.total_ob or 0) }}</td>
+                    <td class="foot_left" data-label="Typ"><strong>Total</strong></td>
+                    <td class="td_center num" data-label="Timmar">{{ "%.2f"|format(year_summary.total_ob_hours or 0) }}</td>
+                    <td class="td_center num" data-label="Belopp">{{ "%.0f"|format(year_summary.total_ob or 0) }}</td>
                 </tr>
             </tfoot>
         </table>


### PR DESCRIPTION
## Summary
- Display table showing all persons working on selected day with their shift assignments
- Improve code quality and fix potential bugs
- Enhance table styling consistency across templates

## Changes
### Features
- **New section in day view**: Shows all persons working on the selected day with their shifts
- **OT shift labeling**: Overtime shifts now display as N1-OT, N2-OT, N3-OT based on start time
- **Sorted display**: Workers sorted by shift code, then alphabetically by name

### Bug Fixes
- Fix potential `IndexError` when period data is empty
- Fix `NameError` for OT shifts with non-standard start times
- Remove debug print statement

### Code Quality
- Extract OT shift display logic to reusable utility function `get_ot_shift_display_code()`
- Add defensive checks for edge cases
- Follow DRY principle by centralizing shift code mapping

### Styling
- Add CSS utility classes for table alignment (`th_left`, `td_center`, `th_right`, etc.)
- Apply consistent alignment across day and year view templates
- Fix HTML semantics: use `<td>` instead of `<th>` in table footers
- Clean up commented HTML tags

## Test plan
- [x] Verify "Alla som arbetar denna dag" table appears in day view
- [x] Check that persons are sorted correctly by shift code
- [x] Test with OT shifts at 06:00, 14:00, 22:00 (should show N1-OT, N2-OT, N3-OT)
- [x] Test with OT shift at non-standard time (should show "OT")
- [x] Check table alignment and styling in day and year views