### PR TITLE
Add per-user custom rates with temporal history

### DIFF
--- a/app/core/rates.py
+++ b/app/core/rates.py
@@ -1,0 +1,212 @@
+"""Per-user rate resolution with fallback to system defaults.
+
+Supports temporal queries (like wages) — rates can change over time.
+User.custom_rates = current rates (fast access).
+RateHistory = full audit trail with effective_from/effective_to.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+from app.core.constants import OT_RATE_DIVISOR
+
+# --- System defaults ---
+DEFAULT_OB_DIVISORS: dict[str, int] = {
+    "OB1": 600,
+    "OB2": 400,
+    "OB3": 300,
+    "OB4": 300,
+    "OB5": 150,
+}
+
+DEFAULT_ONCALL_RATES: dict[str, int] = {
+    "OC_WEEKDAY": 75,
+    "OC_WEEKEND": 97,
+    "OC_WEEKEND_SAT": 97,
+    "OC_WEEKEND_SUN": 97,
+    "OC_WEEKEND_MON": 97,
+    "OC_HOLIDAY_EVE": 97,
+    "OC_HOLIDAY": 112,
+    "OC_SPECIAL": 192,
+}
+
+DEFAULT_VACATION_RATES: dict[str, float] = {
+    "fixed_pct": 0.008,
+    "variable_pct": 0.005,
+    "payout_pct": 0.046,
+}
+
+DEFAULT_OT_DIVISOR: int = OT_RATE_DIVISOR  # 72
+
+
+def _resolve_rates(custom: dict) -> dict:
+    """Convert a raw custom_rates JSON dict into resolved rates."""
+    return {
+        "ob": custom.get("ob") or {},
+        "ot": custom.get("ot"),
+        "oncall": {**DEFAULT_ONCALL_RATES, **(custom.get("oncall") or {})},
+        "vacation": {**DEFAULT_VACATION_RATES, **(custom.get("vacation") or {})},
+    }
+
+
+def get_user_rates(user, session=None, effective_date: datetime.date | None = None) -> dict:
+    """Resolve a user's effective rates, optionally for a specific date.
+
+    Args:
+        user: User model instance
+        session: SQLAlchemy session (needed for temporal queries)
+        effective_date: Date to query rates for. None = current rates from User.custom_rates.
+
+    Returns:
+        {"ob": {}, "ot": None, "oncall": {...}, "vacation": {...}}
+    """
+    if effective_date is not None and session is not None:
+        from app.database.database import RateHistory
+
+        record = (
+            session.query(RateHistory)
+            .filter(
+                RateHistory.user_id == user.id,
+                RateHistory.effective_from <= effective_date,
+                (RateHistory.effective_to.is_(None)) | (RateHistory.effective_to > effective_date),
+            )
+            .order_by(RateHistory.effective_from.desc())
+            .first()
+        )
+
+        if record:
+            return _resolve_rates(record.rates or {})
+
+    # Fallback: current rates from User model
+    custom = getattr(user, "custom_rates", None) or {}
+    return _resolve_rates(custom)
+
+
+def add_new_rates(session, user_id: int, rates: dict, effective_from: datetime.date, created_by: int | None = None):
+    """Add new rate entry, closing previous one. Mirrors add_new_wage() pattern."""
+    from sqlalchemy.orm.attributes import flag_modified
+
+    from app.core.utils import get_today
+    from app.database.database import RateHistory, User
+
+    # Seed: if no RateHistory exists yet but user has custom_rates, create initial entry
+    has_any = session.query(RateHistory).filter(RateHistory.user_id == user_id).count()
+    if not has_any:
+        user = session.query(User).filter(User.id == user_id).first()
+        existing = getattr(user, "custom_rates", None) or {}
+        if existing:
+            seed_from = getattr(user, "employment_start_date", None) or datetime.date(2020, 1, 1)
+            seed = RateHistory(
+                user_id=user_id,
+                rates=existing,
+                effective_from=seed_from,
+                effective_to=None,
+                created_by=created_by,
+            )
+            session.add(seed)
+            session.flush()
+
+    # Close previous rate history
+    previous = (
+        session.query(RateHistory).filter(RateHistory.user_id == user_id, RateHistory.effective_to.is_(None)).first()
+    )
+    if previous:
+        previous.effective_to = effective_from - datetime.timedelta(days=1)
+
+    # Create new entry
+    new_record = RateHistory(
+        user_id=user_id,
+        rates=rates,
+        effective_from=effective_from,
+        effective_to=None,
+        created_by=created_by,
+    )
+    session.add(new_record)
+
+    # Update User.custom_rates if effective_from <= today
+    if effective_from <= get_today():
+        user = session.query(User).filter(User.id == user_id).first()
+        if user:
+            user.custom_rates = rates
+            flag_modified(user, "custom_rates")
+
+    session.commit()
+    return new_record
+
+
+def get_rate_history(session, user_id: int) -> list[dict]:
+    """Get all rate history for a user, newest first."""
+    from app.database.database import RateHistory
+
+    records = (
+        session.query(RateHistory)
+        .filter(RateHistory.user_id == user_id)
+        .order_by(RateHistory.effective_from.desc())
+        .all()
+    )
+
+    from app.core.utils import get_today
+
+    today = get_today()
+
+    return [
+        {
+            "id": r.id,
+            "rates": r.rates or {},
+            "effective_from": r.effective_from,
+            "effective_to": r.effective_to,
+            "status": "future"
+            if r.effective_from > today
+            else ("current" if r.effective_to is None or r.effective_to >= today else "historical"),
+            "created_at": r.created_at,
+        }
+        for r in records
+    ]
+
+
+def delete_rate_history(session, rate_id: int, user_id: int):
+    """Delete a rate history record. Reopen previous if it was closed by this one."""
+    from app.database.database import RateHistory
+
+    record = session.query(RateHistory).filter(RateHistory.id == rate_id, RateHistory.user_id == user_id).first()
+    if not record:
+        return
+
+    deleted_from = record.effective_from
+    session.delete(record)
+    session.flush()
+
+    # Reopen the record whose effective_to was set because of the deleted entry
+    prev = (
+        session.query(RateHistory)
+        .filter(
+            RateHistory.user_id == user_id,
+            RateHistory.effective_to == deleted_from - datetime.timedelta(days=1),
+        )
+        .first()
+    )
+    if prev:
+        # Check if there's still a later record — if so, don't reopen
+        later = (
+            session.query(RateHistory)
+            .filter(
+                RateHistory.user_id == user_id,
+                RateHistory.effective_from > prev.effective_from,
+            )
+            .first()
+        )
+        if not later:
+            prev.effective_to = None
+
+    session.commit()
+
+
+def get_all_defaults() -> dict:
+    """Return all default rates for display in UI."""
+    return {
+        "ob_divisors": dict(DEFAULT_OB_DIVISORS),
+        "ot_divisor": DEFAULT_OT_DIVISOR,
+        "oncall": dict(DEFAULT_ONCALL_RATES),
+        "vacation": dict(DEFAULT_VACATION_RATES),
+    }

--- a/app/core/schedule/overtime.py
+++ b/app/core/schedule/overtime.py
@@ -5,19 +5,20 @@ import datetime
 from app.core.constants import OT_RATE_DIVISOR
 
 
-def calculate_overtime_pay(monthly_salary: int, hours: float) -> float:
+def calculate_overtime_pay(monthly_salary: int, hours: float, ot_hourly_rate: float | None = None) -> float:
     """
     Beräknar övertidsersättning.
