### PR TITLE
Add on-call override functionality

### DIFF
--- a/app/database/database.py
+++ b/app/database/database.py
@@ -43,6 +43,13 @@ class AbsenceType(str, enum.Enum):
     OFF = "OFF"  # Ledig - inget löneavdrag
 
 
+class OnCallOverrideType(str, enum.Enum):
+    """Types of on-call override."""
+
+    ADD = "ADD"  # Manuellt tillagt OC-pass
+    REMOVE = "REMOVE"  # Avbokat OC-pass från rotation
+
+
 class User(Base):
     """User model with authentication and schedule data."""
 
@@ -106,6 +113,27 @@ class Absence(Base):
 
     def __repr__(self):
         return f"<Absence(id={self.id}, user_id={self.user_id}, date={self.date}, type={self.absence_type})>"
+
+
+class OnCallOverride(Base):
+    """On-call override model for manually adding or removing on-call shifts."""
+
+    __tablename__ = "oncall_overrides"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    date = Column(Date, nullable=False)
+    override_type = Column(SQLEnum(OnCallOverrideType), nullable=False)
+    reason = Column(String(255), nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    created_by = Column(Integer, ForeignKey("users.id"), nullable=True)
+
+    # Relationships
+    user = relationship("User", foreign_keys=[user_id])
+    creator = relationship("User", foreign_keys=[created_by])
+
+    def __repr__(self):
+        return f"<OnCallOverride(id={self.id}, user_id={self.user_id}, date={self.date}, type={self.override_type})>"
 
 
 class WageHistory(Base):

--- a/app/main.py
+++ b/app/main.py
@@ -22,6 +22,7 @@ from app.database.database import create_tables, get_db
 from app.routes.admin import router as admin_router
 from app.routes.auth_routes import router as auth_router
 from app.routes.dashboard import router as dashboard_router
+from app.routes.oncall import router as oncall_router
 from app.routes.overtime import router as overtime_router
 from app.routes.schedule_all import router as schedule_all_router
 from app.routes.schedule_api import router as schedule_api_router
@@ -166,6 +167,7 @@ app.include_router(schedule_personal_router)
 app.include_router(schedule_all_router)
 app.include_router(schedule_api_router)
 app.include_router(overtime_router)
+app.include_router(oncall_router)
 app.include_router(auth_router)
 app.include_router(admin_router)
 

--- a/app/routes/oncall.py
+++ b/app/routes/oncall.py
@@ -1,0 +1,154 @@
+# app/routes/oncall.py
+"""
+On-call override management routes - add and remove on-call shifts.
+"""
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Form, HTTPException
+from fastapi.responses import RedirectResponse
+from sqlalchemy.orm import Session
+
+from app.auth.auth import get_current_user
+from app.core.schedule import clear_schedule_cache
+from app.database.database import OnCallOverride, OnCallOverrideType, User, UserRole, get_db
+
+router = APIRouter(prefix="/oncall", tags=["oncall"])
+
+
+@router.post("/add")
+async def add_oncall_override(
+    user_id: int = Form(...),
+    date: str = Form(...),
+    reason: str = Form(None),
+    session: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Add an on-call shift for a person who doesn't normally have one.
+
+    Permissions:
+    - Admin: can add for any user
+    - User: can only add for themselves
+    """
+    # Permission check
+    if current_user.role != UserRole.ADMIN and user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not authorized to add on-call for other users")
+
+    # Parse date
+    oc_date = datetime.strptime(date, "%Y-%m-%d").date()
+
+    # Check if override already exists for this date
+    existing = (
+        session.query(OnCallOverride).filter(OnCallOverride.user_id == user_id, OnCallOverride.date == oc_date).first()
+    )
+
+    if existing:
+        # Update existing override
+        existing.override_type = OnCallOverrideType.ADD
+        existing.reason = reason
+        existing.created_by = current_user.id
+    else:
+        # Create new override
+        override = OnCallOverride(
+            user_id=user_id,
+            date=oc_date,
+            override_type=OnCallOverrideType.ADD,
+            reason=reason,
+            created_by=current_user.id,
+        )
+        session.add(override)
+
+    session.commit()
+
+    # Clear schedule cache to reflect changes
+    clear_schedule_cache()
+
+    return RedirectResponse(url=f"/day/{user_id}/{oc_date.year}/{oc_date.month}/{oc_date.day}", status_code=303)
+
+
+@router.post("/remove")
+async def remove_oncall_override(
+    user_id: int = Form(...),
+    date: str = Form(...),
+    reason: str = Form(None),
+    session: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Remove/cancel an on-call shift from the rotation.
+
+    Permissions:
+    - Admin: can remove for any user
+    - User: can only remove for themselves
+    """
+    # Permission check
+    if current_user.role != UserRole.ADMIN and user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not authorized to remove on-call for other users")
+
+    # Parse date
+    oc_date = datetime.strptime(date, "%Y-%m-%d").date()
+
+    # Check if override already exists for this date
+    existing = (
+        session.query(OnCallOverride).filter(OnCallOverride.user_id == user_id, OnCallOverride.date == oc_date).first()
+    )
+
+    if existing:
+        # Update existing override
+        existing.override_type = OnCallOverrideType.REMOVE
+        existing.reason = reason
+        existing.created_by = current_user.id
+    else:
+        # Create new override
+        override = OnCallOverride(
+            user_id=user_id,
+            date=oc_date,
+            override_type=OnCallOverrideType.REMOVE,
+            reason=reason,
+            created_by=current_user.id,
+        )
+        session.add(override)
+
+    session.commit()
+
+    # Clear schedule cache to reflect changes
+    clear_schedule_cache()
+
+    return RedirectResponse(url=f"/day/{user_id}/{oc_date.year}/{oc_date.month}/{oc_date.day}", status_code=303)
+
+
+@router.post("/{override_id}/delete")
+async def delete_oncall_override(
+    override_id: int,
+    session: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Delete an on-call override (restore to rotation).
+
+    Permissions:
+    - Admin: can delete any override
+    - User: can only delete their own overrides
+    """
+    override = session.query(OnCallOverride).get(override_id)
+
+    if not override:
+        raise HTTPException(status_code=404, detail="On-call override not found")
+
+    # Permission check
+    if current_user.role != UserRole.ADMIN and override.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not authorized to delete this on-call override")
+
+    # Save info for redirect
+    user_id = override.user_id
+    date = override.date
+
+    # Delete
+    session.delete(override)
+    session.commit()
+
+    # Clear schedule cache to reflect changes
+    clear_schedule_cache()
+
+    return RedirectResponse(url=f"/day/{user_id}/{date.year}/{date.month}/{date.day}", status_code=303)

--- a/app/templates/day.html
+++ b/app/templates/day.html
@@ -287,6 +287,93 @@
             {% endif %}
         {% endif %}
 
+        {# Beredskapssection - endast för egen sida när inloggad #}
+        {% if user and user.id == person_id or user.id == 0 %}
+            <h3>Beredskap (On-call)</h3>
+
+            {% if oncall_override %}
+                <div class="oncall-override-display">
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Typ</th>
+                                <th>Anledning</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>
+                                    {% if oncall_override.override_type.value == 'ADD' %}
+                                        <span class="badge" style="background: #22c55e; color: white;">Tillagd OC</span>
+                                    {% else %}
+                                        <span class="badge" style="background: #ef4444; color: white;">Borttagen OC</span>
+                                    {% endif %}
+                                </td>
+                                <td>{{ oncall_override.reason or '-' }}</td>
+                                <td>
+                                    <form method="POST" action="/oncall/{{ oncall_override.id }}/delete" style="display: inline;">
+                                        <button type="submit" class="btn btn-danger" onclick="return confirm('Ångra ändringen och återställ till rotation?')">Ångra</button>
+                                    </form>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <p class="info-text">
+                        {% if oncall_override.override_type.value == 'ADD' %}
+                            Beredskapspass har lagts till manuellt. Klicka "Ångra" för att ta bort.
+                        {% else %}
+                            Beredskapspass har tagits bort manuellt från rotationen. Klicka "Ångra" för att återställa.
+                        {% endif %}
+                    </p>
+                </div>
+            {% else %}
+                {% if has_rotation_oc %}
+                    {# Person har OC enligt rotation - visa ta bort-knapp #}
+                    <form method="POST" action="/oncall/remove" class="oncall-form">
+                        <input type="hidden" name="user_id" value="{{ person_id }}">
+                        <input type="hidden" name="date" value="{{ date }}">
+
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label for="reason">Anledning (valfritt):</label>
+                                <input type="text" id="reason" name="reason" placeholder="T.ex. sjuk, byte med kollega">
+                            </div>
+                        </div>
+
+                        <button type="submit" class="btn btn-danger">Ta bort beredskapspass</button>
+                    </form>
+
+                    <p class="info-text">
+                        Du har beredskap denna dag enligt rotationsschemat.
+                        <br>
+                        Ta bort om du inte kan ha beredskap (t.ex. vid sjukdom eller byte med kollega).
+                    </p>
+                {% else %}
+                    {# Person har inte OC - visa lägg till-knapp #}
+                    <form method="POST" action="/oncall/add" class="oncall-form">
+                        <input type="hidden" name="user_id" value="{{ person_id }}">
+                        <input type="hidden" name="date" value="{{ date }}">
+
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label for="reason">Anledning (valfritt):</label>
+                                <input type="text" id="reason" name="reason" placeholder="T.ex. byte med kollega">
+                            </div>
+                        </div>
+
+                        <button type="submit" class="btn btn-primary">Lägg till beredskapspass</button>
+                    </form>
+
+                    <p class="info-text">
+                        Du har inte beredskap denna dag enligt rotationsschemat.
+                        <br>
+                        Lägg till om du tar över beredskap från en kollega.
+                    </p>
+                {% endif %}
+            {% endif %}
+        {% endif %}
+
         <h3>Alla som arbetar denna dag</h3>
         {% if all_working_persons and all_working_persons|length > 0 %}
             <table>
@@ -310,8 +397,8 @@
 
         {% if show_salary %}
             <section class="day-section">
-            {% if original_shift and original_shift.code == 'OC' %}
-            {# On-call compensation section - only for OC shifts (check original_shift to handle OT replacement) #}
+            {% if is_effective_oc %}
+            {# On-call compensation section - for effective OC shifts (including ADD overrides) #}
                 <h3>Oncall pay</h3>
                 {% set oncall = oncall_details %}
                 {% if oncall and oncall.breakdown %}


### PR DESCRIPTION
## Summary

- Lägger till möjlighet att manuellt lägga till eller ta bort beredskapspass (on-call) oberoende av rotationsschemat
- Användbart för skiftbyten, sjukfrånvaro, eller andra manuella justeringar

### Ändringar

| Fil | Beskrivning |
|-----|-------------|
| `app/database/database.py` | `OnCallOverrideType` enum + `OnCallOverride` modell |
| `app/routes/oncall.py` | **Ny fil** - API endpoints för add/remove/delete |
| `app/main.py` | Registrerar oncall router |
| `app/core/schedule/period.py` | Batch-fetch + override-logik i schemaberäkning |
| `app/routes/schedule_personal.py` | Override-hantering i dagvy |
| `app/templates/day.html` | UI för beredskapshantering |

### API Endpoints

| Endpoint | Funktion |
|----------|----------|
| `POST /oncall/add` | Lägg till OC-pass |
| `POST /oncall/remove` | Ta bort OC-pass från rotation |
| `POST /oncall/{id}/delete` | Ångra override |

## Test plan

- [x] Alla 77 befintliga tester passerar
- [x] Gå till dagvy för person utan OC → "Lägg till"-knapp fungerar
- [x] Lägg till OC → skiftet visas som OC med korrekt ersättning
- [x] Gå till dagvy för person med OC → "Ta bort"-knapp fungerar
- [x] Ta bort OC → skiftet visas som OFF utan OB
- [x] Ångra override → rotation återställs