### PR TITLE
Add error handling, shift swaps, and statistics

### DIFF
--- a/app/database/database.py
+++ b/app/database/database.py
@@ -51,6 +51,15 @@ class OnCallOverrideType(str, enum.Enum):
     REMOVE = "REMOVE"  # Avbokat OC-pass från rotation
 
 
+class SwapStatus(str, enum.Enum):
+    """Status of a shift swap request."""
+
+    PENDING = "PENDING"
+    ACCEPTED = "ACCEPTED"
+    REJECTED = "REJECTED"
+    CANCELLED = "CANCELLED"
+
+
 class User(Base):
     """User model with authentication and schedule data."""
 
@@ -241,6 +250,34 @@ class RotationEra(Base):
         return (
             f"<RotationEra(id={self.id}, start_date={self.start_date}, "
             f"end_date={self.end_date}, rotation_length={self.rotation_length})>"
+        )
+
+
+class ShiftSwap(Base):
+    """Shift swap request between two users, potentially on different dates."""
+
+    __tablename__ = "shift_swaps"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    requester_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    target_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    requester_date = Column(Date, nullable=False)  # Date requester gives away
+    target_date = Column(Date, nullable=False)  # Date requester wants from target
+    requester_shift_code = Column(String(10), nullable=True)
+    target_shift_code = Column(String(10), nullable=True)
+    status = Column(SQLEnum(SwapStatus), default=SwapStatus.PENDING, nullable=False)
+    message = Column(String(255), nullable=True)
+    responded_at = Column(DateTime, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    # Relationships
+    requester = relationship("User", foreign_keys=[requester_id])
+    target = relationship("User", foreign_keys=[target_id])
+
+    def __repr__(self):
+        return (
+            f"<ShiftSwap(id={self.id}, requester={self.requester_id}, "
+            f"target={self.target_id}, date={self.date}, status={self.status})>"
         )
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -29,6 +29,7 @@ from app.routes.schedule_all import router as schedule_all_router
 from app.routes.schedule_api import router as schedule_api_router
 from app.routes.schedule_personal import router as schedule_personal_router
 from app.routes.shift_swap import router as shift_swap_router
+from app.routes.statistics import router as statistics_router
 
 # Setup logging FIRST (before any other imports that might log)
 setup_logging()
@@ -236,6 +237,7 @@ app.include_router(schedule_api_router)
 app.include_router(overtime_router)
 app.include_router(oncall_router)
 app.include_router(shift_swap_router)
+app.include_router(statistics_router)
 app.include_router(auth_router)
 app.include_router(admin_router)
 

--- a/app/main.py
+++ b/app/main.py
@@ -28,6 +28,7 @@ from app.routes.overtime import router as overtime_router
 from app.routes.schedule_all import router as schedule_all_router
 from app.routes.schedule_api import router as schedule_api_router
 from app.routes.schedule_personal import router as schedule_personal_router
+from app.routes.shift_swap import router as shift_swap_router
 
 # Setup logging FIRST (before any other imports that might log)
 setup_logging()
@@ -234,6 +235,7 @@ app.include_router(schedule_all_router)
 app.include_router(schedule_api_router)
 app.include_router(overtime_router)
 app.include_router(oncall_router)
+app.include_router(shift_swap_router)
 app.include_router(auth_router)
 app.include_router(admin_router)
 

--- a/app/routes/dashboard.py
+++ b/app/routes/dashboard.py
@@ -28,7 +28,7 @@ from app.core.schedule import (
 )
 from app.core.storage import calculate_tax_from_table
 from app.core.utils import get_safe_today, get_today
-from app.database.database import Absence, OnCallOverride, OnCallOverrideType, User, get_db
+from app.database.database import Absence, OnCallOverride, OnCallOverrideType, ShiftSwap, SwapStatus, User, get_db
 from app.routes.shared import templates
 
 router = APIRouter(tags=["dashboard"])
@@ -457,6 +457,13 @@ async def read_root(
             if upcoming_vacation:
                 break
 
+    # Check for pending shift swap requests
+    pending_swap_count = (
+        db.query(ShiftSwap)
+        .filter(ShiftSwap.target_id == current_user.id, ShiftSwap.status == SwapStatus.PENDING)
+        .count()
+    )
+
     return render_template(
         templates,
         "dashboard.html",
@@ -469,6 +476,7 @@ async def read_root(
             "month_summary": month_summary,
             "upcoming_vacation": upcoming_vacation,
             "can_see_salary": can_see_salary(current_user, current_user.id),
+            "pending_swap_count": pending_swap_count,
         },
         user=current_user,
     )

--- a/app/routes/schedule_personal.py
+++ b/app/routes/schedule_personal.py
@@ -490,6 +490,16 @@ async def show_day_for_person(
             "is_karens": is_karens,  # Whether this is a karensdag
             "coworkers": coworkers,  # List of coworker names
             "all_working_persons": persons_today_with_shift,
+            "swap_users": [
+                u
+                for u in db.query(User)
+                .filter(User.is_active == 1, User.id != current_user.id, User.role != UserRole.ADMIN)
+                .all()
+                if any(
+                    p.get("person_id") == u.rotation_person_id and (not p.get("shift") or p["shift"].code == "OFF")
+                    for p in persons_today
+                )
+            ],
             "oncall_override": oncall_override,  # On-call override data
             "has_rotation_oc": has_rotation_oc,  # Whether person has OC in rotation
             "is_effective_oc": is_effective_oc,  # Whether this is effectively an OC shift

--- a/app/routes/shift_swap.py
+++ b/app/routes/shift_swap.py
@@ -1,0 +1,303 @@
+# app/routes/shift_swap.py
+"""Shift swap management routes - propose, accept, reject, cancel swaps."""
+
+from datetime import datetime, timedelta
+
+from fastapi import APIRouter, Depends, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from sqlalchemy.orm import Session
+
+from app.auth.auth import get_current_user
+from app.core.helpers import render_template
+from app.core.schedule import build_week_data, clear_schedule_cache
+from app.core.schedule.core import determine_shift_for_date
+from app.core.utils import get_today
+from app.database.database import ShiftSwap, SwapStatus, User, get_db
+from app.routes.shared import templates
+
+router = APIRouter(prefix="/swaps", tags=["shift_swaps"])
+
+
+@router.get("/api/shifts/{user_id}")
+async def get_user_shifts(
+    user_id: int,
+    offering: str = None,
+    ref_date: str = None,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Return target's shifts within ±3 months of ref_date, only on days the requester is free."""
+    from app.core.schedule import calculate_ob_hours, calculate_shift_hours
+    from app.core.schedule.ob import get_combined_rules_for_year
+
+    target = db.query(User).get(user_id)
+    if not target:
+        return JSONResponse(content={"shifts": []})
+
+    today = get_today()
+    center = datetime.strptime(ref_date, "%Y-%m-%d").date() if ref_date else today
+    target_pid = target.rotation_person_id
+    my_pid = current_user.rotation_person_id
+
+    # Build list of days: ±90 days from center, but not in the past
+    scan_start = max(center - timedelta(days=90), today + timedelta(days=1))
+    scan_end = center + timedelta(days=90)
+    total_days = (scan_end - scan_start).days + 1
+
+    # Fetch week data for both users, grouped by ISO week
+    # Include adjacent days for 11h rest rule checks
+    target_weeks = {}
+    my_weeks = {}
+    for day_offset in range(total_days):
+        d = scan_start + timedelta(days=day_offset)
+        for adj in (d - timedelta(days=1), d, d + timedelta(days=1)):
+            iso = adj.isocalendar()
+            wk = (iso[0], iso[1])
+            if wk not in my_weeks:
+                target_weeks[wk] = {
+                    day["date"]: day for day in build_week_data(wk[0], wk[1], person_id=target_pid, session=db)
+                }
+                my_weeks[wk] = {day["date"]: day for day in build_week_data(wk[0], wk[1], person_id=my_pid, session=db)}
+
+    MIN_REST_HOURS = 11
+
+    def get_my_shift_times(d):
+        """Get start/end datetimes for my shift on date d."""
+        iso = d.isocalendar()
+        wk = (iso[0], iso[1])
+        info = my_weeks.get(wk, {}).get(d, {})
+        s = info.get("shift")
+        if not s or s.code in ("OFF", "OC"):
+            return None, None
+        _, start_dt, end_dt = calculate_shift_hours(d, s)
+        return start_dt, end_dt
+
+    shifts = []
+    ob_rules_cache = {}
+    for day_offset in range(total_days):
+        d = scan_start + timedelta(days=day_offset)
+        iso = d.isocalendar()
+        wk = (iso[0], iso[1])
+
+        # Determine what I have on this day
+        my_info = my_weeks[wk].get(d, {})
+        my_shift = my_info.get("shift")
+        my_code = my_shift.code if my_shift else "OFF"
+
+        if my_code not in ("OFF", "OC"):
+            continue  # I'm working a regular shift — can't take this day
+
+        # Check target's shift
+        tgt_info = target_weeks[wk].get(d, {})
+        tgt_shift = tgt_info.get("shift")
+        if not tgt_shift or tgt_shift.code == "OFF":
+            continue
+
+        # OC-to-OC: when offering OC, only show target's OC shifts (requester must be OFF)
+        # Regular: when offering a regular shift, only show target's regular shifts
+        if offering == "OC":
+            if tgt_shift.code != "OC":
+                continue  # Offering OC — only interested in target's OC
+            if my_code != "OFF":
+                continue  # Must be OFF to take their OC
+        else:
+            if tgt_shift.code == "OC":
+                continue  # Offering regular — can't take OC
+            if my_code != "OFF":
+                continue  # Must be OFF to take their shift
+
+        # Calculate target shift times (the shift I would work)
+        _, tgt_start, tgt_end = calculate_shift_hours(d, tgt_shift)
+
+        # 11h rest rule: check against my shifts on adjacent days
+        if tgt_start and tgt_end:
+            rest_ok = True
+            # Check day before: my shift end → target shift start >= 11h
+            prev_start, prev_end = get_my_shift_times(d - timedelta(days=1))
+            if prev_end and (tgt_start - prev_end).total_seconds() / 3600 < MIN_REST_HOURS:
+                rest_ok = False
+            # Check day after: target shift end → my next shift start >= 11h
+            next_start, next_end = get_my_shift_times(d + timedelta(days=1))
+            if rest_ok and next_start and (next_start - tgt_end).total_seconds() / 3600 < MIN_REST_HOURS:
+                rest_ok = False
+            if not rest_ok:
+                continue
+
+        # Calculate OB hours for the target's shift
+        ob_total = 0.0
+        if tgt_start and tgt_end:
+            year = d.year
+            if year not in ob_rules_cache:
+                ob_rules_cache[year] = get_combined_rules_for_year(year)
+            ob_dict = calculate_ob_hours(tgt_start, tgt_end, ob_rules_cache[year])
+            ob_total = sum(ob_dict.values())
+
+        shifts.append(
+            {
+                "date": d.isoformat(),
+                "date_display": d.strftime("%a %d %b"),
+                "code": tgt_shift.code,
+                "label": tgt_shift.label or tgt_shift.code,
+                "ob_hours": round(ob_total, 1),
+            }
+        )
+
+    return JSONResponse(content={"shifts": shifts})
+
+
+@router.get("/", response_class=HTMLResponse)
+async def list_swaps(
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """List all swaps for the current user (both sent and received)."""
+    sent = (
+        db.query(ShiftSwap)
+        .filter(ShiftSwap.requester_id == current_user.id)
+        .order_by(ShiftSwap.created_at.desc())
+        .all()
+    )
+    received = (
+        db.query(ShiftSwap).filter(ShiftSwap.target_id == current_user.id).order_by(ShiftSwap.created_at.desc()).all()
+    )
+
+    pending_count = sum(1 for s in received if s.status == SwapStatus.PENDING)
+
+    return render_template(
+        templates,
+        "shift_swaps.html",
+        request,
+        {"sent_swaps": sent, "received_swaps": received, "pending_count": pending_count},
+        user=current_user,
+    )
+
+
+@router.post("/propose")
+async def propose_swap(
+    target_id: int = Form(...),
+    requester_date: str = Form(...),
+    target_date: str = Form(...),
+    message: str = Form(None),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Propose a shift swap: give your shift on requester_date, take target's shift on target_date."""
+    if target_id == current_user.id:
+        raise HTTPException(status_code=400, detail="Kan inte byta pass med dig själv")
+
+    req_date = datetime.strptime(requester_date, "%Y-%m-%d").date()
+    tgt_date = datetime.strptime(target_date, "%Y-%m-%d").date()
+    today = get_today()
+
+    if req_date <= today or tgt_date <= today:
+        raise HTTPException(status_code=400, detail="Kan bara byta framtida pass")
+
+    target_user = db.query(User).get(target_id)
+    if not target_user:
+        raise HTTPException(status_code=404, detail="Användaren hittades inte")
+
+    # Check no duplicate pending swap
+    existing = (
+        db.query(ShiftSwap)
+        .filter(
+            ShiftSwap.requester_id == current_user.id,
+            ShiftSwap.target_id == target_id,
+            ShiftSwap.requester_date == req_date,
+            ShiftSwap.target_date == tgt_date,
+            ShiftSwap.status == SwapStatus.PENDING,
+        )
+        .first()
+    )
+    if existing:
+        raise HTTPException(status_code=400, detail="Byte redan föreslaget för dessa datum")
+
+    # Get shift codes for both dates
+    req_result = determine_shift_for_date(req_date, start_week=current_user.rotation_person_id)
+    tgt_result = determine_shift_for_date(tgt_date, start_week=target_user.rotation_person_id)
+
+    swap = ShiftSwap(
+        requester_id=current_user.id,
+        target_id=target_id,
+        requester_date=req_date,
+        target_date=tgt_date,
+        requester_shift_code=req_result[0].code if req_result and req_result[0] else None,
+        target_shift_code=tgt_result[0].code if tgt_result and tgt_result[0] else None,
+        message=message,
+    )
+    db.add(swap)
+    db.commit()
+
+    return RedirectResponse(url="/swaps", status_code=303)
+
+
+@router.post("/{swap_id}/accept")
+async def accept_swap(
+    swap_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Accept a swap request (target user only)."""
+    swap = db.query(ShiftSwap).get(swap_id)
+    if not swap:
+        raise HTTPException(status_code=404, detail="Bytet hittades inte")
+    if swap.target_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Inte behörig")
+    if swap.status != SwapStatus.PENDING:
+        raise HTTPException(status_code=400, detail="Bytet är inte längre väntande")
+
+    swap.status = SwapStatus.ACCEPTED
+    swap.responded_at = datetime.utcnow()
+    db.commit()
+    clear_schedule_cache()
+
+    return RedirectResponse(url="/swaps", status_code=303)
+
+
+@router.post("/{swap_id}/reject")
+async def reject_swap(
+    swap_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Reject a swap request (target user only)."""
+    swap = db.query(ShiftSwap).get(swap_id)
+    if not swap:
+        raise HTTPException(status_code=404, detail="Bytet hittades inte")
+    if swap.target_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Inte behörig")
+    if swap.status != SwapStatus.PENDING:
+        raise HTTPException(status_code=400, detail="Bytet är inte längre väntande")
+
+    swap.status = SwapStatus.REJECTED
+    swap.responded_at = datetime.utcnow()
+    db.commit()
+
+    return RedirectResponse(url="/swaps", status_code=303)
+
+
+@router.post("/{swap_id}/cancel")
+async def cancel_swap(
+    swap_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Cancel a pending or accepted swap (requester, target, or admin)."""
+    swap = db.query(ShiftSwap).get(swap_id)
+    if not swap:
+        raise HTTPException(status_code=404, detail="Bytet hittades inte")
+
+    is_participant = swap.requester_id == current_user.id or swap.target_id == current_user.id
+    is_admin = current_user.role.value == "admin"
+
+    if not is_participant and not is_admin:
+        raise HTTPException(status_code=403, detail="Inte behörig")
+    if swap.status not in (SwapStatus.PENDING, SwapStatus.ACCEPTED):
+        raise HTTPException(status_code=400, detail="Kan bara avbryta väntande eller accepterade byten")
+
+    swap.status = SwapStatus.CANCELLED
+    swap.responded_at = datetime.utcnow()
+    db.commit()
+    clear_schedule_cache()
+
+    return RedirectResponse(url="/swaps", status_code=303)

--- a/app/routes/statistics.py
+++ b/app/routes/statistics.py
@@ -1,0 +1,179 @@
+# app/routes/statistics.py
+"""Statistics and trends routes - charts and visualizations for schedule data."""
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from sqlalchemy.orm import Session
+
+from app.auth.auth import get_current_user_optional
+from app.core.helpers import can_see_salary, render_template, strip_salary_data
+from app.core.schedule import (
+    _cached_special_rules,
+    ob_rules,
+    summarize_year_for_person,
+)
+from app.core.schedule import persons as person_list
+from app.core.schedule.vacation import calculate_vacation_balance
+from app.core.utils import get_safe_today
+from app.core.validators import validate_person_id
+from app.database.database import User, UserRole, get_db
+from app.routes.shared import templates
+
+router = APIRouter(prefix="/statistics", tags=["statistics"])
+
+
+@router.get("/{person_id}", response_class=HTMLResponse, name="statistics_person")
+async def statistics_view(
+    request: Request,
+    person_id: int,
+    year: int = Query(None),
+    current_user: User | None = Depends(get_current_user_optional),
+    db: Session = Depends(get_db),
+):
+    """Statistics and trend charts for a specific person."""
+    if current_user is None:
+        return RedirectResponse(url=f"/login?next={request.url.path}", status_code=302)
+
+    # Handle both user_id (>10) and rotation position (1-10)
+    if person_id > 10:
+        target_user = db.query(User).filter(User.id == person_id).first()
+        if not target_user:
+            raise HTTPException(status_code=404, detail="User not found")
+        user_id_for_wages = person_id
+        rotation_position = target_user.rotation_person_id
+        person_name = target_user.name
+    else:
+        person_id = validate_person_id(person_id)
+        user_id_for_wages = person_id
+        rotation_position = person_id
+        person_name = None
+
+    # Non-admin users can only view their own data
+    if current_user.role != UserRole.ADMIN and current_user.id != user_id_for_wages:
+        return RedirectResponse(
+            url=f"/statistics/{current_user.id}?year={year or ''}",
+            status_code=302,
+        )
+
+    from app.core.schedule import rotation_start_date
+
+    safe_today = get_safe_today(rotation_start_date)
+    year = year or safe_today.year
+
+    # Resolve person name
+    if person_name is None:
+        if current_user.rotation_person_id == rotation_position:
+            person_name = current_user.name
+        else:
+            holder = db.query(User).filter(User.person_id == rotation_position).first()
+            if holder:
+                person_name = holder.name
+            else:
+                holder = db.query(User).filter(User.id == rotation_position).first()
+                person_name = holder.name if holder else person_list[rotation_position - 1].name
+
+    # Fetch year data
+    year_data = summarize_year_for_person(
+        year, rotation_position, session=db, current_user=current_user, wage_user_id=user_id_for_wages
+    )
+    months = year_data["months"]
+    year_summary = year_data["year_summary"]
+
+    show_salary = can_see_salary(current_user, rotation_position)
+
+    if not show_salary:
+        months = [strip_salary_data(m) for m in months]
+        year_summary = strip_salary_data(year_summary)
+
+    # Add vacation supplement data
+    if show_salary:
+        vac_user = (
+            db.query(User).filter(User.id == user_id_for_wages).first()
+            if user_id_for_wages > 10
+            else db.query(User).filter(User.person_id == rotation_position).first()
+        )
+        if vac_user:
+            try:
+                vacation_pay = calculate_vacation_balance(vac_user, year, db)
+                supp_per_day = vacation_pay.get("pay", {}).get("supplement_per_day", 0)
+                for m in months:
+                    sem_days = sum(1 for d in m.get("days", []) if d.get("shift") and d["shift"].code == "SEM")
+                    m["vacation_days"] = sem_days
+                    m["vacation_supplement"] = round(supp_per_day * sem_days, 0)
+                    if m["vacation_supplement"] > 0:
+                        supp = m["vacation_supplement"]
+                        brutto_before = m.get("brutto_pay", 0) or 0
+                        netto_before = m.get("netto_pay", 0) or 0
+                        m["brutto_pay"] = brutto_before + supp
+                        if brutto_before > 0:
+                            tax_ratio = netto_before / brutto_before
+                            m["netto_pay"] = round(netto_before + supp * tax_ratio, 0)
+
+                year_summary["total_brutto"] = sum((m.get("brutto_pay", 0) or 0) for m in months)
+                year_summary["total_netto"] = sum((m.get("netto_pay", 0) or 0) for m in months)
+            except Exception:
+                pass
+
+    # Build chart data for template
+    chart_labels = []
+    chart_brutto = []
+    chart_netto = []
+    chart_ob = {"OB1": [], "OB2": [], "OB3": [], "OB4": [], "OB5": []}
+    chart_oncall = []
+    chart_hours = []
+
+    for m in months:
+        label = f"{m.get('payment_year', m['year'])}-{m.get('payment_month', m['month']):02d}"
+        chart_labels.append(label)
+        chart_brutto.append(round(m.get("brutto_pay", 0) or 0))
+        chart_netto.append(round(m.get("netto_pay", 0) or 0))
+        chart_oncall.append(round(m.get("oncall_pay", 0) or 0))
+        chart_hours.append(round(m.get("total_hours", 0) or 0, 1))
+        ob_pay = m.get("ob_pay", {})
+        for code in chart_ob:
+            chart_ob[code].append(round(ob_pay.get(code, 0) or 0))
+
+    # OB rules for labels
+    special_rules = _cached_special_rules(year)
+    combined_rules = ob_rules + special_rules
+    ob_labels = {}
+    for rule in combined_rules:
+        if rule.code not in ob_labels:
+            ob_labels[rule.code] = rule.label
+
+    # Absence summary for doughnut
+    absence_data = {
+        "sick": year_summary.get("total_sick_days", 0) or 0,
+        "vab": year_summary.get("total_vab_days", 0) or 0,
+        "leave": year_summary.get("total_leave_days", 0) or 0,
+        "off": year_summary.get("total_off_days", 0) or 0,
+    }
+
+    # Person list for admin navigation
+    all_persons = None
+    if current_user.role == UserRole.ADMIN:
+        all_persons = db.query(User).filter(User.is_active == 1, User.role != UserRole.ADMIN).order_by(User.name).all()
+
+    return render_template(
+        templates,
+        "statistics.html",
+        request,
+        {
+            "year": year,
+            "person_id": person_id,
+            "person_name": person_name,
+            "months": months,
+            "year_summary": year_summary,
+            "show_salary": show_salary,
+            "chart_labels": chart_labels,
+            "chart_brutto": chart_brutto,
+            "chart_netto": chart_netto,
+            "chart_ob": chart_ob,
+            "chart_oncall": chart_oncall,
+            "chart_hours": chart_hours,
+            "ob_labels": ob_labels,
+            "absence_data": absence_data,
+            "all_persons": all_persons,
+        },
+        user=current_user,
+    )

--- a/app/static/css/components.css
+++ b/app/static/css/components.css
@@ -264,3 +264,30 @@ input, select {
 @media (max-width: 768px) {
   .dashboard-container { grid-template-columns: 1fr; }
 }
+
+/* Error Pages */
+.error-page {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 60vh;
+  text-align: center;
+}
+.error-container { max-width: 480px; }
+.error-code {
+  font-size: 6rem;
+  font-weight: 800;
+  color: var(--accent);
+  line-height: 1;
+  margin-bottom: 0.5rem;
+}
+.error-title {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+}
+.error-message {
+  color: var(--muted);
+  margin-bottom: 2rem;
+  line-height: 1.6;
+}
+

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -51,6 +51,7 @@
                         <div class="nav-row">
                             {# <span class="nav-divider"></span> #}
                             <a href="/" class="nav-link">Overview</a>
+                            <a href="/swaps" class="nav-link">Byten</a>
                             {% if user.role.value == 'admin' %}
                                 <a href="/admin/users" class="nav-link">Users</a>
                                 <a href="/admin/vacation" class="nav-link">Semester</a>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -6,6 +6,15 @@
         <h2>Welcome, {{ user.name }}</h2>
 
         <div class="dashboard-container">
+            <!-- Pending Swap Notification -->
+            {% if pending_swap_count and pending_swap_count > 0 %}
+            <div class="card" style="border-color: var(--warning); grid-column: 1 / -1;">
+                <h3 style="color: var(--warning); margin-bottom: 0.5rem;">Skiftbyten</h3>
+                <p>Du har <strong>{{ pending_swap_count }}</strong> väntande bytesförfrågan{{ 'gar' if pending_swap_count > 1 }}.</p>
+                <a href="/swaps" class="btn" style="margin-top: 0.5rem;">Visa byten</a>
+            </div>
+            {% endif %}
+
             <!-- Next Shifts Card -->
             {% if next_shift or next_oncall_shift %}
             <div class="card">

--- a/app/templates/day.html
+++ b/app/templates/day.html
@@ -393,6 +393,81 @@
                 </tbody>
             </table>
         {% endif %}
+
+        {% if swap_users and user and user.id == person_id %}
+        <h3 style="margin-top: 1.5rem;">Föreslå skiftbyte</h3>
+        <form method="POST" action="/swaps/propose" class="ot-form" id="swap-form">
+            <input type="hidden" name="requester_date" value="{{ date }}">
+            <div class="form-row">
+                <div class="form-group">
+                    <label for="target_id">Byt med:</label>
+                    <select id="target_id" name="target_id" required>
+                        <option value="">-- Välj kollega --</option>
+                        {% for u in swap_users %}
+                        <option value="{{ u.id }}">{{ u.name }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="target_date">Deras pass:</label>
+                    <select id="target_date" name="target_date" required disabled>
+                        <option value="">-- Välj kollega först --</option>
+                    </select>
+                </div>
+            </div>
+            <div class="form-row">
+                <div class="form-group">
+                    <label for="swap_message">Meddelande (valfritt):</label>
+                    <input type="text" id="swap_message" name="message" placeholder="T.ex. kan jag ta ditt pass?">
+                </div>
+            </div>
+            <button type="submit" class="btn" id="swap-submit" disabled>Föreslå byte</button>
+            <p class="info-text">
+                Du erbjuder ditt pass denna dag
+                {% if shift %}
+                    ({{ shift.code }}{% if ob_hours %}, {{ "%.1f"|format(ob_hours.values()|sum) }}h OB{% endif %})
+                {% endif %}
+                och väljer vilket av kollegans pass du vill ta.
+            </p>
+        </form>
+        <script>
+            document.getElementById('target_id').addEventListener('change', function() {
+                const userId = this.value;
+                const targetSelect = document.getElementById('target_date');
+                const submitBtn = document.getElementById('swap-submit');
+
+                if (!userId) {
+                    targetSelect.innerHTML = '<option value="">-- Välj kollega först --</option>';
+                    targetSelect.disabled = true;
+                    submitBtn.disabled = true;
+                    return;
+                }
+
+                targetSelect.innerHTML = '<option value="">Laddar pass...</option>';
+                targetSelect.disabled = true;
+
+                const offering = '{{ shift.code if shift else "OFF" }}';
+                const refDate = '{{ date }}';
+                fetch('/swaps/api/shifts/' + userId + '?offering=' + offering + '&ref_date=' + refDate)
+                    .then(r => r.json())
+                    .then(data => {
+                        if (data.shifts.length === 0) {
+                            targetSelect.innerHTML = '<option value="">Inga kommande pass</option>';
+                            submitBtn.disabled = true;
+                            return;
+                        }
+                        let html = '<option value="">-- Välj pass --</option>';
+                        data.shifts.forEach(s => {
+                            const ob = s.ob_hours > 0 ? ' (' + s.ob_hours + 'h OB)' : '';
+                            html += '<option value="' + s.date + '">' + s.date_display + ' — ' + s.label + ob + '</option>';
+                        });
+                        targetSelect.innerHTML = html;
+                        targetSelect.disabled = false;
+                        submitBtn.disabled = false;
+                    });
+            });
+        </script>
+        {% endif %}
         </section>
 
         {% if show_salary %}

--- a/app/templates/error.html
+++ b/app/templates/error.html
@@ -1,0 +1,13 @@
+{# app/templates/error.html #}
+{% extends "base.html" %}
+
+{% block page_content %}
+<section class="error-page">
+    <div class="error-container">
+        <div class="error-code">{{ status_code }}</div>
+        <h2 class="error-title">{{ title }}</h2>
+        <p class="error-message">{{ message }}</p>
+        <a href="/" class="btn btn-primary">Tillbaka till startsidan</a>
+    </div>
+</section>
+{% endblock %}

--- a/app/templates/month.html
+++ b/app/templates/month.html
@@ -192,11 +192,11 @@
                         <th class="th_right">Start</th>
                         <th class="th_right">Slut</th>
                         <th class="th_right">Norm</th>
-                        <th class="th_right">OB1</th>
-                        <th class="th_right">OB2</th>
-                        <th class="th_right">OB3</th>
-                        <th class="th_right">OB4</th>
-                        <th class="th_right">OB5</th>
+                        <th class="th_right">OB1(1,12)</th>
+                        <th class="th_right">OB2(1,18)</th>
+                        <th class="th_right">OB3(1,24)</th>
+                        <th class="th_right">OB4(1,24)</th>
+                        <th class="th_right">OB5(1,47)</th>
                         <th class="th_right">B.Vardag</th>
                         <th class="th_right">B.Helg</th>
                         <th class="th_right">B.Helgdag</th>
@@ -298,7 +298,11 @@
                 {% if ns.has_rows %}
                 <tfoot>
                     <tr>
-                        <td class="td_left" colspan="5"><strong>Total</strong></td>
+                        <td class="td_left" colspan="1"><strong>Total</strong></td>
+                        <td> </td>
+                        <td> </td>
+                        <td> </td>
+                        <td> </td>
                         <td class="td_right num"><strong>{% if ns.tot_norm %}{{ "%.1f"|format(ns.tot_norm) }}{% endif %}</strong></td>
                         <td class="td_right num"><strong>{% if ns.tot_ob1 %}{{ "%.1f"|format(ns.tot_ob1) }}{% endif %}</strong></td>
                         <td class="td_right num"><strong>{% if ns.tot_ob2 %}{{ "%.1f"|format(ns.tot_ob2) }}{% endif %}</strong></td>

--- a/app/templates/shift_swaps.html
+++ b/app/templates/shift_swaps.html
@@ -1,0 +1,115 @@
+{# app/templates/shift_swaps.html #}
+{% extends "base.html" %}
+
+{% block page_content %}
+<section>
+    <h2>Skiftbyten</h2>
+
+    {% if pending_count > 0 %}
+    <div class="card" style="border-color: var(--warning); margin-bottom: 1.5rem;">
+        <strong style="color: var(--warning);">{{ pending_count }} väntande förfrågan{{ 'gar' if pending_count > 1 }}</strong>
+    </div>
+    {% endif %}
+
+    <h3>Mottagna förfrågningar</h3>
+    {% if received_swaps %}
+    <table class="summary">
+        <thead>
+            <tr>
+                <th>Från</th>
+                <th>Ger dig</th>
+                <th>Vill ha</th>
+                <th>Meddelande</th>
+                <th>Status</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for swap in received_swaps %}
+            <tr class="shift-row">
+                <td data-label="Från">{{ swap.requester.name }}</td>
+                <td data-label="Ger dig">{{ swap.requester_shift_code or '?' }} ({{ swap.requester_date }})</td>
+                <td data-label="Vill ha">{{ swap.target_shift_code or '?' }} ({{ swap.target_date }})</td>
+                <td data-label="Meddelande">{{ swap.message or '-' }}</td>
+                <td data-label="Status">
+                    {% if swap.status.value == 'PENDING' %}
+                        <span class="badge" style="background: var(--warning); color: #000;">Väntande</span>
+                    {% elif swap.status.value == 'ACCEPTED' %}
+                        <span class="badge" style="background: var(--accent-2); color: #000;">Accepterat</span>
+                    {% elif swap.status.value == 'REJECTED' %}
+                        <span class="badge" style="background: var(--danger); color: #fff;">Avvisat</span>
+                    {% else %}
+                        <span class="badge badge-off">Avbrutet</span>
+                    {% endif %}
+                </td>
+                <td>
+                    {% if swap.status.value == 'PENDING' %}
+                        <form method="POST" action="/swaps/{{ swap.id }}/accept" style="display:inline;">
+                            <button type="submit" class="btn" style="font-size:0.8rem; padding:0.3rem 0.6rem;">Acceptera</button>
+                        </form>
+                        <form method="POST" action="/swaps/{{ swap.id }}/reject" style="display:inline; margin-left:0.25rem;">
+                            <button type="submit" class="btn btn-danger" style="font-size:0.8rem;">Avvisa</button>
+                        </form>
+                    {% elif swap.status.value == 'ACCEPTED' %}
+                        <form method="POST" action="/swaps/{{ swap.id }}/cancel" style="display:inline;">
+                            <button type="submit" class="btn btn-danger" style="font-size:0.8rem;"
+                                    onclick="return confirm('Ångra accepterat byte?')">Ångra</button>
+                        </form>
+                    {% endif %}
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+        <p class="info-text">Inga mottagna förfrågningar.</p>
+    {% endif %}
+
+    <h3 style="margin-top: 2rem;">Skickade förfrågningar</h3>
+    {% if sent_swaps %}
+    <table class="summary">
+        <thead>
+            <tr>
+                <th>Till</th>
+                <th>Du ger</th>
+                <th>Du får</th>
+                <th>Status</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for swap in sent_swaps %}
+            <tr class="shift-row">
+                <td data-label="Till">{{ swap.target.name }}</td>
+                <td data-label="Du ger">{{ swap.requester_shift_code or '?' }} ({{ swap.requester_date }})</td>
+                <td data-label="Du får">{{ swap.target_shift_code or '?' }} ({{ swap.target_date }})</td>
+                <td data-label="Status">
+                    {% if swap.status.value == 'PENDING' %}
+                        <span class="badge" style="background: var(--warning); color: #000;">Väntande</span>
+                    {% elif swap.status.value == 'ACCEPTED' %}
+                        <span class="badge" style="background: var(--accent-2); color: #000;">Accepterat</span>
+                    {% elif swap.status.value == 'REJECTED' %}
+                        <span class="badge" style="background: var(--danger); color: #fff;">Avvisat</span>
+                    {% else %}
+                        <span class="badge badge-off">Avbrutet</span>
+                    {% endif %}
+                </td>
+                <td>
+                    {% if swap.status.value in ('PENDING', 'ACCEPTED') %}
+                        <form method="POST" action="/swaps/{{ swap.id }}/cancel" style="display:inline;">
+                            <button type="submit" class="btn btn-danger" style="font-size:0.8rem;"
+                                    onclick="return confirm('{{ 'Ångra accepterat byte?' if swap.status.value == 'ACCEPTED' else 'Avbryta bytet?' }}')">
+                                {{ 'Ångra' if swap.status.value == 'ACCEPTED' else 'Avbryt' }}
+                            </button>
+                        </form>
+                    {% endif %}
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+        <p class="info-text">Inga skickade förfrågningar.</p>
+    {% endif %}
+</section>
+{% endblock %}

--- a/app/templates/statistics.html
+++ b/app/templates/statistics.html
@@ -1,0 +1,197 @@
+{# app/templates/statistics.html #}
+{% extends "base.html" %}
+
+{% block page_content %}
+<section>
+    <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 0.5rem;">
+        <h2>Statistik {{ year }} - {{ person_name }}</h2>
+        <div style="display: flex; gap: 0.5rem; align-items: center;">
+            <a href="/statistics/{{ person_id }}?year={{ year - 1 }}" class="btn btn-primary">&larr; {{ year - 1 }}</a>
+            <a href="/statistics/{{ person_id }}?year={{ year + 1 }}" class="btn btn-primary">{{ year + 1 }} &rarr;</a>
+            {% if all_persons %}
+            <select onchange="window.location.href='/statistics/' + this.value + '?year={{ year }}'" style="padding: 0.4rem; border-radius: 4px; background: var(--bg-card); color: var(--text); border: 1px solid var(--muted-bg);">
+                {% for p in all_persons %}
+                <option value="{{ p.id }}" {% if p.id == person_id %}selected{% endif %}>{{ p.name }}</option>
+                {% endfor %}
+            </select>
+            {% endif %}
+        </div>
+    </div>
+
+    {% if show_salary %}
+    <div style="display: grid; grid-template-columns: 1fr; gap: 1.5rem; margin-top: 1.5rem;">
+
+        {# Pay trend chart - full width #}
+        <div class="card">
+            <h3>Löneutveckling</h3>
+            <canvas id="payChart" style="min-height: 300px;"></canvas>
+        </div>
+
+        {# OB breakdown chart - full width #}
+        <div class="card">
+            <h3>OB-ersättning per månad</h3>
+            <canvas id="obChart" style="min-height: 300px;"></canvas>
+        </div>
+
+        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1.5rem;">
+            {# Absence doughnut #}
+            <div class="card">
+                <h3>Frånvaro</h3>
+                {% set total_absence = absence_data.sick + absence_data.vab + absence_data.leave + absence_data.off %}
+                {% if total_absence > 0 %}
+                <canvas id="absenceChart" style="min-height: 280px;"></canvas>
+                {% else %}
+                <p class="info-text">Ingen registrerad frånvaro {{ year }}.</p>
+                {% endif %}
+            </div>
+
+            {# Hours chart #}
+            <div class="card">
+                <h3>Arbetstimmar per månad</h3>
+                <canvas id="hoursChart" style="min-height: 280px;"></canvas>
+            </div>
+        </div>
+    </div>
+
+    {# Summary cards #}
+    <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 1rem; margin-top: 1.5rem;">
+        <div class="card" style="text-align: center;">
+            <div style="color: var(--muted); font-size: 0.85rem;">Total brutto</div>
+            <div style="font-size: 1.4rem; font-weight: bold;">{{ "{:,.0f}".format(year_summary.total_brutto or 0).replace(",", " ") }} kr</div>
+        </div>
+        <div class="card" style="text-align: center;">
+            <div style="color: var(--muted); font-size: 0.85rem;">Total netto</div>
+            <div style="font-size: 1.4rem; font-weight: bold;">{{ "{:,.0f}".format(year_summary.total_netto or 0).replace(",", " ") }} kr</div>
+        </div>
+        <div class="card" style="text-align: center;">
+            <div style="color: var(--muted); font-size: 0.85rem;">Total OB</div>
+            <div style="font-size: 1.4rem; font-weight: bold;">{{ "{:,.0f}".format(year_summary.total_ob or 0).replace(",", " ") }} kr</div>
+        </div>
+        <div class="card" style="text-align: center;">
+            <div style="color: var(--muted); font-size: 0.85rem;">Total beredskap</div>
+            <div style="font-size: 1.4rem; font-weight: bold;">{{ "{:,.0f}".format(year_summary.total_oncall or 0).replace(",", " ") }} kr</div>
+        </div>
+        <div class="card" style="text-align: center;">
+            <div style="color: var(--muted); font-size: 0.85rem;">Totala timmar</div>
+            <div style="font-size: 1.4rem; font-weight: bold;">{{ "{:,.0f}".format(year_summary.total_hours or 0).replace(",", " ") }}h</div>
+        </div>
+        <div class="card" style="text-align: center;">
+            <div style="color: var(--muted); font-size: 0.85rem;">Antal pass</div>
+            <div style="font-size: 1.4rem; font-weight: bold;">{{ year_summary.total_shifts or 0 }}</div>
+        </div>
+    </div>
+
+    {# Monthly detail table #}
+    <h3 style="margin-top: 2rem;">Månadsöversikt</h3>
+    <table class="summary">
+        <thead>
+            <tr>
+                <th>Månad</th>
+                <th class="th_right">Brutto</th>
+                <th class="th_right">Netto</th>
+                <th class="th_right">OB</th>
+                <th class="th_right">Beredskap</th>
+                <th class="th_right">OT</th>
+                <th class="th_right">Avdrag</th>
+                <th class="th_right">Timmar</th>
+                <th class="th_right">Pass</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for m in months %}
+            <tr class="shift-row">
+                <td data-label="Månad">{{ m.get('payment_year', m.year) }}-{{ "%02d"|format(m.get('payment_month', m.month)) }}</td>
+                <td data-label="Brutto" class="td_right num">{{ "{:,.0f}".format(m.brutto_pay or 0).replace(",", " ") }}</td>
+                <td data-label="Netto" class="td_right num">{{ "{:,.0f}".format(m.netto_pay or 0).replace(",", " ") }}</td>
+                <td data-label="OB" class="td_right num">{{ "{:,.0f}".format(m.total_ob or 0).replace(",", " ") }}</td>
+                <td data-label="Beredskap" class="td_right num">{{ "{:,.0f}".format(m.oncall_pay or 0).replace(",", " ") }}</td>
+                <td data-label="OT" class="td_right num">{{ "{:,.0f}".format(m.ot_pay or 0).replace(",", " ") }}</td>
+                <td data-label="Avdrag" class="td_right num">{{ "{:,.0f}".format(m.absence_deduction or 0).replace(",", " ") }}</td>
+                <td data-label="Timmar" class="td_right num">{{ "%.1f"|format(m.total_hours or 0) }}</td>
+                <td data-label="Pass" class="td_right num">{{ m.num_shifts or 0 }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+        <tfoot>
+            <tr>
+                <td><strong>Total</strong></td>
+                <td class="td_right num"><strong>{{ "{:,.0f}".format(year_summary.total_brutto or 0).replace(",", " ") }}</strong></td>
+                <td class="td_right num"><strong>{{ "{:,.0f}".format(year_summary.total_netto or 0).replace(",", " ") }}</strong></td>
+                <td class="td_right num"><strong>{{ "{:,.0f}".format(year_summary.total_ob or 0).replace(",", " ") }}</strong></td>
+                <td class="td_right num"><strong>{{ "{:,.0f}".format(year_summary.total_oncall or 0).replace(",", " ") }}</strong></td>
+                <td class="td_right num"><strong>{{ "{:,.0f}".format(year_summary.total_ot or 0).replace(",", " ") }}</strong></td>
+                <td class="td_right num"><strong>{{ "{:,.0f}".format(year_summary.total_absence_deduction or 0).replace(",", " ") }}</strong></td>
+                <td class="td_right num"><strong>{{ "%.1f"|format(year_summary.total_hours or 0) }}</strong></td>
+                <td class="td_right num"><strong>{{ year_summary.total_shifts or 0 }}</strong></td>
+            </tr>
+        </tfoot>
+    </table>
+
+    {% else %}
+    <p class="info-text" style="margin-top: 2rem;">Lönedata visas bara för din egen statistik.</p>
+    {% endif %}
+</section>
+
+{% if show_salary %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
+<script>
+    Chart.defaults.color = '#9aa5b1';
+    const gridColor = 'rgba(154, 165, 177, 0.15)';
+    const labels = {{ chart_labels | tojson }};
+
+    // 1. Pay trend (line)
+    new Chart(document.getElementById('payChart'), {
+        type: 'line',
+        data: {
+            labels: labels,
+            datasets: [
+                { label: 'Brutto', data: {{ chart_brutto | tojson }}, borderColor: '#40a9ff', backgroundColor: 'rgba(64,169,255,0.1)', fill: true, tension: 0.3 },
+                { label: 'Netto', data: {{ chart_netto | tojson }}, borderColor: '#7bd389', backgroundColor: 'rgba(123,211,137,0.1)', fill: true, tension: 0.3 }
+            ]
+        },
+        options: { responsive: true, scales: { x: { grid: { color: gridColor } }, y: { grid: { color: gridColor }, ticks: { callback: v => v.toLocaleString('sv-SE') + ' kr' } } }, plugins: { tooltip: { callbacks: { label: ctx => ctx.dataset.label + ': ' + ctx.parsed.y.toLocaleString('sv-SE') + ' kr' } } } }
+    });
+
+    // 2. OB stacked bar
+    const obData = {{ chart_ob | tojson }};
+    const obColors = { OB1: '#40a9ff', OB2: '#7bd389', OB3: '#ffa500', OB4: '#ef4444', OB5: '#a855f7' };
+    const obLabels = {{ ob_labels | tojson }};
+    new Chart(document.getElementById('obChart'), {
+        type: 'bar',
+        data: {
+            labels: labels,
+            datasets: Object.keys(obData).map(code => ({
+                label: obLabels[code] || code,
+                data: obData[code],
+                backgroundColor: obColors[code] || '#9aa5b1',
+                borderRadius: 2
+            }))
+        },
+        options: { responsive: true, scales: { x: { stacked: true, grid: { color: gridColor } }, y: { stacked: true, grid: { color: gridColor }, ticks: { callback: v => v.toLocaleString('sv-SE') + ' kr' } } }, plugins: { tooltip: { callbacks: { label: ctx => ctx.dataset.label + ': ' + ctx.parsed.y.toLocaleString('sv-SE') + ' kr' } } } }
+    });
+
+    // 3. Absence doughnut
+    const absenceData = {{ absence_data | tojson }};
+    if (absenceData.sick + absenceData.vab + absenceData.leave + absenceData.off > 0) {
+        new Chart(document.getElementById('absenceChart'), {
+            type: 'doughnut',
+            data: {
+                labels: ['Sjuk', 'VAB', 'Ledigt', 'Ledig'],
+                datasets: [{ data: [absenceData.sick, absenceData.vab, absenceData.leave, absenceData.off], backgroundColor: ['#ef4444', '#ffa500', '#a855f7', '#9aa5b1'], borderWidth: 0 }]
+            },
+            options: { responsive: true, plugins: { legend: { position: 'bottom' }, tooltip: { callbacks: { label: ctx => ctx.label + ': ' + ctx.parsed + ' dagar' } } } }
+        });
+    }
+
+    // 4. Hours bar
+    new Chart(document.getElementById('hoursChart'), {
+        type: 'bar',
+        data: {
+            labels: labels,
+            datasets: [{ label: 'Timmar', data: {{ chart_hours | tojson }}, backgroundColor: 'rgba(64,169,255,0.6)', borderRadius: 3 }]
+        },
+        options: { responsive: true, scales: { x: { grid: { color: gridColor } }, y: { grid: { color: gridColor } } }, plugins: { tooltip: { callbacks: { label: ctx => ctx.parsed.y + 'h' } } } }
+    });
+</script>
+{% endif %}
+{% endblock %}

--- a/app/templates/year.html
+++ b/app/templates/year.html
@@ -10,6 +10,7 @@
         <a href="/year/{{ person_id }}?year={{ year - 1 }}" class="btn btn-primary">Previous year</a>
         <a href="/year/{{ person_id }}" class="btn btn-primary">Today</a>
         <a href="/year/{{ person_id }}?year={{ year + 1 }}" class="btn btn-primary">Next year</a>
+        <a href="/statistics/{{ person_id }}?year={{ year }}" class="btn secondary">Statistik</a>
     </div>
 
     <div class="page-header-right">

--- a/migrate_shift_swaps.py
+++ b/migrate_shift_swaps.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Migration script to create shift_swaps table."""
+
+import sqlite3
+import sys
+from pathlib import Path
+
+
+def migrate(db_path: str = "app/database/schedule.db"):
+    """Create shift_swaps table."""
+    path = Path(db_path)
+    if not path.exists():
+        print(f"Error: Database not found at {path}")
+        sys.exit(1)
+
+    conn = sqlite3.connect(path)
+    cursor = conn.cursor()
+
+    try:
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='shift_swaps'")
+        if cursor.fetchone():
+            print("Table 'shift_swaps' already exists. Skipping.")
+            return
+
+        print("Creating shift_swaps table...")
+        cursor.execute("""
+            CREATE TABLE shift_swaps (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                requester_id INTEGER NOT NULL REFERENCES users(id),
+                target_id INTEGER NOT NULL REFERENCES users(id),
+                requester_date DATE NOT NULL,
+                target_date DATE NOT NULL,
+                requester_shift_code VARCHAR(10),
+                target_shift_code VARCHAR(10),
+                status VARCHAR(10) NOT NULL DEFAULT 'PENDING',
+                message VARCHAR(255),
+                responded_at DATETIME,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+
+        cursor.execute("CREATE INDEX idx_shift_swaps_requester ON shift_swaps(requester_id, status)")
+        cursor.execute("CREATE INDEX idx_shift_swaps_target ON shift_swaps(target_id, status)")
+        cursor.execute("CREATE INDEX idx_shift_swaps_req_date ON shift_swaps(requester_date)")
+        cursor.execute("CREATE INDEX idx_shift_swaps_tgt_date ON shift_swaps(target_date)")
+
+        conn.commit()
+        print("Successfully created shift_swaps table with indexes.")
+
+    except sqlite3.Error as e:
+        print(f"Error during migration: {e}")
+        conn.rollback()
+        sys.exit(1)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("Migration: Create shift_swaps table")
+    print("=" * 60)
+    migrate()
+    print("\nMigration completed successfully!")


### PR DESCRIPTION
## Summary
- **Global error handling**: Themed error pages (404, 500, etc.) with JSON fallback for API clients
- **Shift swap system**: Propose, accept, reject, and cancel shift swaps between colleagues with schedule integration, 11h rest rule, OC-to-OC filtering, and OB hours display
- **Statistics page**: Chart.js visualizations (pay trend, OB breakdown, absence doughnut, hours) with summary cards and monthly detail table, accessible from year view

## Test plan
- [ ] Visit `/nonexistent` → themed 404 page. API request → JSON error
- [ ] Propose a shift swap from day view → verify colleague filtering (OFF only, no admin, 11h rule)
- [ ] Accept swap → verify schedule shows swapped shifts in week/day views
- [ ] Cancel accepted swap → schedule reverts
- [ ] OC-to-OC swap: from OC day, only OC colleagues shown, only their OC shifts listed
- [ ] Statistics page from year view → 4 charts render with correct data
- [ ] Year navigation and admin person selector work on statistics page
- [ ] Run `migrate_shift_swaps.py` on prod before deploying