### PR TITLE
Add shift extension overtime

### DIFF
--- a/app/core/schedule/period.py
+++ b/app/core/schedule/period.py
@@ -674,7 +674,8 @@ def _build_person_day_basic(
                 pass
 
     # Visa OT som skift bara om det är registrerat på aktuell dag
-    if ot_shift_for_display:
+    # is_extension=True innebär att skiftet förlängs – visa originalskiftet kvar
+    if ot_shift_for_display and not ot_shift_for_display.is_extension:
         ot_shift_type = next((s for s in shift_types if s.code == "OT"), None)
         if ot_shift_type:
             shift = ot_shift_type
@@ -957,17 +958,19 @@ def _populate_single_person_day(
             "hours": ot_hours,
             "pay": ot_pay,
             "hourly_rate": hourly_rate,
+            "is_extension": ot_shift.is_extension,
         }
 
-        # Replace shift with OT for display
-        ot_shift_type = next((s for s in shift_types if s.code == "OT"), None)
-        if ot_shift_type:
-            shift = ot_shift_type
-            hours = ot_shift.hours
-            try:
-                start, end = parse_ot_times(ot_shift, current_day)
-            except ValueError:
-                start, end = None, None
+        # Ersätt skift med OT för visning – men inte om det är en förlängning
+        if not ot_shift.is_extension:
+            ot_shift_type = next((s for s in shift_types if s.code == "OT"), None)
+            if ot_shift_type:
+                shift = ot_shift_type
+                hours = ot_shift.hours
+                try:
+                    start, end = parse_ot_times(ot_shift, current_day)
+                except ValueError:
+                    start, end = None, None
 
     day_info.update(
         {

--- a/app/database/database.py
+++ b/app/database/database.py
@@ -8,6 +8,7 @@ from datetime import datetime
 
 from sqlalchemy import (
     JSON,
+    Boolean,
     Column,
     Date,
     DateTime,
@@ -118,6 +119,7 @@ class OvertimeShift(Base):
     end_time = Column(Time, nullable=False)
     hours = Column(Float, nullable=False)
     ot_pay = Column(Float, nullable=False)
+    is_extension = Column(Boolean, default=False, nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow)
     created_by = Column(Integer, ForeignKey("users.id"))
 

--- a/app/routes/overtime.py
+++ b/app/routes/overtime.py
@@ -23,6 +23,7 @@ async def add_overtime_shift(
     start_time: str = Form(...),
     end_time: str = Form(...),
     hours: float = Form(8.5),
+    is_extension: bool = Form(False),
     session: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
@@ -63,6 +64,7 @@ async def add_overtime_shift(
         end_time=end_t,
         hours=hours,
         ot_pay=ot_pay,
+        is_extension=is_extension,
         created_by=current_user.id,
     )
 

--- a/app/templates/day.html
+++ b/app/templates/day.html
@@ -100,66 +100,149 @@
                 </tbody>
             </table>
 
-            <h3>Övertidspass (OT)</h3>
+            <h3>Övertid (OT)</h3>
 
             {% if ot_shift %}
-                <div class="ot-display">
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Start</th>
-                                <th>Slut</th>
-                                <th>Timmar</th>
-                                <th>Timlön</th>
-                                <th>OT-lön</th>
-                                <th></th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td>{{ ot_shift.start_time }}</td>
-                                <td>{{ ot_shift.end_time }}</td>
-                                <td>{{ "%.2f"|format(ot_shift.hours) }}</td>
-                                <td>{{ "%.2f"|format(ot_shift.hourly_rate) }} kr/h</td>
-                                <td>{{ "%.2f"|format(ot_shift.pay) }} kr</td>
-                                <td>
-                                    <form method="POST" action="/overtime/{{ ot_shift_id }}/delete" style="display: inline;">
-                                        <button type="submit" class="btn btn-danger" onclick="return confirm('Ta bort övertidspass?')">Ta bort</button>
-                                    </form>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
+                {% if ot_shift.is_extension %}
+                    {# Förlängning av ordinarie skift #}
+                    <div class="ot-display">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Typ</th>
+                                    <th>Start</th>
+                                    <th>Slut</th>
+                                    <th>Extra tid</th>
+                                    <th>Timlön</th>
+                                    <th>OT-lön</th>
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><span class="badge" style="background:#f59e0b;color:#000;">Förlängning</span></td>
+                                    <td>{{ ot_shift.start_time }}</td>
+                                    <td>{{ ot_shift.end_time }}</td>
+                                    <td>{{ "%.2f"|format(ot_shift.hours) }} h</td>
+                                    <td>{{ "%.2f"|format(ot_shift.hourly_rate) }} kr/h</td>
+                                    <td>{{ "%.2f"|format(ot_shift.pay) }} kr</td>
+                                    <td>
+                                        <form method="POST" action="/overtime/{{ ot_shift_id }}/delete" style="display: inline;">
+                                            <button type="submit" class="btn btn-danger" onclick="return confirm('Ta bort förlängning?')">Ta bort</button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                {% else %}
+                    {# Inkallat övertidspass #}
+                    <div class="ot-display">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Start</th>
+                                    <th>Slut</th>
+                                    <th>Timmar</th>
+                                    <th>Timlön</th>
+                                    <th>OT-lön</th>
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>{{ ot_shift.start_time }}</td>
+                                    <td>{{ ot_shift.end_time }}</td>
+                                    <td>{{ "%.2f"|format(ot_shift.hours) }}</td>
+                                    <td>{{ "%.2f"|format(ot_shift.hourly_rate) }} kr/h</td>
+                                    <td>{{ "%.2f"|format(ot_shift.pay) }} kr</td>
+                                    <td>
+                                        <form method="POST" action="/overtime/{{ ot_shift_id }}/delete" style="display: inline;">
+                                            <button type="submit" class="btn btn-danger" onclick="return confirm('Ta bort övertidspass?')">Ta bort</button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
 
-                    {% if original_shift and original_shift.code == 'OC' %}
-                    <p class="info-text">
-                        <strong>OC-pass avslutas:</strong> OC-lön 00:00-{{ ot_shift.start_time }}, sedan OT-lön {{ ot_shift.start_time }}-{{ ot_shift.end_time }}
-                    </p>
-                    {% endif %}
-                </div>
+                        {% if original_shift and original_shift.code == 'OC' %}
+                        <p class="info-text">
+                            <strong>OC-pass avslutas:</strong> OC-lön 00:00-{{ ot_shift.start_time }}, sedan OT-lön {{ ot_shift.start_time }}-{{ ot_shift.end_time }}
+                        </p>
+                        {% endif %}
+                    </div>
+                {% endif %}
             {% else %}
-                <form method="POST" action="/overtime/add" class="ot-form">
+                {# Förlängningsformulär för ordinarie arbetspass #}
+                {% if shift and shift.code in ('N1', 'N2', 'N3') %}
+                    <p class="info-text" style="margin-bottom:0.5rem;">Stannade du kvar efter {{ shift.end_time }}? Logga förlängning:</p>
+                    <form method="POST" action="/overtime/add" class="ot-form" id="ext-form">
+                        <input type="hidden" name="user_id" value="{{ person_id }}">
+                        <input type="hidden" name="date" value="{{ date }}">
+                        <input type="hidden" name="is_extension" value="true">
+
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label for="ext_start_time">Ordinarie slut:</label>
+                                <input type="time" id="ext_start_time" name="start_time" value="{{ shift.end_time }}" readonly style="opacity:0.6;">
+                            </div>
+                            <div class="form-group">
+                                <label for="ext_end_time">Faktisk sluttid:</label>
+                                <input type="time" id="ext_end_time" name="end_time" value="{{ shift.end_time }}" required>
+                            </div>
+                            <div class="form-group">
+                                <label for="ext_hours">Timmar:</label>
+                                <input type="number" id="ext_hours" name="hours" value="0" step="0.01" min="0.01" max="8" required>
+                            </div>
+                        </div>
+
+                        <button type="submit" class="btn btn-primary">Logga förlängning</button>
+                    </form>
+
+                    <script>
+                    (function() {
+                        var startInput = document.getElementById('ext_start_time');
+                        var endInput = document.getElementById('ext_end_time');
+                        var hoursInput = document.getElementById('ext_hours');
+
+                        function updateHours() {
+                            var start = startInput.value, end = endInput.value;
+                            if (!start || !end) return;
+                            var sm = parseInt(start.split(':')[0]) * 60 + parseInt(start.split(':')[1]);
+                            var em = parseInt(end.split(':')[0]) * 60 + parseInt(end.split(':')[1]);
+                            var diff = em - sm;
+                            if (diff > 0) hoursInput.value = (diff / 60).toFixed(2);
+                        }
+                        endInput.addEventListener('change', updateHours);
+                    })();
+                    </script>
+
+                    <p class="info-text">Övertidslön beräknas som månadslön / 72 per timme.</p>
+                {% endif %}
+
+                {# Fullt övertidspass (inkallning) #}
+                <form method="POST" action="/overtime/add" class="ot-form" style="margin-top: {% if shift and shift.code in ('N1', 'N2', 'N3') %}1.5rem{% else %}0{% endif %};">
                     <input type="hidden" name="user_id" value="{{ person_id }}">
                     <input type="hidden" name="date" value="{{ date }}">
 
-                    <div class="form-row">
-                        <div class="form-group">
-                            <label for="start_time">Starttid:</label>
-                            <input type="time" id="start_time" name="start_time" value="14:00" required>
+                    <details>
+                        <summary style="cursor:pointer; color: var(--text-muted); font-size:0.9rem;">Lägg till inkallat övertidspass...</summary>
+                        <div class="form-row" style="margin-top:0.75rem;">
+                            <div class="form-group">
+                                <label for="start_time">Starttid:</label>
+                                <input type="time" id="start_time" name="start_time" value="14:00" required>
+                            </div>
+                            <div class="form-group">
+                                <label for="end_time">Sluttid:</label>
+                                <input type="time" id="end_time" name="end_time" value="22:30" required>
+                            </div>
+                            <div class="form-group">
+                                <label for="hours">Timmar:</label>
+                                <input type="number" id="hours" name="hours" value="8.5" step="0.5" min="0.5" max="24" required>
+                            </div>
                         </div>
-
-                        <div class="form-group">
-                            <label for="end_time">Sluttid:</label>
-                            <input type="time" id="end_time" name="end_time" value="22:30" required>
-                        </div>
-
-                        <div class="form-group">
-                            <label for="hours">Timmar:</label>
-                            <input type="number" id="hours" name="hours" value="8.5" step="0.5" min="0.5" max="24" required>
-                        </div>
-                    </div>
-
-                    <button type="submit" class="btn btn-primary">Lägg till övertidspass</button>
+                        <button type="submit" class="btn btn-primary">Lägg till övertidspass</button>
+                    </details>
                 </form>
 
                 <p class="info-text">

--- a/app/templates/month.html
+++ b/app/templates/month.html
@@ -192,16 +192,16 @@
                         <th class="th_right">Start</th>
                         <th class="th_right">Slut</th>
                         <th class="th_right">Norm</th>
-                        <th class="th_right">OB1(1,12)</th>
-                        <th class="th_right">OB2(1,18)</th>
-                        <th class="th_right">OB3(1,24)</th>
-                        <th class="th_right">OB4(1,24)</th>
-                        <th class="th_right">OB5(1,47)</th>
-                        <th class="th_right">B.Vardag</th>
-                        <th class="th_right">B.Helg</th>
-                        <th class="th_right">B.Helgdag</th>
-                        <th class="th_right">B.Storhelg</th>
-                        <th class="th_right">OT</th>
+                        <th class="th_right">OB1(x1,12)</th>
+                        <th class="th_right">OB2(x1,18)</th>
+                        <th class="th_right">OB3(x1,24)</th>
+                        <th class="th_right">OB4(x1,24)</th>
+                        <th class="th_right">OB5(x1,47)</th>
+                        <th class="th_right">B.Vardag(75)</th>
+                        <th class="th_right">B.Helg(97)</th>
+                        <th class="th_right">B.Helgdag(112)</th>
+                        <th class="th_right">B.Storhelg(192)</th>
+                        <th class="th_right">ÖT(x2)</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -264,6 +264,10 @@
                             {% else %}
                                 {% set t_start = '' %}
                                 {% set t_end = '' %}
+                            {% endif %}
+                            {# För förlängningar: visa faktisk sluttid från OT-data #}
+                            {% if d.ot_details and d.ot_details.get('is_extension') %}
+                                {% set t_end = d.ot_details.end_time[:5] %}
                             {% endif %}
 
                             <tr>

--- a/migrate_add_ot_extension.py
+++ b/migrate_add_ot_extension.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""
+Migration: Add is_extension column to overtime_shifts table.
+
+This enables shift extensions (staying extra time after a regular shift)
+distinct from full overtime call-in shifts.
+
+Run: python migrate_add_ot_extension.py
+"""
+
+import sqlite3
+import sys
+
+DB_PATH = "app/database/schedule.db"
+
+
+def migrate(db_path: str) -> None:
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    # Check if column already exists
+    cursor.execute("PRAGMA table_info(overtime_shifts)")
+    columns = [row[1] for row in cursor.fetchall()]
+
+    if "is_extension" in columns:
+        print("Column 'is_extension' already exists – skipping.")
+        conn.close()
+        return
+
+    cursor.execute("ALTER TABLE overtime_shifts ADD COLUMN is_extension BOOLEAN NOT NULL DEFAULT 0")
+    conn.commit()
+    conn.close()
+    print("Migration complete: added 'is_extension' to overtime_shifts.")
+
+
+if __name__ == "__main__":
+    path = sys.argv[1] if len(sys.argv) > 1 else DB_PATH
+    migrate(path)


### PR DESCRIPTION
## Summary

- Adds ability to log staying late after a regular shift (N1/N2/N3) as overtime extension
- New `is_extension` flag on `OvertimeShift` distinguishes stay-late extensions from full call-in OT shifts
- Extension keeps original shift display and OB hours intact; only adds OT pay on top
- Month detail table shows actual end time while preserving correct OB calculation

## Details

- **Day view**: pre-filled start time from shift end, hours auto-calculated via JS
- **Month breakdown**: end time reflects actual departure, OB calculated on scheduled hours only
- **Migration**: `migrate_add_ot_extension.py` (run on prod ✅)

## Test plan

- [x] Log a shift extension on an N1/N2/N3 day – verify shift code stays unchanged
- [x] Confirm OB hours are unchanged vs same shift without extension
- [x] Confirm OT pay appears correctly in month summary
- [x] Confirm end time in month detail table shows extension end time
- [x] Confirm full call-in OT (non-extension) still works as before