### PR TITLE
Add comprehensive vacation management system

### DIFF
--- a/app/core/schedule/period.py
+++ b/app/core/schedule/period.py
@@ -458,8 +458,13 @@ def _build_person_day_basic(
         absence = session.query(Absence).filter(Absence.user_id == person_id, Absence.date == date).first()
 
     if absence:
-        # Hitta rätt shift type för frånvarotypen
-        absence_shift = next((s for s in shift_types if s.code == absence.absence_type.value), None)
+        # VACATION absences use the SEM shift (same as week-based vacation)
+        from app.database.database import AbsenceType
+
+        if absence.absence_type == AbsenceType.VACATION:
+            absence_shift = vacation_shift
+        else:
+            absence_shift = next((s for s in shift_types if s.code == absence.absence_type.value), None)
         if absence_shift:
             result = determine_shift_for_date(date, person_id)
             original_shift, rotation_week = result if result else (None, None)
@@ -652,8 +657,13 @@ def _populate_single_person_day(
         absence = session.query(Absence).filter(Absence.user_id == person_id, Absence.date == current_day).first()
 
     if absence:
-        # Hitta rätt shift type för frånvarotypen
-        absence_shift = next((s for s in shift_types if s.code == absence.absence_type.value), None)
+        # VACATION absences use the SEM shift (same as week-based vacation)
+        from app.database.database import AbsenceType
+
+        if absence.absence_type == AbsenceType.VACATION:
+            absence_shift = vacation_shift
+        else:
+            absence_shift = next((s for s in shift_types if s.code == absence.absence_type.value), None)
         if absence_shift:
             shift = absence_shift
             # Get original shift for coworker matching

--- a/app/core/schedule/vacation.py
+++ b/app/core/schedule/vacation.py
@@ -1,6 +1,7 @@
-"""Semesterhantering."""
+"""Semesterhantering – veckobaserad, dagsnivå och saldoberäkning."""
 
 import datetime
+import math
 
 from app.core.constants import PERSON_IDS
 from app.core.storage import load_persons
@@ -10,10 +11,13 @@ def get_vacation_dates_for_year(year: int) -> dict[int, set[datetime.date]]:
     """
     Hämtar semesterdatum för alla personer för ett år.
 
+    Merges both week-based vacation (User.vacation JSON) and
+    day-level vacation (Absence records with type VACATION).
+
     Returns:
         Dict med person_id -> set av semesterdatum
     """
-    from app.database.database import SessionLocal, User
+    from app.database.database import Absence, AbsenceType, SessionLocal, User
 
     persons = load_persons()
     per_person: dict[int, set[datetime.date]] = {p.id: set() for p in persons}
@@ -32,9 +36,337 @@ def get_vacation_dates_for_year(year: int) -> dict[int, set[datetime.date]]:
                         d = datetime.date.fromisocalendar(year, week, day)
                         per_person[user.id].add(d)
                     except ValueError:
-                        # Ogiltig vecka för året, ignorera
                         continue
+
+        # Merge day-level vacation from absences table
+        day_absences = (
+            db.query(Absence)
+            .filter(
+                Absence.user_id.in_(PERSON_IDS),
+                Absence.absence_type == AbsenceType.VACATION,
+                Absence.date >= datetime.date(year, 1, 1),
+                Absence.date <= datetime.date(year, 12, 31),
+            )
+            .all()
+        )
+        for absence in day_absences:
+            if absence.user_id in per_person:
+                per_person[absence.user_id].add(absence.date)
     finally:
         db.close()
 
     return per_person
+
+
+# ---------------------------------------------------------------------------
+# Vacation balance calculation
+# ---------------------------------------------------------------------------
+
+
+def get_vacation_year_boundaries(reference_year: int, start_month: int) -> tuple[datetime.date, datetime.date]:
+    """
+    Calculate the vacation year boundaries for a given reference year and break month.
+
+    For start_month=4 (April) and reference_year=2026:
+      Vacation year: 2026-04-01 → 2027-03-31
+
+    Returns:
+        (year_start, year_end) as datetime.date
+    """
+    year_start = datetime.date(reference_year, start_month, 1)
+    if start_month == 1:
+        year_end = datetime.date(reference_year, 12, 31)
+    else:
+        year_end = datetime.date(reference_year + 1, start_month, 1) - datetime.timedelta(days=1)
+    return year_start, year_end
+
+
+def _count_weekdays_in_vacation_weeks(
+    weeks: list[int],
+    iso_year: int,
+    period_start: datetime.date,
+    period_end: datetime.date,
+) -> int:
+    """
+    Count weekdays (Mon-Fri) in the given ISO weeks that fall within [period_start, period_end].
+    """
+    count = 0
+    for week in weeks:
+        for iso_day in range(1, 6):  # 1=Monday .. 5=Friday
+            try:
+                d = datetime.date.fromisocalendar(iso_year, week, iso_day)
+            except ValueError:
+                continue
+            if period_start <= d <= period_end:
+                count += 1
+    return count
+
+
+def count_vacation_days_used(
+    user_id: int,
+    year_start: datetime.date,
+    year_end: datetime.date,
+    db,
+    vacation_json: dict | None = None,
+) -> dict:
+    """
+    Count vacation days consumed in a period from both sources.
+
+    Args:
+        user_id: The user to count for
+        year_start: Start of vacation year (inclusive)
+        year_end: End of vacation year (inclusive)
+        db: Database session
+        vacation_json: User.vacation dict (if already loaded), avoids extra query
+
+    Returns:
+        {"week_based": int, "day_level": int, "total": int}
+    """
+    from app.database.database import Absence, AbsenceType, User
+
+    # Get vacation JSON if not provided
+    if vacation_json is None:
+        user = db.query(User).filter(User.id == user_id).first()
+        vacation_json = user.vacation if user else {}
+
+    vacation_json = vacation_json or {}
+
+    # Count weekdays from week-based vacation
+    week_based = 0
+    # The vacation year may span two calendar years, so check both
+    calendar_years = set()
+    d = year_start
+    while d <= year_end:
+        calendar_years.add(d.year)
+        # Jump forward by month to avoid iterating every day
+        if d.month == 12:
+            d = datetime.date(d.year + 1, 1, 1)
+        else:
+            d = datetime.date(d.year, d.month + 1, 1)
+
+    for cal_year in calendar_years:
+        weeks = vacation_json.get(str(cal_year), []) or []
+        if weeks:
+            week_based += _count_weekdays_in_vacation_weeks(weeks, cal_year, year_start, year_end)
+
+    # Count day-level vacation from absences
+    day_level = (
+        db.query(Absence)
+        .filter(
+            Absence.user_id == user_id,
+            Absence.absence_type == AbsenceType.VACATION,
+            Absence.date >= year_start,
+            Absence.date <= year_end,
+        )
+        .count()
+    )
+
+    return {
+        "week_based": week_based,
+        "day_level": day_level,
+        "total": week_based + day_level,
+    }
+
+
+def _calculate_prorated_days(
+    employment_start: datetime.date,
+    earning_year_start: datetime.date,
+    earning_year_end: datetime.date,
+    full_year_days: int,
+) -> int:
+    """
+    Pro-rate vacation for partial earning year.
+
+    Each calendar month with at least 1 day of employment within the earning year
+    counts as 1/12 of the full entitlement. Result is rounded up (Swedish practice).
+    """
+    # Start counting from when employment actually began within the earning year
+    effective_start = max(employment_start, earning_year_start)
+    if effective_start > earning_year_end:
+        return 0
+
+    months = 0
+    current = effective_start
+    while current <= earning_year_end:
+        months += 1
+        # Advance to first of next month
+        if current.month == 12:
+            current = datetime.date(current.year + 1, 1, 1)
+        else:
+            current = datetime.date(current.year, current.month + 1, 1)
+
+    return math.ceil(full_year_days * months / 12)
+
+
+def calculate_vacation_balance(user, target_year: int, db) -> dict:
+    """
+    Calculate complete vacation balance for a user in a given vacation year.
+
+    The vacation year starts at the user's vacation_year_start_month.
+    The earning year is the year before the vacation year.
+
+    Args:
+        user: User ORM object (must have vacation fields)
+        target_year: The reference year for the vacation year
+        db: Database session
+
+    Returns:
+        {
+            "entitled_days": int,
+            "used_days": int,
+            "remaining_days": int,
+            "year_start": date,
+            "year_end": date,
+            "earning_year_start": date,
+            "earning_year_end": date,
+            "is_first_year": bool,
+            "week_based_used": int,
+            "day_level_used": int,
+        }
+    """
+    start_month = user.vacation_year_start_month or 4
+
+    # Vacation year boundaries
+    year_start, year_end = get_vacation_year_boundaries(target_year, start_month)
+
+    # Earning year is the year before the vacation year
+    earning_start, earning_end = get_vacation_year_boundaries(target_year - 1, start_month)
+
+    # Determine entitled days
+    full_days = user.vacation_days_per_year or 25
+    employment_start = user.employment_start_date
+
+    is_first_year = False
+    if employment_start and employment_start > earning_start:
+        # Employee started during or after the earning year → pro-rate
+        is_first_year = True
+        entitled_days = _calculate_prorated_days(employment_start, earning_start, earning_end, full_days)
+    else:
+        entitled_days = full_days
+
+    # Count used days in this vacation year
+    used = count_vacation_days_used(
+        user_id=user.id,
+        year_start=year_start,
+        year_end=year_end,
+        db=db,
+        vacation_json=user.vacation,
+    )
+
+    # Calculate vacation pay
+    pay = calculate_vacation_pay(
+        user=user,
+        entitled_days=entitled_days,
+        earning_start=earning_start,
+        earning_end=earning_end,
+        db=db,
+    )
+
+    return {
+        "entitled_days": entitled_days,
+        "used_days": used["total"],
+        "remaining_days": entitled_days - used["total"],
+        "year_start": year_start,
+        "year_end": year_end,
+        "earning_year_start": earning_start,
+        "earning_year_end": earning_end,
+        "is_first_year": is_first_year,
+        "week_based_used": used["week_based"],
+        "day_level_used": used["day_level"],
+        "pay": pay,
+    }
+
+
+def calculate_vacation_pay(
+    user,
+    entitled_days: int,
+    earning_start: datetime.date,
+    earning_end: datetime.date,
+    db,
+) -> dict:
+    """
+    Calculate vacation supplement (semestertillägg) per Handelns tjänstemannaavtal 2025-2027.
+
+    When taking vacation, the employee receives their normal monthly salary PLUS
+    a vacation supplement per vacation day:
+
+      0.8% of monthly salary (fast del)
+    + 0.5% of ALL variable earnings paid during the earning year (rörlig del)
+
+    Variable components (rörliga lönedelar) include all of:
+      Skifttillägg/OB, beredskapsersättning, övertid, etc.
+
+    Note: This is NOT semesterersättning (4.6%) which only applies when
+    leaving employment with unused vacation days.
+
+    Args:
+        user: User ORM object
+        entitled_days: Number of vacation days entitled
+        earning_start: Start of earning year
+        earning_end: End of earning year
+        db: Database session
+    """
+    from app.core.schedule.summary import summarize_month_for_person
+    from app.core.schedule.wages import get_user_wage
+
+    # Get current wage
+    try:
+        monthly_salary = get_user_wage(db, user.id, 0)
+    except Exception:
+        monthly_salary = user.wage if hasattr(user, "wage") else 0
+    if monthly_salary == 0:
+        monthly_salary = user.wage if hasattr(user, "wage") else 0
+
+    # Fixed supplement: 0.8% of monthly salary per vacation day
+    fixed_per_day = round(monthly_salary * 0.008, 2)
+
+    # Sum ALL variable earnings during earning year
+    ob_total = 0.0
+    ot_total = 0.0
+    oncall_total = 0.0
+
+    person_id = user.rotation_person_id
+    if person_id and 1 <= person_id <= 10:
+        current = earning_start
+        while current <= earning_end:
+            try:
+                summary = summarize_month_for_person(
+                    year=current.year,
+                    month=current.month,
+                    person_id=person_id,
+                    session=db,
+                    fetch_tax_table=False,
+                    wage_user_id=user.id,
+                )
+                ob_pay_dict = summary.get("ob_pay", {})
+                ob_total += sum(ob_pay_dict.values())
+                ot_total += summary.get("ot_pay", 0.0)
+                oncall_total += summary.get("oncall_pay", 0.0)
+            except Exception:
+                pass
+
+            if current.month == 12:
+                current = datetime.date(current.year + 1, 1, 1)
+            else:
+                current = datetime.date(current.year, current.month + 1, 1)
+
+    # All variable components are included (no exclusion rules for semestertillägg)
+    variable_total = ob_total + ot_total + oncall_total
+
+    # Variable supplement: 0.5% of total variable earnings, per vacation day
+    variable_per_day = round(variable_total * 0.005, 2)
+
+    # Total supplement per day
+    supplement_per_day = round(fixed_per_day + variable_per_day, 2)
+
+    return {
+        "fixed_per_day": fixed_per_day,
+        "variable_per_day": variable_per_day,
+        "supplement_per_day": supplement_per_day,
+        "supplement_total": round(supplement_per_day * entitled_days, 2),
+        "variable_total": round(variable_total, 2),
+        "ob_total": round(ob_total, 2),
+        "ot_total": round(ot_total, 2),
+        "oncall_total": round(oncall_total, 2),
+        "monthly_salary": monthly_salary,
+    }

--- a/app/database/database.py
+++ b/app/database/database.py
@@ -41,6 +41,7 @@ class AbsenceType(str, enum.Enum):
     VAB = "VAB"  # Vård av barn - ingen extra ersättning
     LEAVE = "LEAVE"  # Ledigt/Permission - ingen extra ersättning
     OFF = "OFF"  # Ledig - inget löneavdrag
+    VACATION = "VACATION"  # Enskild semesterdag
 
 
 class OnCallOverrideType(str, enum.Enum):
@@ -72,6 +73,13 @@ class User(Base):
     person_id = Column(
         Integer, nullable=True
     )  # Rotation position (1-10). If NULL, defaults to user.id for legacy compatibility
+    employment_start_date = Column(Date, nullable=True)  # When employee started working (for vacation balance)
+    vacation_year_start_month = Column(
+        Integer, default=4, nullable=False
+    )  # Brytmånad: month (1-12) when vacation year starts (default April)
+    vacation_days_per_year = Column(
+        Integer, default=25, nullable=False
+    )  # Annual vacation entitlement (Swedish standard: 25)
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 

--- a/app/static/css/layout.css
+++ b/app/static/css/layout.css
@@ -61,9 +61,10 @@ footer {
 .year-monthly  { grid-column: 1 / -1; }
 .year-ob       { grid-row: 2; grid-column: 1; }
 .year-absence  { grid-row: 2; grid-column: 2; }
-.year-overtime { grid-row: 3; grid-column: 1; }
-.year-oncall   { grid-row: 3; grid-column: 2; }
-.year-cowork   { grid-column: 1 / -1; }
+.year-overtime  { grid-row: 3; grid-column: 1; }
+.year-oncall    { grid-row: 3; grid-column: 2; }
+.year-vacation  { grid-column: 1 / -1; }
+.year-cowork    { grid-column: 1 / -1; }
 
 /* Responsive Layout */
 @media (max-width: 900px) {
@@ -79,7 +80,7 @@ footer {
 
   /* Year view: single column on narrow screens */
   .year-layout { grid-template-columns: 1fr; }
-  .year-monthly, .year-ob, .year-oncall, .year-overtime, .year-absence, .year-cowork {
+  .year-monthly, .year-ob, .year-oncall, .year-overtime, .year-absence, .year-vacation, .year-cowork {
     grid-column: auto;
     grid-row: auto;
   }

--- a/app/templates/admin_user_edit.html
+++ b/app/templates/admin_user_edit.html
@@ -295,22 +295,45 @@
     </div>
     {% endif %}
 
-    <!-- Semester info -->
+    <!-- Semester -->
     <div class="card" style="margin-top: 16px;">
         <h3 style="margin-top: 0;">Semester</h3>
+
+        {% if vacation_balance %}
+        <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-bottom: 16px;">
+            <div style="text-align: center;">
+                <div style="color: var(--muted); font-size: 0.8rem; margin-bottom: 4px;">Tilldelade</div>
+                <div style="font-size: 1.3rem; font-weight: 700;">{{ vacation_balance.entitled_days }}</div>
+            </div>
+            <div style="text-align: center;">
+                <div style="color: var(--muted); font-size: 0.8rem; margin-bottom: 4px;">Uttagna</div>
+                <div style="font-size: 1.3rem; font-weight: 700;">{{ vacation_balance.used_days }}</div>
+            </div>
+            <div style="text-align: center;">
+                <div style="color: var(--muted); font-size: 0.8rem; margin-bottom: 4px;">Kvar</div>
+                <div style="font-size: 1.3rem; font-weight: 700; color: {% if vacation_balance.remaining_days > 5 %}var(--accent-2){% elif vacation_balance.remaining_days > 0 %}var(--warning){% else %}var(--danger){% endif %};">
+                    {{ vacation_balance.remaining_days }}
+                </div>
+            </div>
+        </div>
+        <div style="font-size: 0.8rem; color: var(--muted); margin-bottom: 12px;">
+            Semester&aring;r: {{ vacation_balance.year_start.strftime('%Y-%m-%d') }} &mdash; {{ vacation_balance.year_end.strftime('%Y-%m-%d') }}
+            {% if vacation_balance.is_first_year %}<span style="color: var(--warning);"> (proportionellt)</span>{% endif %}
+        </div>
+        {% endif %}
+
         {% set vacation = edit_user.vacation or {} %}
         {% if vacation %}
             {% for year, weeks in vacation.items() %}
                 {% if weeks %}
-                    <p><strong>{{ year }}:</strong> vecka {{ weeks | join(', ') }}</p>
+                    <p style="font-size: 0.85rem;"><strong>{{ year }}:</strong> v{{ weeks | join(', v') }}</p>
                 {% endif %}
             {% endfor %}
-            {% if not vacation.values() | select | list %}
-                <p style="color: var(--muted);">Ingen semester registrerad.</p>
-            {% endif %}
-        {% else %}
-            <p style="color: var(--muted);">Ingen semester registrerad.</p>
         {% endif %}
+
+        <a href="/admin/vacation/{{ edit_user.id }}" class="btn secondary" style="margin-top: 8px;">
+            Hantera semester
+        </a>
     </div>
 </div>
 

--- a/app/templates/admin_vacation.html
+++ b/app/templates/admin_vacation.html
@@ -1,0 +1,103 @@
+{# app/templates/admin_vacation.html #}
+{% extends "base.html" %}
+
+{% block page_content %}
+
+<div class="page-header">
+    <div class="page-header-left">
+        <a href="/admin/vacation?year={{ year - 1 }}" class="btn secondary">{{ year - 1 }}</a>
+        <span style="padding: 8px 16px; font-weight: 600;">{{ year }}</span>
+        <a href="/admin/vacation?year={{ year + 1 }}" class="btn secondary">{{ year + 1 }}</a>
+    </div>
+    <div class="page-header-right">
+        <a href="/admin/users" class="btn secondary">Tillbaka</a>
+    </div>
+</div>
+
+<h2 class="page-title">Semester&ouml;versikt {{ year }}</h2>
+
+<!-- Heatmap Grid -->
+<div class="card" style="overflow-x: auto; margin-bottom: 24px;">
+    <h3 style="margin-top: 0;">Semesterveckor</h3>
+    <table style="min-width: 900px;">
+        <thead>
+            <tr>
+                <th style="position: sticky; left: 0; background: var(--panel); z-index: 1; min-width: 120px;">Namn</th>
+                {% for w in weeks_range %}
+                    <th style="text-align: center; padding: 4px 2px; font-size: 0.7rem; min-width: 22px;">{{ w }}</th>
+                {% endfor %}
+            </tr>
+        </thead>
+        <tbody>
+            {% for entry in team_data %}
+            <tr>
+                <td style="position: sticky; left: 0; background: var(--panel); z-index: 1;">
+                    <a href="/admin/vacation/{{ entry.user.id }}?year={{ year }}" style="color: var(--accent); text-decoration: none;">
+                        {{ entry.user.name }}
+                    </a>
+                </td>
+                {% for w in weeks_range %}
+                    {% if w in entry.vacation_weeks and w in entry.day_vacation_weeks %}
+                        <td style="background: linear-gradient(135deg, var(--accent) 50%, var(--accent-2) 50%); padding: 2px;" title="v{{ w }}: vecka + dag"></td>
+                    {% elif w in entry.vacation_weeks %}
+                        <td style="background: var(--accent); padding: 2px;" title="v{{ w }}: semestervecka"></td>
+                    {% elif w in entry.day_vacation_weeks %}
+                        <td style="background: var(--accent-2); padding: 2px;" title="v{{ w }}: enskild dag"></td>
+                    {% else %}
+                        <td style="padding: 2px;"></td>
+                    {% endif %}
+                {% endfor %}
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    <div style="margin-top: 12px; display: flex; gap: 16px; font-size: 0.8rem; color: var(--muted);">
+        <span><span style="display: inline-block; width: 12px; height: 12px; background: var(--accent); border-radius: 2px; vertical-align: middle;"></span> Semestervecka</span>
+        <span><span style="display: inline-block; width: 12px; height: 12px; background: var(--accent-2); border-radius: 2px; vertical-align: middle;"></span> Enskild dag</span>
+    </div>
+</div>
+
+<!-- Balance Table -->
+<div class="card">
+    <h3 style="margin-top: 0;">Semestersaldo</h3>
+    <table>
+        <thead>
+            <tr>
+                <th>Namn</th>
+                <th class="num">Tilldelade</th>
+                <th class="num">Uttagna</th>
+                <th class="num">Kvar</th>
+                <th>Semester&aring;r</th>
+                <th>Anst&auml;llningsstart</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for entry in team_data %}
+            <tr>
+                <td>
+                    <a href="/admin/vacation/{{ entry.user.id }}?year={{ year }}" style="color: var(--accent); text-decoration: none;">
+                        {{ entry.user.name }}
+                    </a>
+                </td>
+                <td class="num">{{ entry.balance.entitled_days }}</td>
+                <td class="num">{{ entry.balance.used_days }}</td>
+                <td class="num" style="font-weight: 600; color: {% if entry.balance.remaining_days > 5 %}var(--accent-2){% elif entry.balance.remaining_days > 0 %}var(--warning){% else %}var(--danger){% endif %};">
+                    {{ entry.balance.remaining_days }}
+                </td>
+                <td style="font-size: 0.85rem; color: var(--muted);">
+                    {{ entry.balance.year_start.strftime('%Y-%m-%d') }} &mdash; {{ entry.balance.year_end.strftime('%Y-%m-%d') }}
+                </td>
+                <td style="font-size: 0.85rem; color: var(--muted);">
+                    {% if entry.user.employment_start_date %}
+                        {{ entry.user.employment_start_date.strftime('%Y-%m-%d') }}
+                    {% else %}
+                        <span style="color: var(--warning);">Ej satt</span>
+                    {% endif %}
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+
+{% endblock %}

--- a/app/templates/admin_vacation_user.html
+++ b/app/templates/admin_vacation_user.html
@@ -1,0 +1,359 @@
+{# app/templates/admin_vacation_user.html #}
+{% extends "base.html" %}
+
+{% block page_content %}
+
+<div class="page-header">
+    <div class="page-header-left">
+        <a href="/admin/vacation/{{ edit_user.id }}?year={{ year - 1 }}" class="btn secondary">{{ year - 1 }}</a>
+        <span style="padding: 8px 16px; font-weight: 600;">{{ year }}</span>
+        <a href="/admin/vacation/{{ edit_user.id }}?year={{ year + 1 }}" class="btn secondary">{{ year + 1 }}</a>
+    </div>
+    <div class="page-header-right">
+        <a href="/admin/vacation?year={{ year }}" class="btn secondary">Tillbaka till &ouml;versikt</a>
+    </div>
+</div>
+
+<h2 class="page-title">Semester: {{ edit_user.name }} {{ year }}</h2>
+
+{% if success %}
+<div style="background: rgba(100,255,100,0.2); border: 1px solid #4caf50; padding: 12px; border-radius: var(--radius); margin-bottom: 16px;">
+    {{ success }}
+</div>
+{% endif %}
+
+<div class="row" style="gap: 24px; flex-wrap: wrap; align-items: flex-start;">
+
+    <!-- Left column: week grid + day-level -->
+    <div class="col" style="min-width: 400px; flex: 2;">
+
+        <!-- Balance Card -->
+        <div class="card" style="margin-bottom: 16px;">
+            <h3 style="margin-top: 0;">Semestersaldo</h3>
+            <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px;">
+                <div style="text-align: center;">
+                    <div style="color: var(--muted); font-size: 0.8rem; margin-bottom: 4px;">Tilldelade</div>
+                    <div style="font-size: 1.5rem; font-weight: 700;">{{ balance.entitled_days }}</div>
+                </div>
+                <div style="text-align: center;">
+                    <div style="color: var(--muted); font-size: 0.8rem; margin-bottom: 4px;">Uttagna</div>
+                    <div style="font-size: 1.5rem; font-weight: 700;">{{ balance.used_days }}</div>
+                </div>
+                <div style="text-align: center;">
+                    <div style="color: var(--muted); font-size: 0.8rem; margin-bottom: 4px;">Kvar</div>
+                    <div style="font-size: 1.5rem; font-weight: 700; color: {% if balance.remaining_days > 5 %}var(--accent-2){% elif balance.remaining_days > 0 %}var(--warning){% else %}var(--danger){% endif %};">
+                        {{ balance.remaining_days }}
+                    </div>
+                </div>
+            </div>
+            <div style="margin-top: 12px; font-size: 0.8rem; color: var(--muted); text-align: center;">
+                Semester&aring;r: {{ balance.year_start.strftime('%Y-%m-%d') }} &mdash; {{ balance.year_end.strftime('%Y-%m-%d') }}
+                {% if balance.is_first_year %}<span style="color: var(--warning);"> (f&ouml;rsta &aring;ret, proportionellt)</span>{% endif %}
+            </div>
+            {% if balance.week_based_used > 0 or balance.day_level_used > 0 %}
+            <div style="margin-top: 8px; font-size: 0.8rem; color: var(--muted); text-align: center;">
+                Veckobaserat: {{ balance.week_based_used }}d | Enskilda dagar: {{ balance.day_level_used }}d
+            </div>
+            {% endif %}
+        </div>
+
+        <!-- Vacation Supplement Card -->
+        {% if balance.pay %}
+        <div class="card" style="margin-bottom: 16px;">
+            <h3 style="margin-top: 0;">Semestertill&auml;gg</h3>
+            <div style="font-size: 0.7rem; color: var(--muted); margin-bottom: 12px;">Handelns tj&auml;nstemannaavtal 2025&ndash;2027</div>
+            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-bottom: 12px;">
+                <div style="text-align: center;">
+                    <div style="color: var(--muted); font-size: 0.75rem; margin-bottom: 4px;">Fast/dag</div>
+                    <div style="font-size: 1.2rem; font-weight: 700;">{{ "%.0f"|format(balance.pay.fixed_per_day) }} kr</div>
+                    <div style="color: var(--muted); font-size: 0.7rem;">0,8% av m&aring;nadsl&ouml;n</div>
+                </div>
+                <div style="text-align: center;">
+                    <div style="color: var(--muted); font-size: 0.75rem; margin-bottom: 4px;">R&ouml;rlig/dag</div>
+                    <div style="font-size: 1.2rem; font-weight: 700; color: var(--accent);">{{ "%.0f"|format(balance.pay.variable_per_day) }} kr</div>
+                    <div style="color: var(--muted); font-size: 0.7rem;">0,5% av r&ouml;rliga</div>
+                </div>
+            </div>
+            <div style="text-align: center; padding: 8px; background: rgba(255,255,255,0.03); border-radius: var(--radius); margin-bottom: 12px;">
+                <div style="color: var(--muted); font-size: 0.75rem; margin-bottom: 4px;">Tilll&auml;gg per semesterdag</div>
+                <div style="font-size: 1.5rem; font-weight: 700; color: var(--accent-2);">{{ "%.0f"|format(balance.pay.supplement_per_day) }} kr</div>
+                <div style="color: var(--muted); font-size: 0.7rem; margin-top: 4px;">
+                    Totalt f&ouml;r {{ balance.entitled_days }} dagar: {{ "{:,.0f}".format(balance.pay.supplement_total).replace(",", " ") }} kr
+                </div>
+            </div>
+            <div style="font-size: 0.75rem; color: var(--muted);">
+                <div style="margin-bottom: 4px;">R&ouml;rliga delar under intj&auml;nande&aring;ret ({{ balance.earning_year_start.strftime('%Y-%m-%d') }} &mdash; {{ balance.earning_year_end.strftime('%Y-%m-%d') }}):</div>
+                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 2px 12px;">
+                    <span>OB/skifttill&auml;gg:</span>
+                    <span style="text-align: right;">{{ "{:,.0f}".format(balance.pay.ob_total).replace(",", " ") }} kr</span>
+                    <span>&Ouml;vertid:</span>
+                    <span style="text-align: right;">{{ "{:,.0f}".format(balance.pay.ot_total).replace(",", " ") }} kr</span>
+                    <span>Beredskap:</span>
+                    <span style="text-align: right;">{{ "{:,.0f}".format(balance.pay.oncall_total).replace(",", " ") }} kr</span>
+                </div>
+                <div style="margin-top: 6px; padding-top: 6px; border-top: 1px solid var(--table-border);">
+                    <span>Summa r&ouml;rligt:</span>
+                    <span style="float: right;">{{ "{:,.0f}".format(balance.pay.variable_total).replace(",", " ") }} kr</span>
+                </div>
+                <div>
+                    <span>M&aring;nadsl&ouml;n:</span>
+                    <span style="float: right;">{{ "{:,.0f}".format(balance.pay.monthly_salary).replace(",", " ") }} kr</span>
+                </div>
+            </div>
+        </div>
+        {% endif %}
+
+        <!-- Week Selection Grid -->
+        <div class="card" style="margin-bottom: 16px;">
+            <h3 style="margin-top: 0;">Semesterveckor</h3>
+            <p style="color: var(--muted); margin-bottom: 16px;">Klicka p&aring; veckor f&ouml;r att markera/avmarkera.</p>
+
+            <form method="POST" action="/admin/vacation/{{ edit_user.id }}/weeks" id="vacation-form">
+                <input type="hidden" name="year" value="{{ year }}">
+                <input type="hidden" name="weeks" id="weeks-input" value="{{ vacation_weeks | join(',') }}">
+
+                <div class="week-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(60px, 1fr)); gap: 8px; margin-bottom: 24px;">
+                    {% for week in range(1, 53) %}
+                        <button
+                            type="button"
+                            class="week-btn {% if week in vacation_weeks %}selected{% endif %}"
+                            data-week="{{ week }}"
+                            style="
+                                padding: 12px 8px;
+                                border-radius: var(--radius);
+                                border: 1px solid var(--table-border);
+                                background: {% if week in vacation_weeks %}var(--accent){% else %}var(--panel){% endif %};
+                                color: {% if week in vacation_weeks %}var(--bg){% else %}var(--text){% endif %};
+                                cursor: pointer;
+                                font-weight: {% if week in vacation_weeks %}600{% else %}400{% endif %};
+                                transition: all 0.15s;
+                            "
+                        >
+                            v{{ week }}
+                        </button>
+                    {% endfor %}
+                </div>
+
+                <button type="submit" class="btn">Spara veckor</button>
+            </form>
+        </div>
+
+        <!-- Day-Level Vacation Calendar -->
+        <div class="card">
+            <h3 style="margin-top: 0;">Enskilda semesterdagar</h3>
+            <p style="color: var(--muted); margin-bottom: 16px;">Klicka p&aring; dagar f&ouml;r att markera/avmarkera semester.</p>
+
+            <form method="POST" action="/admin/vacation/{{ edit_user.id }}/days/sync" id="days-form">
+                <input type="hidden" name="year" value="{{ year }}">
+                <input type="hidden" name="dates" id="dates-input"
+                    value="{% for a in day_absences %}{{ a.date.strftime('%Y-%m-%d') }}{% if not loop.last %},{% endif %}{% endfor %}">
+
+                <div id="day-calendar" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 12px; margin-bottom: 16px;"></div>
+
+                <div style="display: flex; justify-content: space-between; align-items: center;">
+                    <span id="day-count" style="color: var(--muted); font-size: 0.85rem;"></span>
+                    <button type="submit" class="btn">Spara dagar</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <!-- Right column: settings + summary -->
+    <div class="col" style="min-width: 280px; flex: 1;">
+
+        <!-- Vacation Settings -->
+        <div class="card" style="margin-bottom: 16px;">
+            <h3 style="margin-top: 0;">Inst&auml;llningar</h3>
+            <form method="POST" action="/admin/vacation/{{ edit_user.id }}/settings">
+                <div style="margin-bottom: 12px;">
+                    <label style="display: block; margin-bottom: 6px; color: var(--muted); font-size: 0.85rem;">Anst&auml;llningsdatum</label>
+                    <input type="date" name="employment_start_date"
+                        value="{{ edit_user.employment_start_date.strftime('%Y-%m-%d') if edit_user.employment_start_date else '' }}"
+                        style="width: 100%; padding: 8px 12px; border-radius: var(--radius); border: 1px solid var(--table-border); background: var(--panel); color: var(--text);">
+                </div>
+                <div style="margin-bottom: 12px;">
+                    <label style="display: block; margin-bottom: 6px; color: var(--muted); font-size: 0.85rem;">Brytm&aring;nad</label>
+                    <select name="vacation_year_start_month"
+                        style="width: 100%; padding: 8px 12px; border-radius: var(--radius); border: 1px solid var(--table-border); background: var(--panel); color: var(--text);">
+                        {% for m in range(1, 13) %}
+                        <option value="{{ m }}" {% if edit_user.vacation_year_start_month == m %}selected{% endif %}>
+                            {{ month_names[m-1] }}
+                        </option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div style="margin-bottom: 16px;">
+                    <label style="display: block; margin-bottom: 6px; color: var(--muted); font-size: 0.85rem;">Semesterdagar/&aring;r</label>
+                    <input type="number" name="vacation_days_per_year"
+                        value="{{ edit_user.vacation_days_per_year }}" min="0" max="40"
+                        style="width: 100%; padding: 8px 12px; border-radius: var(--radius); border: 1px solid var(--table-border); background: var(--panel); color: var(--text);">
+                </div>
+                <button type="submit" class="btn" style="width: 100%;">Spara inst&auml;llningar</button>
+            </form>
+        </div>
+
+        <!-- Week Summary -->
+        <div class="card">
+            <h3 style="margin-top: 0;">Valda veckor</h3>
+            <div id="selected-summary">
+                {% if vacation_weeks %}
+                    <p><strong>{{ vacation_weeks | length }}</strong> veckor valda:</p>
+                    <p style="color: var(--muted);">{{ vacation_weeks | join(', ') }}</p>
+                {% else %}
+                    <p style="color: var(--muted);">Inga semesterveckor valda f&ouml;r {{ year }}.</p>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const weeksInput = document.getElementById('weeks-input');
+    const buttons = document.querySelectorAll('.week-btn');
+    const summary = document.getElementById('selected-summary');
+
+    let selectedWeeks = weeksInput.value
+        ? weeksInput.value.split(',').map(w => parseInt(w.trim())).filter(w => !isNaN(w))
+        : [];
+
+    function updateSummary() {
+        selectedWeeks.sort((a, b) => a - b);
+        weeksInput.value = selectedWeeks.join(',');
+
+        if (selectedWeeks.length > 0) {
+            summary.innerHTML = `
+                <p><strong>${selectedWeeks.length}</strong> veckor valda:</p>
+                <p style="color: var(--muted);">${selectedWeeks.join(', ')}</p>
+            `;
+        } else {
+            summary.innerHTML = '<p style="color: var(--muted);">Inga semesterveckor valda.</p>';
+        }
+    }
+
+    buttons.forEach(btn => {
+        btn.addEventListener('click', function() {
+            const week = parseInt(this.dataset.week);
+            const index = selectedWeeks.indexOf(week);
+
+            if (index > -1) {
+                selectedWeeks.splice(index, 1);
+                this.classList.remove('selected');
+                this.style.background = 'var(--panel)';
+                this.style.color = 'var(--text)';
+                this.style.fontWeight = '400';
+            } else {
+                selectedWeeks.push(week);
+                this.classList.add('selected');
+                this.style.background = 'var(--accent)';
+                this.style.color = 'var(--bg)';
+                this.style.fontWeight = '600';
+            }
+
+            updateSummary();
+        });
+    });
+
+    // --- Day-level calendar ---
+    const datesInput = document.getElementById('dates-input');
+    const calendarEl = document.getElementById('day-calendar');
+    const dayCountEl = document.getElementById('day-count');
+    const calYear = {{ year }};
+
+    const monthNames = ['Januari','Februari','Mars','April','Maj','Juni',
+                        'Juli','Augusti','September','Oktober','November','December'];
+    const dayHeaders = ['M&aring;','Ti','On','To','Fr','L&ouml;','S&ouml;'];
+
+    let selectedDates = new Set(
+        datesInput.value ? datesInput.value.split(',').map(s => s.trim()).filter(Boolean) : []
+    );
+
+    function updateDayCount() {
+        datesInput.value = Array.from(selectedDates).sort().join(',');
+        dayCountEl.textContent = selectedDates.size + ' dag' + (selectedDates.size !== 1 ? 'ar' : '') + ' valda';
+    }
+
+    function renderCalendar() {
+        calendarEl.innerHTML = '';
+        for (let m = 0; m < 12; m++) {
+            const monthDiv = document.createElement('div');
+            monthDiv.style.cssText = 'background: var(--panel); border-radius: var(--radius); padding: 8px; border: 1px solid var(--table-border);';
+
+            const title = document.createElement('div');
+            title.style.cssText = 'text-align: center; font-weight: 600; font-size: 0.85rem; margin-bottom: 6px;';
+            title.textContent = monthNames[m];
+            monthDiv.appendChild(title);
+
+            const grid = document.createElement('div');
+            grid.style.cssText = 'display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px; font-size: 0.75rem;';
+
+            // Day headers
+            dayHeaders.forEach(dh => {
+                const hdr = document.createElement('div');
+                hdr.style.cssText = 'text-align: center; color: var(--muted); font-size: 0.65rem; padding: 2px 0;';
+                hdr.innerHTML = dh;
+                grid.appendChild(hdr);
+            });
+
+            // Find first day of month and how many days
+            const firstDay = new Date(calYear, m, 1);
+            const daysInMonth = new Date(calYear, m + 1, 0).getDate();
+            // Monday=0 offset (JS getDay: 0=Sun, so convert)
+            let startOffset = (firstDay.getDay() + 6) % 7;
+
+            // Empty cells before first day
+            for (let i = 0; i < startOffset; i++) {
+                const empty = document.createElement('div');
+                grid.appendChild(empty);
+            }
+
+            // Day cells
+            for (let d = 1; d <= daysInMonth; d++) {
+                const dt = new Date(calYear, m, d);
+                const iso = calYear + '-' + String(m+1).padStart(2,'0') + '-' + String(d).padStart(2,'0');
+                const dayOfWeek = (dt.getDay() + 6) % 7; // 0=Mon
+                const isWeekend = dayOfWeek >= 5;
+
+                const cell = document.createElement('div');
+                cell.textContent = d;
+                cell.dataset.date = iso;
+
+                const isSelected = selectedDates.has(iso);
+                cell.style.cssText = 'text-align: center; padding: 3px 1px; border-radius: 3px; cursor: pointer; transition: all 0.1s; user-select: none;'
+                    + (isSelected ? 'background: var(--accent); color: var(--bg); font-weight: 600;'
+                       : isWeekend ? 'color: var(--muted); opacity: 0.4;'
+                       : 'color: var(--text);');
+
+                cell.addEventListener('click', function() {
+                    const date = this.dataset.date;
+                    if (selectedDates.has(date)) {
+                        selectedDates.delete(date);
+                        const wd = (new Date(date).getDay() + 6) % 7;
+                        this.style.background = 'transparent';
+                        this.style.color = wd >= 5 ? 'var(--muted)' : 'var(--text)';
+                        this.style.fontWeight = '400';
+                        this.style.opacity = wd >= 5 ? '0.4' : '1';
+                    } else {
+                        selectedDates.add(date);
+                        this.style.background = 'var(--accent)';
+                        this.style.color = 'var(--bg)';
+                        this.style.fontWeight = '600';
+                        this.style.opacity = '1';
+                    }
+                    updateDayCount();
+                });
+
+                grid.appendChild(cell);
+            }
+
+            monthDiv.appendChild(grid);
+            calendarEl.appendChild(monthDiv);
+        }
+        updateDayCount();
+    }
+
+    renderCalendar();
+});
+</script>
+
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -54,6 +54,7 @@
                             <a href="/profile" class="nav-link">{{ user.name }}</a>
                             {% if user.role.value == 'admin' %}
                                 <a href="/admin/users" class="nav-link">Users</a>
+                                <a href="/admin/vacation" class="nav-link">Semester</a>
                                 <a href="/admin/settings" class="nav-link">Settings</a>
                             {% endif %}
                             <a href="/logout" class="nav-link" style="color: var(--muted);">Log out</a>

--- a/app/templates/month.html
+++ b/app/templates/month.html
@@ -91,6 +91,14 @@
         </tbody>
     </table>
 
+    {% if vacation_month %}
+    <div style="background: rgba(100,200,255,0.08); border: 1px solid var(--accent); padding: 10px 16px; border-radius: var(--radius); margin-bottom: 16px; font-size: 0.9rem;">
+        <strong>{{ vacation_month.days }} semesterdag{{ 'ar' if vacation_month.days != 1 else '' }}</strong> denna m&aring;nad
+        &rarr; semestertill&auml;gg: <strong style="color: var(--accent-2);">{{ "{:,.0f}".format(vacation_month.supplement_month).replace(",", " ") }} kr</strong>
+        <span style="color: var(--muted);">({{ "%.0f"|format(vacation_month.supplement_per_day) }} kr/dag)</span>
+    </div>
+    {% endif %}
+
     {# Calendar grid view #}
     {% set weekday_names_short = ['Mån', 'Tis', 'Ons', 'Tor', 'Fre', 'Lör', 'Sön'] %}
 

--- a/app/templates/vacation.html
+++ b/app/templates/vacation.html
@@ -17,21 +17,23 @@
 <h2 class="page-title">Semester {{ year }} - {{ user.name }}</h2>
 
 <div class="row" style="gap: 24px; flex-wrap: wrap; align-items: flex-start;">
-    
-    <!-- Välj veckor -->
+
+    <!-- Left column: week grid + day-level -->
     <div class="col" style="min-width: 400px; flex: 2;">
-        <div class="card">
-            <h3 style="margin-top: 0;">Välj semesterveckor</h3>
-            <p style="color: var(--muted); margin-bottom: 16px;">Klicka på veckor för att markera/avmarkera semester.</p>
-            
+
+        <!-- Week Selection -->
+        <div class="card" style="margin-bottom: 16px;">
+            <h3 style="margin-top: 0;">V&auml;lj semesterveckor</h3>
+            <p style="color: var(--muted); margin-bottom: 16px;">Klicka p&aring; veckor f&ouml;r att markera/avmarkera semester.</p>
+
             <form method="POST" action="/profile/vacation" id="vacation-form">
                 <input type="hidden" name="year" value="{{ year }}">
                 <input type="hidden" name="weeks" id="weeks-input" value="{{ vacation_weeks | join(',') }}">
-                
+
                 <div class="week-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(60px, 1fr)); gap: 8px; margin-bottom: 24px;">
                     {% for week in range(1, 53) %}
-                        <button 
-                            type="button" 
+                        <button
+                            type="button"
                             class="week-btn {% if week in vacation_weeks %}selected{% endif %}"
                             data-week="{{ week }}"
                             style="
@@ -49,27 +51,129 @@
                         </button>
                     {% endfor %}
                 </div>
-                
+
                 <button type="submit" class="btn">Spara semester</button>
             </form>
         </div>
-    </div>
-    
-    <!-- Sammanfattning -->
-    <div class="col" style="min-width: 250px; flex: 1;">
+
+        <!-- Day-Level Vacation Calendar -->
         <div class="card">
-            <h3 style="margin-top: 0;">Vald semester</h3>
+            <h3 style="margin-top: 0;">Enskilda semesterdagar</h3>
+            <p style="color: var(--muted); margin-bottom: 16px;">Klicka p&aring; dagar f&ouml;r att markera/avmarkera semester.</p>
+
+            <form method="POST" action="/profile/vacation/days/sync" id="days-form">
+                <input type="hidden" name="year" value="{{ year }}">
+                <input type="hidden" name="dates" id="dates-input"
+                    value="{% for a in day_absences %}{{ a.date.strftime('%Y-%m-%d') }}{% if not loop.last %},{% endif %}{% endfor %}">
+
+                <div id="day-calendar" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 12px; margin-bottom: 16px;"></div>
+
+                <div style="display: flex; justify-content: space-between; align-items: center;">
+                    <span id="day-count" style="color: var(--muted); font-size: 0.85rem;"></span>
+                    <button type="submit" class="btn">Spara dagar</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <!-- Right column: balance + summary -->
+    <div class="col" style="min-width: 250px; flex: 1;">
+
+        <!-- Balance Card -->
+        {% if balance %}
+        <div class="card" style="margin-bottom: 16px;">
+            <h3 style="margin-top: 0;">Semestersaldo</h3>
+            <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px;">
+                <div style="text-align: center;">
+                    <div style="color: var(--muted); font-size: 0.75rem; margin-bottom: 4px;">Tilldelade</div>
+                    <div style="font-size: 1.4rem; font-weight: 700;">{{ balance.entitled_days }}</div>
+                </div>
+                <div style="text-align: center;">
+                    <div style="color: var(--muted); font-size: 0.75rem; margin-bottom: 4px;">Uttagna</div>
+                    <div style="font-size: 1.4rem; font-weight: 700;">{{ balance.used_days }}</div>
+                </div>
+                <div style="text-align: center;">
+                    <div style="color: var(--muted); font-size: 0.75rem; margin-bottom: 4px;">Kvar</div>
+                    <div style="font-size: 1.4rem; font-weight: 700; color: {% if balance.remaining_days > 5 %}var(--accent-2){% elif balance.remaining_days > 0 %}var(--warning){% else %}var(--danger){% endif %};">
+                        {{ balance.remaining_days }}
+                    </div>
+                </div>
+            </div>
+            <div style="margin-top: 10px; font-size: 0.75rem; color: var(--muted); text-align: center;">
+                {{ balance.year_start.strftime('%Y-%m-%d') }} &mdash; {{ balance.year_end.strftime('%Y-%m-%d') }}
+                {% if balance.is_first_year %}<br><span style="color: var(--warning);">F&ouml;rsta &aring;ret (proportionellt)</span>{% endif %}
+            </div>
+        </div>
+
+        <!-- Vacation Supplement Card -->
+        {% if balance.pay %}
+        <div class="card" style="margin-bottom: 16px;">
+            <h3 style="margin-top: 0;">Semestertill&auml;gg</h3>
+            <div style="font-size: 0.7rem; color: var(--muted); margin-bottom: 10px;">Handelns avtal 2025&ndash;2027</div>
+            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 6px; margin-bottom: 10px;">
+                <div style="text-align: center;">
+                    <div style="color: var(--muted); font-size: 0.7rem; margin-bottom: 4px;">Fast/dag</div>
+                    <div style="font-size: 1rem; font-weight: 700;">{{ "%.0f"|format(balance.pay.fixed_per_day) }} kr</div>
+                    <div style="color: var(--muted); font-size: 0.65rem;">0,8%</div>
+                </div>
+                <div style="text-align: center;">
+                    <div style="color: var(--muted); font-size: 0.7rem; margin-bottom: 4px;">R&ouml;rlig/dag</div>
+                    <div style="font-size: 1rem; font-weight: 700; color: var(--accent);">{{ "%.0f"|format(balance.pay.variable_per_day) }} kr</div>
+                    <div style="color: var(--muted); font-size: 0.65rem;">0,5%</div>
+                </div>
+            </div>
+            <div style="text-align: center; padding: 6px; background: rgba(255,255,255,0.03); border-radius: var(--radius); margin-bottom: 10px;">
+                <div style="color: var(--muted); font-size: 0.7rem; margin-bottom: 2px;">Tilll&auml;gg per semesterdag</div>
+                <div style="font-size: 1.3rem; font-weight: 700; color: var(--accent-2);">{{ "%.0f"|format(balance.pay.supplement_per_day) }} kr</div>
+                <div style="color: var(--muted); font-size: 0.65rem; margin-top: 2px;">
+                    Totalt {{ balance.entitled_days }} dagar: {{ "{:,.0f}".format(balance.pay.supplement_total).replace(",", " ") }} kr
+                </div>
+            </div>
+            <div style="font-size: 0.7rem; color: var(--muted);">
+                <div style="display: grid; grid-template-columns: 1fr auto; gap: 2px 8px;">
+                    <span>OB/skift:</span>
+                    <span style="text-align: right;">{{ "{:,.0f}".format(balance.pay.ob_total).replace(",", " ") }} kr</span>
+                    <span>&Ouml;vertid:</span>
+                    <span style="text-align: right;">{{ "{:,.0f}".format(balance.pay.ot_total).replace(",", " ") }} kr</span>
+                    <span>Beredskap:</span>
+                    <span style="text-align: right;">{{ "{:,.0f}".format(balance.pay.oncall_total).replace(",", " ") }} kr</span>
+                </div>
+                <div style="margin-top: 4px; padding-top: 4px; border-top: 1px solid var(--table-border);">
+                    Summa r&ouml;rligt: {{ "{:,.0f}".format(balance.pay.variable_total).replace(",", " ") }} kr
+                </div>
+            </div>
+        </div>
+        {% endif %}
+        {% endif %}
+
+        <!-- Week Summary -->
+        <div class="card" style="margin-bottom: 16px;">
+            <h3 style="margin-top: 0;">Valda veckor</h3>
             <div id="selected-summary">
                 {% if vacation_weeks %}
                     <p><strong>{{ vacation_weeks | length }}</strong> veckor valda:</p>
                     <p style="color: var(--muted);">{{ vacation_weeks | join(', ') }}</p>
                 {% else %}
-                    <p style="color: var(--muted);">Ingen semester vald för {{ year }}.</p>
+                    <p style="color: var(--muted);">Ingen semester vald f&ouml;r {{ year }}.</p>
                 {% endif %}
             </div>
         </div>
+
+        <!-- Employment start date -->
+        <div class="card">
+            <h3 style="margin-top: 0;">Anst&auml;llningsstart</h3>
+            <form method="POST" action="/profile/vacation/settings">
+                <div style="margin-bottom: 12px;">
+                    <label style="display: block; margin-bottom: 6px; color: var(--muted); font-size: 0.85rem;">Startdatum</label>
+                    <input type="date" name="employment_start_date"
+                        value="{{ user.employment_start_date.strftime('%Y-%m-%d') if user.employment_start_date else '' }}"
+                        style="width: 100%; padding: 8px 12px; border-radius: var(--radius); border: 1px solid var(--table-border); background: var(--panel); color: var(--text); box-sizing: border-box;">
+                </div>
+                <button type="submit" class="btn" style="width: 100%;">Spara</button>
+            </form>
+        </div>
     </div>
-    
+
 </div>
 
 <script>
@@ -77,16 +181,15 @@ document.addEventListener('DOMContentLoaded', function() {
     const weeksInput = document.getElementById('weeks-input');
     const buttons = document.querySelectorAll('.week-btn');
     const summary = document.getElementById('selected-summary');
-    
-    // Parse initial weeks
-    let selectedWeeks = weeksInput.value 
+
+    let selectedWeeks = weeksInput.value
         ? weeksInput.value.split(',').map(w => parseInt(w.trim())).filter(w => !isNaN(w))
         : [];
-    
+
     function updateSummary() {
         selectedWeeks.sort((a, b) => a - b);
         weeksInput.value = selectedWeeks.join(',');
-        
+
         if (selectedWeeks.length > 0) {
             summary.innerHTML = `
                 <p><strong>${selectedWeeks.length}</strong> veckor valda:</p>
@@ -96,31 +199,123 @@ document.addEventListener('DOMContentLoaded', function() {
             summary.innerHTML = '<p style="color: var(--muted);">Ingen semester vald.</p>';
         }
     }
-    
+
     buttons.forEach(btn => {
         btn.addEventListener('click', function() {
             const week = parseInt(this.dataset.week);
             const index = selectedWeeks.indexOf(week);
-            
+
             if (index > -1) {
-                // Remove
                 selectedWeeks.splice(index, 1);
                 this.classList.remove('selected');
                 this.style.background = 'var(--panel)';
                 this.style.color = 'var(--text)';
                 this.style.fontWeight = '400';
             } else {
-                // Add
                 selectedWeeks.push(week);
                 this.classList.add('selected');
                 this.style.background = 'var(--accent)';
                 this.style.color = 'var(--bg)';
                 this.style.fontWeight = '600';
             }
-            
+
             updateSummary();
         });
     });
+
+    // --- Day-level calendar ---
+    const datesInput = document.getElementById('dates-input');
+    const calendarEl = document.getElementById('day-calendar');
+    const dayCountEl = document.getElementById('day-count');
+    const calYear = {{ year }};
+
+    const monthNames = ['Januari','Februari','Mars','April','Maj','Juni',
+                        'Juli','Augusti','September','Oktober','November','December'];
+    const dayHeaders = ['M\u00e5','Ti','On','To','Fr','L\u00f6','S\u00f6'];
+
+    let selectedDates = new Set(
+        datesInput.value ? datesInput.value.split(',').map(s => s.trim()).filter(Boolean) : []
+    );
+
+    function updateDayCount() {
+        datesInput.value = Array.from(selectedDates).sort().join(',');
+        dayCountEl.textContent = selectedDates.size + ' dag' + (selectedDates.size !== 1 ? 'ar' : '') + ' valda';
+    }
+
+    function renderCalendar() {
+        calendarEl.innerHTML = '';
+        for (let m = 0; m < 12; m++) {
+            const monthDiv = document.createElement('div');
+            monthDiv.style.cssText = 'background: var(--panel); border-radius: var(--radius); padding: 8px; border: 1px solid var(--table-border);';
+
+            const title = document.createElement('div');
+            title.style.cssText = 'text-align: center; font-weight: 600; font-size: 0.85rem; margin-bottom: 6px;';
+            title.textContent = monthNames[m];
+            monthDiv.appendChild(title);
+
+            const grid = document.createElement('div');
+            grid.style.cssText = 'display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px; font-size: 0.75rem;';
+
+            dayHeaders.forEach(dh => {
+                const hdr = document.createElement('div');
+                hdr.style.cssText = 'text-align: center; color: var(--muted); font-size: 0.65rem; padding: 2px 0;';
+                hdr.textContent = dh;
+                grid.appendChild(hdr);
+            });
+
+            const firstDay = new Date(calYear, m, 1);
+            const daysInMonth = new Date(calYear, m + 1, 0).getDate();
+            let startOffset = (firstDay.getDay() + 6) % 7;
+
+            for (let i = 0; i < startOffset; i++) {
+                grid.appendChild(document.createElement('div'));
+            }
+
+            for (let d = 1; d <= daysInMonth; d++) {
+                const dt = new Date(calYear, m, d);
+                const iso = calYear + '-' + String(m+1).padStart(2,'0') + '-' + String(d).padStart(2,'0');
+                const dayOfWeek = (dt.getDay() + 6) % 7;
+                const isWeekend = dayOfWeek >= 5;
+
+                const cell = document.createElement('div');
+                cell.textContent = d;
+                cell.dataset.date = iso;
+
+                const isSelected = selectedDates.has(iso);
+                cell.style.cssText = 'text-align: center; padding: 3px 1px; border-radius: 3px; cursor: pointer; transition: all 0.1s; user-select: none;'
+                    + (isSelected ? 'background: var(--accent); color: var(--bg); font-weight: 600;'
+                       : isWeekend ? 'color: var(--muted); opacity: 0.4;'
+                       : 'color: var(--text);');
+
+                cell.addEventListener('click', function() {
+                    const date = this.dataset.date;
+                    if (selectedDates.has(date)) {
+                        selectedDates.delete(date);
+                        const wd = (new Date(date).getDay() + 6) % 7;
+                        this.style.background = 'transparent';
+                        this.style.color = wd >= 5 ? 'var(--muted)' : 'var(--text)';
+                        this.style.fontWeight = '400';
+                        this.style.opacity = wd >= 5 ? '0.4' : '1';
+                    } else {
+                        selectedDates.add(date);
+                        this.style.background = 'var(--accent)';
+                        this.style.color = 'var(--bg)';
+                        this.style.fontWeight = '600';
+                        this.style.opacity = '1';
+                    }
+                    updateDayCount();
+                });
+
+                grid.appendChild(cell);
+            }
+
+            monthDiv.appendChild(grid);
+            calendarEl.appendChild(monthDiv);
+        }
+        updateDayCount();
+    }
+
+    renderCalendar();
 });
 </script>
 

--- a/app/templates/year.html
+++ b/app/templates/year.html
@@ -52,6 +52,7 @@
                 <th class="th_right">On-call</th>
                 <th class="th_right">OT pay</th>
                 <th class="th_right">Absence</th>
+                {% if vacation_pay %}<th class="th_right">Sem.till.</th>{% endif %}
                 {% endif %}
             </tr>
             </thead>
@@ -87,6 +88,11 @@
                             0
                         {% endif %}
                     </td>
+                    {% if vacation_pay %}
+                    <td class="td_right num" data-label="Sem.tillägg" style="{% if m.vacation_supplement %}color: var(--accent-2);{% endif %}">
+                        {% if m.vacation_supplement %}{{ "%.0f"|format(m.vacation_supplement) }}{% else %}0{% endif %}
+                    </td>
+                    {% endif %}
                     {% endif %}
                 </tr>
                 {% endfor %}
@@ -112,6 +118,9 @@
                         0
                     {% endif %}
                 </td>
+                {% if vacation_pay %}
+                <td class="td_right foot_right num" data-label="Sem.tillägg" style="color: var(--accent-2);">{{ "%.0f"|format(year_summary.total_vacation_supplement or 0) }}</td>
+                {% endif %}
                 {% endif %}
             </tr>
             <tr>
@@ -134,6 +143,9 @@
                         0
                     {% endif %}
                 </td>
+                {% if vacation_pay %}
+                <td class="td_right foot_right num" data-label="Sem.tillägg" style="color: var(--accent-2);">{{ "%.0f"|format(year_summary.avg_vacation_supplement or 0) }}</td>
+                {% endif %}
                 {% endif %}
             </tr>
             </tfoot>
@@ -276,7 +288,46 @@
         </table>
     </div>
 
-    <!-- 6. Cowork stats (2 wide) -->
+    <!-- 6. Vacation supplement -->
+    {% if show_salary and vacation_pay and vacation_pay.pay %}
+    <div class="year-vacation">
+        <h3 class="page-title">Semestertill&auml;gg</h3>
+        <table class="summary">
+            <thead>
+                <tr>
+                    <th class="th_left">Komponent</th>
+                    <th class="th_right">Per dag</th>
+                    <th class="th_right">Totalt ({{ vacation_pay.used_days }} dagar)</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr class="shift-row">
+                    <td class="td_left" data-label="Typ">Fast tilll&auml;gg (0,8%)</td>
+                    <td class="td_right num" data-label="Per dag">{{ "%.0f"|format(vacation_pay.pay.fixed_per_day) }} kr</td>
+                    <td class="td_right num" data-label="Totalt">{{ "%.0f"|format(vacation_pay.pay.fixed_per_day * vacation_pay.used_days) }} kr</td>
+                </tr>
+                <tr class="shift-row">
+                    <td class="td_left" data-label="Typ">R&ouml;rligt tilll&auml;gg (0,5%)</td>
+                    <td class="td_right num" data-label="Per dag">{{ "%.0f"|format(vacation_pay.pay.variable_per_day) }} kr</td>
+                    <td class="td_right num" data-label="Totalt">{{ "%.0f"|format(vacation_pay.pay.variable_per_day * vacation_pay.used_days) }} kr</td>
+                </tr>
+            </tbody>
+            <tfoot>
+                <tr>
+                    <td class="td_left foot_left" data-label="Typ"><strong>Tilll&auml;gg</strong></td>
+                    <td class="td_right foot_right num" data-label="Per dag"><strong>{{ "%.0f"|format(vacation_pay.pay.supplement_per_day) }} kr</strong></td>
+                    <td class="td_right foot_right num" data-label="Totalt" style="color: var(--accent-2);"><strong>{{ "%.0f"|format(vacation_pay.pay.supplement_per_day * vacation_pay.used_days) }} kr</strong></td>
+                </tr>
+            </tfoot>
+        </table>
+        <div style="margin-top: 8px; font-size: 0.8rem; color: var(--muted);">
+            Saldo: {{ vacation_pay.entitled_days }} tilldelade &minus; {{ vacation_pay.used_days }} uttagna = {{ vacation_pay.remaining_days }} kvar
+            &nbsp;&middot;&nbsp; Semester&aring;r: {{ vacation_pay.year_start.strftime('%Y-%m-%d') }} &mdash; {{ vacation_pay.year_end.strftime('%Y-%m-%d') }}
+        </div>
+    </div>
+    {% endif %}
+
+    <!-- 7. Cowork stats (2 wide) -->
     <div class="year-cowork">
         <h2 class="page-title">Cowork stats {{ year }} - {{ person_name }}</h2>
 

--- a/migrate_vacation_fields.py
+++ b/migrate_vacation_fields.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""
+Migration script to add vacation-related columns to users table.
+
+Adds:
+- employment_start_date: When the employee started working (for vacation balance)
+- vacation_year_start_month: Month (1-12) when vacation year starts (default 4 = April)
+- vacation_days_per_year: Annual vacation entitlement (default 25)
+
+Also backfills employment_start_date from person_history where possible.
+"""
+
+import sqlite3
+import sys
+from pathlib import Path
+
+
+def migrate():
+    """Add vacation fields to users table."""
+    db_path = Path("app/database/schedule.db")
+
+    if not db_path.exists():
+        print(f"Error: Database not found at {db_path}")
+        sys.exit(1)
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    try:
+        # Check existing columns
+        cursor.execute("PRAGMA table_info(users)")
+        columns = [row[1] for row in cursor.fetchall()]
+
+        added = []
+
+        # Add employment_start_date
+        if "employment_start_date" not in columns:
+            print("Adding employment_start_date column...")
+            cursor.execute("""
+                ALTER TABLE users
+                ADD COLUMN employment_start_date DATE
+            """)
+            added.append("employment_start_date")
+        else:
+            print("Column 'employment_start_date' already exists. Skipping.")
+
+        # Add vacation_year_start_month
+        if "vacation_year_start_month" not in columns:
+            print("Adding vacation_year_start_month column...")
+            cursor.execute("""
+                ALTER TABLE users
+                ADD COLUMN vacation_year_start_month INTEGER DEFAULT 4 NOT NULL
+            """)
+            # Ensure all existing rows have the default
+            cursor.execute("""
+                UPDATE users
+                SET vacation_year_start_month = 4
+                WHERE vacation_year_start_month IS NULL
+            """)
+            added.append("vacation_year_start_month")
+        else:
+            print("Column 'vacation_year_start_month' already exists. Skipping.")
+
+        # Add vacation_days_per_year
+        if "vacation_days_per_year" not in columns:
+            print("Adding vacation_days_per_year column...")
+            cursor.execute("""
+                ALTER TABLE users
+                ADD COLUMN vacation_days_per_year INTEGER DEFAULT 25 NOT NULL
+            """)
+            # Ensure all existing rows have the default
+            cursor.execute("""
+                UPDATE users
+                SET vacation_days_per_year = 25
+                WHERE vacation_days_per_year IS NULL
+            """)
+            added.append("vacation_days_per_year")
+        else:
+            print("Column 'vacation_days_per_year' already exists. Skipping.")
+
+        # Backfill employment_start_date from person_history
+        if "employment_start_date" in added:
+            print("\nBackfilling employment_start_date from person_history...")
+            cursor.execute("""
+                UPDATE users
+                SET employment_start_date = (
+                    SELECT MIN(ph.effective_from)
+                    FROM person_history ph
+                    WHERE ph.user_id = users.id
+                )
+                WHERE employment_start_date IS NULL
+                AND EXISTS (
+                    SELECT 1 FROM person_history ph WHERE ph.user_id = users.id
+                )
+            """)
+            backfilled = cursor.rowcount
+            print(f"  Backfilled {backfilled} user(s) from person_history")
+
+        conn.commit()
+
+        if added:
+            print(f"\nSuccessfully added columns: {', '.join(added)}")
+        else:
+            print("\nNo changes needed - all columns already exist.")
+
+        # Verify
+        cursor.execute("""
+            SELECT id, username, employment_start_date, vacation_year_start_month, vacation_days_per_year
+            FROM users
+        """)
+        rows = cursor.fetchall()
+        print(f"\nCurrent state ({len(rows)} users):")
+        for row in rows:
+            print(f"  id={row[0]}, username={row[1]}, start={row[2]}, break_month={row[3]}, days/year={row[4]}")
+
+    except sqlite3.Error as e:
+        print(f"Error during migration: {e}")
+        conn.rollback()
+        sys.exit(1)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("Migration: Add vacation fields to users table")
+    print("=" * 60)
+    migrate()
+    print("\nMigration completed successfully!")


### PR DESCRIPTION
## Summary
- **Datamodell**: VACATION absence type + 3 nya User-fält (employment_start_date, vacation_year_start_month, vacation_days_per_year) med migreringsscript
- **Semestersaldo**: Beräkning med intjänandeår, pro-rata första året, och semestertillägg enligt Handelns tjänstemannaavtal 2025–2027 (0,8% fast + 0,5% rörlig per dag)
- **Admin-vyer**: Teamöversikt med heatmap + saldotabell, per-användare med veckogrid, kalender-picker för enskilda dagar, och inställningar
- **Självservice**: Saldo, semestertillägg, veckogrid, kalender-picker och anställningsstartdatum på /profile/vacation
- **Year/Month-vyer**: Semestertillägg-kolumn i monthly summary-tabellen (inkluderat i brutto/netto), detaljsektion, och banner i månadsvyn
- **Schemalogik**: VACATION absence → SEM shift-mappning i period.py

## Test plan
- [x] Kört `python3 migrate_vacation_fields.py` på dev och prod DB
- [x] Verifierat admin teamöversikt: `/admin/vacation` — heatmap och saldotabell
- [x] Verifierat per-användare: `/admin/vacation/{id}` — veckor, kalender-picker, inställningar
- [x] Verifierat självservice: `/profile/vacation` — saldo, tillägg, kalender-picker
- [x] Kontrollerat year-vy: Sem.till.-kolumn + detaljsektion stämmer med brutto/netto
- [x] Kontrollerat month-vy: Banner visas för månader med SEM-dagar
- [x] Verifierat att enskilda semesterdagar visas som SEM i schema-vyer
- [x] Testat bulk sync (kalender-picker): markera/avmarkera flera dagar och spara