-
-    Formel: (månadslön / 72) * timmar
 
     Args:
         monthly_salary: Månadslön i SEK
         hours: Antal övertidstimmar
+        ot_hourly_rate: Per-user fixed kr/tim. If None, uses salary / 72.
 
     Returns:
         Övertidsersättning i SEK
     """
+    if ot_hourly_rate is not None:
+        return ot_hourly_rate * hours
     return (monthly_salary / OT_RATE_DIVISOR) * hours
 
 

--- a/app/routes/auth_routes.py
+++ b/app/routes/auth_routes.py
@@ -283,6 +283,8 @@ async def profile_page(request: Request, current_user: User = Depends(get_curren
     # Get wage history for current user
     wage_history = get_wage_history(db, current_user.id)
 
+    from app.core.rates import get_all_defaults, get_rate_history
+
     return templates.TemplateResponse(
         "profile.html",
         {
@@ -290,6 +292,9 @@ async def profile_page(request: Request, current_user: User = Depends(get_curren
             "user": current_user,
             "available_tax_tables": available_tax_tables,
             "wage_history": wage_history,
+            "rate_defaults": get_all_defaults(),
+            "custom_rates": current_user.custom_rates or {},
+            "rate_history": get_rate_history(db, current_user.id),
         },
     )
 
@@ -327,6 +332,39 @@ async def update_profile(
         db.rollback()
         raise
 
+    clear_schedule_cache()
+
+    return RedirectResponse(url="/profile", status_code=302)
+
+
+@router.post("/profile/rates", name="profile_update_rates")
+async def profile_update_rates(
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """User: add new rate entry with effective date."""
+    from app.core.rates import add_new_rates
+
+    form = await request.form()
+    rates = _parse_rates_form(form)
+    effective_from = form.get("effective_from", "").strip()
+
+    if not effective_from:
+        raise HTTPException(status_code=400, detail="Från-datum krävs")
+
+    try:
+        effective_date = datetime.datetime.strptime(effective_from, "%Y-%m-%d").date()
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=f"Ogiltigt datum: {e}") from e
+
+    add_new_rates(
+        session=db,
+        user_id=current_user.id,
+        rates=rates,
+        effective_from=effective_date,
+        created_by=current_user.id,
+    )
     clear_schedule_cache()
 
     return RedirectResponse(url="/profile", status_code=302)
@@ -459,6 +497,21 @@ async def profile_delete_wage(
     db.commit()
 
     # Clear schedule cache
+    clear_schedule_cache()
+
+    return RedirectResponse(url="/profile", status_code=302)
+
+
+@router.post("/profile/delete-rate/{rate_id}", name="profile_delete_rate")
+async def profile_delete_rate(
+    rate_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """User: delete a rate history entry (only their own)."""
+    from app.core.rates import delete_rate_history
+
+    delete_rate_history(db, rate_id, current_user.id)
     clear_schedule_cache()
 
     return RedirectResponse(url="/profile", status_code=302)
@@ -914,6 +967,8 @@ async def admin_edit_user_page(
     # Get vacation balance
     vacation_balance = calculate_vacation_balance(edit_user, get_today().year, db)
 
+    from app.core.rates import get_all_defaults, get_rate_history
+
     return templates.TemplateResponse(
         "admin_user_edit.html",
         {
@@ -924,6 +979,9 @@ async def admin_edit_user_page(
             "wage_history": wage_history,
             "person_history": person_history,
             "vacation_balance": vacation_balance,
+            "rate_defaults": get_all_defaults(),
+            "custom_rates": edit_user.custom_rates or {},
+            "rate_history": get_rate_history(db, edit_user.id),
         },
     )
 
@@ -973,6 +1031,90 @@ async def admin_update_user(
         raise
 
     return RedirectResponse(url="/admin/users", status_code=302)
+
+
+def _parse_rates_form(form) -> dict:
+    """Parse rate form fields into custom_rates dict."""
+    from app.core.rates import DEFAULT_OB_DIVISORS, DEFAULT_VACATION_RATES
+
+    custom = {}
+
+    # OB rates (kr/tim, fixed)
+    ob = {}
+    for code in DEFAULT_OB_DIVISORS:
+        val = form.get(f"rate_ob_{code}", "").strip()
+        if val:
+            ob[code] = float(val)
+    if ob:
+        custom["ob"] = ob
+
+    # OT rate (kr/tim, fixed)
+    ot_val = form.get("rate_ot", "").strip()
+    if ot_val:
+        custom["ot"] = float(ot_val)
+
+    # On-call rates (fixed SEK/hr) — UI shows 4 groups, fan out weekend to sub-codes
+    oncall = {}
+    for code in ["OC_WEEKDAY", "OC_WEEKEND", "OC_HOLIDAY", "OC_SPECIAL"]:
+        val = form.get(f"rate_oc_{code}", "").strip()
+        if val:
+            rate = float(val)
+            if code == "OC_WEEKEND":
+                for sub in ["OC_WEEKEND", "OC_WEEKEND_SAT", "OC_WEEKEND_SUN", "OC_WEEKEND_MON", "OC_HOLIDAY_EVE"]:
+                    oncall[sub] = rate
+            else:
+                oncall[code] = rate
+    if oncall:
+        custom["oncall"] = oncall
+
+    # Vacation percentages
+    vac = {}
+    for key in DEFAULT_VACATION_RATES:
+        val = form.get(f"rate_vac_{key}", "").strip()
+        if val:
+            vac[key] = float(val)
+    if vac:
+        custom["vacation"] = vac
+
+    return custom
+
+
+@router.post("/admin/users/{user_id}/update-rates", name="admin_update_rates")
+async def admin_update_rates(
+    request: Request,
+    user_id: int,
+    current_user: User = Depends(get_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Admin: add new rate entry with effective date for a user."""
+    from app.core.rates import add_new_rates
+
+    edit_user = db.query(User).filter(User.id == user_id).first()
+    if not edit_user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    form = await request.form()
+    rates = _parse_rates_form(form)
+    effective_from = form.get("effective_from", "").strip()
+
+    if not effective_from:
+        raise HTTPException(status_code=400, detail="Från-datum krävs")
+
+    try:
+        effective_date = datetime.datetime.strptime(effective_from, "%Y-%m-%d").date()
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=f"Ogiltigt datum: {e}") from e
+
+    add_new_rates(
+        session=db,
+        user_id=user_id,
+        rates=rates,
+        effective_from=effective_date,
+        created_by=current_user.id,
+    )
+    clear_schedule_cache()
+
+    return RedirectResponse(url=f"/admin/users/{user_id}", status_code=302)
 
 
 @router.post("/admin/users/{user_id}/add-wage", name="admin_add_wage")
