### PR TITLE
Fix on-call recalculation when OT crosses midnight

### DIFF
--- a/app/core/schedule/period.py
+++ b/app/core/schedule/period.py
@@ -782,17 +782,17 @@ def _populate_single_person_day(
             except ValueError:
                 pass
 
+    # Om jour + övertid (samma dag ELLER föregående dag över midnatt), räkna om jour
+    if shift and shift.code == "OC" and ot_shift_for_oncall:
+        oncall_pay, oncall_details = _recalculate_oncall_before_ot(
+            current_day, ot_shift_for_oncall, user_wages, person_id, settings
+        )
+
     ot_pay = 0.0
     ot_hours = 0.0
     ot_details = {}
 
     if ot_shift:
-        # Om jour + övertid, räkna om jour för perioden före/efter övertid
-        if shift and shift.code == "OC" and ot_shift_for_oncall:
-            oncall_pay, oncall_details = _recalculate_oncall_before_ot(
-                current_day, ot_shift_for_oncall, user_wages, person_id, settings
-            )
-
         # Beräkna övertidsersättning med temporal wage query
         from app.core.constants import OT_RATE_DIVISOR
 


### PR DESCRIPTION
## Summary
- Fix bug where year/month views showed full 24h on-call instead of reduced hours when a night OT shift (e.g. 22:00-06:30) crossed midnight into an on-call day
- Move the on-call recalculation check outside the same-day OT block in `_populate_single_person_day()` so it triggers for both same-day and midnight-crossing OT shifts
- The day view already handled this correctly — this aligns `period.py` with the same pattern

## Test plan
- [x] All 77 existing tests pass
- [x] Verify: register a night OT (e.g. 22:00-06:30) on a day before an OC day, check that year and month views show reduced on-call hours
- [x] Verify: same-day OT on an OC day still works correctly in all views