@@ -1074,6 +1216,22 @@ async def admin_delete_wage(
     db.commit()
 
     # Clear schedule cache
+    clear_schedule_cache()
+
+    return RedirectResponse(url=f"/admin/users/{user_id}", status_code=302)
+
+
+@router.post("/admin/users/{user_id}/delete-rate/{rate_id}", name="admin_delete_rate")
+async def admin_delete_rate(
+    user_id: int,
+    rate_id: int,
+    current_user: User = Depends(get_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Admin: delete a rate history entry for a user."""
+    from app.core.rates import delete_rate_history
+
+    delete_rate_history(db, rate_id, user_id)
     clear_schedule_cache()
 
     return RedirectResponse(url=f"/admin/users/{user_id}", status_code=302)

--- a/app/templates/admin_user_edit.html
+++ b/app/templates/admin_user_edit.html
@@ -335,6 +335,11 @@
             Hantera semester
         </a>
     </div>
+
+    <!-- Ersättningssatser -->
+    {% set rates_form_action = "/admin/users/" ~ edit_user.id ~ "/update-rates" %}
+    {% set rates_delete_prefix = "/admin/users/" ~ edit_user.id ~ "/delete-rate/" %}
+    {% include "rates_form.html" with context %}
 </div>
 
 {% endblock %}

--- a/app/templates/day.html
+++ b/app/templates/day.html
@@ -120,7 +120,7 @@
                                 <td>{{ ot_shift.start_time }}</td>
                                 <td>{{ ot_shift.end_time }}</td>
                                 <td>{{ "%.2f"|format(ot_shift.hours) }}</td>
-                                <td>{{ "%.2f"|format(monthly_salary / 72) }} kr/h</td>
+                                <td>{{ "%.2f"|format(ot_shift.hourly_rate) }} kr/h</td>
                                 <td>{{ "%.2f"|format(ot_shift.pay) }} kr</td>
                                 <td>
                                     <form method="POST" action="/overtime/{{ ot_shift_id }}/delete" style="display: inline;">

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -194,4 +194,10 @@
             📅 Exportera schema till kalender på engelska
         </a>
     </section>
+
+    <!-- Ersättningssatser -->
+    {% set rates_form_action = "/profile/rates" %}
+    {% set rates_delete_prefix = "/profile/delete-rate/" %}
+    {% include "rates_form.html" with context %}
+
 {% endblock %}

--- a/app/templates/rates_form.html
+++ b/app/templates/rates_form.html
@@ -1,0 +1,146 @@
+{# Shared rates form — used by admin_user_edit.html and profile.html #}
+{# Expects: rate_defaults, custom_rates, rates_form_action, rates_delete_prefix, rate_history #}
+
+<!-- Rate History -->
+{% if rate_history %}
+<div class="card" style="margin-top: 16px;">
+    <h3 style="margin-top: 0;">Ers&auml;ttningshistorik</h3>
+
+    <table style="width: 100%; border-collapse: collapse;">
+        <thead>
+            <tr style="border-bottom: 1px solid var(--border);">
+                <th style="text-align: left; padding: 8px; color: var(--muted); font-weight: 500;">Fr&aring;n datum</th>
+                <th style="text-align: left; padding: 8px; color: var(--muted); font-weight: 500;">Till datum</th>
+                <th style="text-align: left; padding: 8px; color: var(--muted); font-weight: 500;">&Ouml;versikt</th>
+                <th style="text-align: left; padding: 8px; color: var(--muted); font-weight: 500;">Status</th>
+                <th style="text-align: left; padding: 8px; color: var(--muted); font-weight: 500;">&Aring;tg&auml;rd</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for record in rate_history %}
+            <tr style="border-bottom: 1px solid var(--border);">
+                <td style="padding: 8px;">{{ record.effective_from }}</td>
+                <td style="padding: 8px;">
+                    {% if record.effective_to %}
+                        {{ record.effective_to }}
+                    {% else %}
+                        <span style="color: var(--muted); font-style: italic;">p&aring;g&aring;ende</span>
+                    {% endif %}
+                </td>
+                <td style="padding: 8px; font-size: 0.8rem;">
+                    {% set r = record.rates %}
+                    {% set parts = [] %}
+                    {% if r.get('ob') %}{% set _ = parts.append('OB: ' ~ r.ob.keys()|list|join(', ')) %}{% endif %}
+                    {% if r.get('ot') %}{% set _ = parts.append('&Ouml;T: ' ~ r.ot ~ ' kr/tim') %}{% endif %}
+                    {% if r.get('oncall') %}{% set _ = parts.append('Beredskap') %}{% endif %}
+                    {% if r.get('vacation') %}{% set _ = parts.append('Semester') %}{% endif %}
+                    {% if parts %}
+                        {{ parts|join(' &middot; ') }}
+                    {% else %}
+                        <span style="color: var(--muted);">Standardsatser</span>
+                    {% endif %}
+                </td>
+                <td style="padding: 8px;">
+                    {% if record.status == 'current' %}
+                        <span style="color: var(--success); font-weight: 500;">&check; Aktuell</span>
+                    {% elif record.status == 'future' %}
+                        <span style="color: var(--warning); font-weight: 500;">Kommande</span>
+                    {% else %}
+                        <span style="color: var(--muted);">Historisk</span>
+                    {% endif %}
+                </td>
+                <td style="padding: 8px;">
+                    {% if rate_history | length > 1 %}
+                        <form method="POST" action="{{ rates_delete_prefix }}{{ record.id }}" style="display: inline;" onsubmit="return confirm('&Auml;r du s&auml;ker p&aring; att du vill ta bort denna ers&auml;ttningspost?');">
+                            <button type="submit" class="btn danger" style="padding: 4px 8px; font-size: 0.875rem;">Ta bort</button>
+                        </form>
+                    {% else %}
+                        <span style="color: var(--muted); font-size: 0.875rem;">&mdash;</span>
+                    {% endif %}
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endif %}
+
+<!-- Add New Rates -->
+<div class="card" style="margin-top: 16px;">
+    <h3 style="margin-top: 0;">{% if rate_history %}L&auml;gg till nya ers&auml;ttningssatser{% else %}Ers&auml;ttningssatser{% endif %}</h3>
+    <p style="color: var(--muted); font-size: 0.85rem; margin-bottom: 16px;">
+        Individuella avvikelser fr&aring;n standardsatser. L&auml;mna tomt f&ouml;r att anv&auml;nda standard (l&ouml;nebaserad ber&auml;kning).
+        {% if rate_history %}Tidigare satser avslutas automatiskt dagen innan nytt fr&aring;n-datum.{% endif %}
+    </p>
+
+    <form method="POST" action="{{ rates_form_action }}">
+
+        <!-- Från datum -->
+        <div style="margin-bottom: 16px;">
+            <label for="effective_from_rates" style="display: block; margin-bottom: 6px; color: var(--muted);">Fr&aring;n datum</label>
+            <input type="date" id="effective_from_rates" name="effective_from" required
+                   style="width: 200px; box-sizing: border-box;">
+        </div>
+
+        <!-- OB-tillägg (kr/tim) -->
+        <h4 style="margin-bottom: 8px; margin-top: 0;">OB-till&auml;gg <span style="color: var(--muted); font-weight: 400; font-size: 0.8rem;">(kr/tim)</span></h4>
+        <p style="color: var(--muted); font-size: 0.8rem; margin-top: -4px; margin-bottom: 8px;">
+            Standard: l&ouml;n / divisor. Fyll i f&ouml;r fast kr/tim ist&auml;llet.
+        </p>
+        <div style="display: grid; grid-template-columns: repeat(5, 1fr); gap: 8px; margin-bottom: 16px;">
+            {% for code, divisor in rate_defaults.ob_divisors.items() %}
+            <div>
+                <label style="display: block; font-size: 0.75rem; color: var(--muted); margin-bottom: 2px;">{{ code }} <span style="font-size: 0.7rem;">(std: l&ouml;n/{{ divisor }})</span></label>
+                <input type="number" step="0.01" name="rate_ob_{{ code }}" min="0"
+                       value="{{ custom_rates.get('ob', {}).get(code, '') }}"
+                       placeholder="kr/tim"
+                       class="input" style="width: 100%; box-sizing: border-box;">
+            </div>
+            {% endfor %}
+        </div>
+
+        <!-- Övertid (kr/tim) -->
+        <h4 style="margin-bottom: 8px;">&Ouml;vertid <span style="color: var(--muted); font-weight: 400; font-size: 0.8rem;">(kr/tim)</span></h4>
+        <p style="color: var(--muted); font-size: 0.8rem; margin-top: -4px; margin-bottom: 8px;">
+            Standard: l&ouml;n / {{ rate_defaults.ot_divisor }}. Fyll i f&ouml;r fast kr/tim ist&auml;llet.
+        </p>
+        <div style="margin-bottom: 16px;">
+            <input type="number" step="0.01" name="rate_ot" min="0"
+                   value="{{ custom_rates.get('ot', '') }}"
+                   placeholder="kr/tim"
+                   class="input" style="width: 200px;">
+        </div>
+
+        <!-- Beredskap (kr/tim) -->
+        <h4 style="margin-bottom: 8px;">Beredskap <span style="color: var(--muted); font-weight: 400; font-size: 0.8rem;">(kr/tim)</span></h4>
+        <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; margin-bottom: 16px;">
+            {% set oc_groups = [("OC_WEEKDAY", "Vardag", 75), ("OC_WEEKEND", "Helg", 97), ("OC_HOLIDAY", "R\u00f6d dag", 112), ("OC_SPECIAL", "Storhelg", 192)] %}
+            {% for code, label, default in oc_groups %}
+            <div>
+                <label style="display: block; font-size: 0.75rem; color: var(--muted); margin-bottom: 2px;">{{ label }} (std: {{ default }} kr)</label>
+                <input type="number" step="0.01" name="rate_oc_{{ code }}" min="0"
+                       value="{{ custom_rates.get('oncall', {}).get(code, '') }}"
+                       placeholder="{{ default }}"
+                       class="input" style="width: 100%; box-sizing: border-box;">
+            </div>
+            {% endfor %}
+        </div>
+
+        <!-- Semester -->
+        <h4 style="margin-bottom: 8px;">Semesterers&auml;ttning <span style="color: var(--muted); font-weight: 400; font-size: 0.8rem;">(decimalform, t.ex. 0.008 = 0.8%)</span></h4>
+        <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; margin-bottom: 16px;">
+            {% set vac_fields = [("fixed_pct", "Fast del", 0.008, "0.8%"), ("variable_pct", "R\u00f6rlig del", 0.005, "0.5%"), ("payout_pct", "Utbetalning", 0.046, "4.6%")] %}
+            {% for key, label, default, pct in vac_fields %}
+            <div>
+                <label style="display: block; font-size: 0.75rem; color: var(--muted); margin-bottom: 2px;">{{ label }} (std: {{ pct }})</label>
+                <input type="number" step="0.001" name="rate_vac_{{ key }}" min="0" max="1"
+                       value="{{ custom_rates.get('vacation', {}).get(key, '') }}"
+                       placeholder="{{ default }}"
+                       class="input" style="width: 100%; box-sizing: border-box;">
+            </div>
+            {% endfor %}
+        </div>
+
+        <button type="submit" class="btn">Spara satser</button>
+    </form>
+</div>

--- a/migrate_custom_rates.py
+++ b/migrate_custom_rates.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Migration: Add custom_rates column + rate_history table.
+
+1. users.custom_rates - JSON for current rate overrides (quick access)
+2. rate_history - temporal rate tracking (like wage_history)
+"""
+
+import sqlite3
+import sys
+from pathlib import Path
+
+
+def migrate(db_path: str = "app/database/schedule.db"):
+    path = Path(db_path)
+    if not path.exists():
+        print(f"Error: Database not found at {path}")
+        sys.exit(1)
+
+    conn = sqlite3.connect(path)
+    cursor = conn.cursor()
+
+    try:
+        # 1. Add custom_rates column to users
+        cursor.execute("PRAGMA table_info(users)")
+        columns = [row[1] for row in cursor.fetchall()]
+
+        if "custom_rates" not in columns:
+            print("Adding custom_rates column to users...")
+            cursor.execute("ALTER TABLE users ADD COLUMN custom_rates TEXT DEFAULT '{}'")
+            print("  Done.")
+        else:
+            print("Column 'custom_rates' already exists.")
+
+        # 2. Create rate_history table
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='rate_history'")
+        if cursor.fetchone() is None:
+            print("Creating rate_history table...")
+            cursor.execute("""
+                CREATE TABLE rate_history (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id INTEGER NOT NULL REFERENCES users(id),
+                    rates TEXT NOT NULL DEFAULT '{}',
+                    effective_from DATE NOT NULL,
+                    effective_to DATE,
+                    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                    created_by INTEGER REFERENCES users(id)
+                )
+            """)
+            cursor.execute("CREATE INDEX ix_rate_history_user_id ON rate_history(user_id)")
+            cursor.execute("CREATE INDEX ix_rate_history_effective ON rate_history(user_id, effective_from)")
+            print("  Done.")
+        else:
+            print("Table 'rate_history' already exists.")
+
+        conn.commit()
+
+        # Show current state
+        cursor.execute("SELECT id, username, custom_rates FROM users")
+        print("\nUsers:")
+        for row in cursor.fetchall():
+            print(f"  id={row[0]}, username={row[1]}, custom_rates={row[2]}")
+
+        cursor.execute("SELECT COUNT(*) FROM rate_history")
+        print(f"Rate history records: {cursor.fetchone()[0]}")
+
+    except sqlite3.Error as e:
+        print(f"Error: {e}")
+        conn.rollback()
+        sys.exit(1)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    migrate()


### PR DESCRIPTION
## Summary
- Per-user rate overrides for all variable compensations (OB, OT, on-call, vacation) with kr/tim for OB/OT and divisor-based defaults
- Full temporal history (ERA-based) mirroring WageHistory pattern — changing rates won't affect past months
- Admin and user self-service UI with rate history table, add/delete support

## Test plan
- [ ] Run migration script on prod
- [ ] Add custom rates for a user with a from-date, verify history table shows correctly
- [ ] Verify OT/OB/oncall calculations use custom rates on day view and month summary
- [ ] Add a future rate era, verify status shows "Kommande"
- [ ] Delete a future era, verify previous era's effective_to is cleared
- [ ] Verify users can edit their own rates on profile page