### PR TITLE
Add employment transition (övertag) feature

### DIFF
--- a/app/core/schedule/summary.py
+++ b/app/core/schedule/summary.py
@@ -421,11 +421,13 @@ def _process_day_for_summary(
     oncall_details = day.get("oncall_details", {})
     oncall_hours = oncall_details.get("total_hours", 0.0) if oncall_details else 0.0
     ot_pay = day.get("ot_pay", 0.0)
+    ot_hours = day.get("ot_hours", 0.0)
 
     totals["brutto_pay"] += oncall_pay + ot_pay
     totals["oncall_pay"] += oncall_pay
     totals["oncall_hours"] += oncall_hours
     totals["ot_pay"] += ot_pay
+    totals["total_hours"] += ot_hours
 
     return {
         "date": day["date"],

--- a/app/core/schedule/transition.py
+++ b/app/core/schedule/transition.py
@@ -1,0 +1,368 @@
+"""Anställningsövergång — beräkningar för konsult → direktanställning.
+
+Hanterar:
+- Automatisk beräkning av genomsnittlig daglig rörlig lön från intjänandeåret
+- Semesterutlösning enligt semesterlagen (sammalöneregeln)
+- Uppdelning av övergångsmånadens lön per arbetsgivare
+"""
+
+import datetime
+import math
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.database.database import EmploymentTransition, User
+
+
+# ---------------------------------------------------------------------------
+# Hjälpfunktioner
+# ---------------------------------------------------------------------------
+
+
+def get_earning_year(
+    transition: "EmploymentTransition",
+) -> tuple[datetime.date, datetime.date]:
+    """
+    Räknar ut intjänandeåret för konsultens semester.
+
+    Under semesterlagen löper intjänandeåret 1 april–31 mars.
+    Om transition.earning_year_start/end är satta används de istället.
+
+    Returns:
+        (earning_start, earning_end) som datetime.date
+    """
+    if transition.earning_year_start and transition.earning_year_end:
+        return transition.earning_year_start, transition.earning_year_end
+
+    end = transition.transition_date - datetime.timedelta(days=1)
+    # Senaste 1 april som infaller på eller innan sista konsultdagen
+    april_year = end.year if end.month >= 4 else end.year - 1
+    start = datetime.date(april_year, 4, 1)
+    return start, end
+
+
+def calculate_consultant_vacation_days(
+    user: "User",
+    transition: "EmploymentTransition",
+    full_year_days: int = 25,
+) -> int | None:
+    """
+    Beräknar pro-ratade semesterdagar intjänade under konsultanställningen.
+
+    Formel (semesterlagen §7):
+        ceil(full_year_days * anställda_dagar / totala_dagar_i_intjänandeåret)
+
+    Anställda dagar = överlappen mellan employment_start_date och dagen före
+    transition_date inom intjänandeåret.
+
+    Returns:
+        Antal dagar (avrundat uppåt), eller None om data saknas.
+    """
+    if not user.employment_start_date:
+        return None
+
+    earning_start, earning_end = get_earning_year(transition)
+
+    overlap_start = max(user.employment_start_date, earning_start)
+    overlap_end = min(transition.transition_date - datetime.timedelta(days=1), earning_end)
+
+    if overlap_start > overlap_end:
+        return 0
+
+    employed_days = (overlap_end - overlap_start).days + 1
+    total_days = (earning_end - earning_start).days + 1
+
+    return math.ceil(full_year_days * employed_days / total_days)
+
+
+def _iter_months(start: datetime.date, end: datetime.date) -> list[tuple[int, int]]:
+    """Returnerar lista av (år, månad) för alla månader i intervallet."""
+    months = []
+    current = datetime.date(start.year, start.month, 1)
+    while current <= end:
+        months.append((current.year, current.month))
+        if current.month == 12:
+            current = datetime.date(current.year + 1, 1, 1)
+        else:
+            current = datetime.date(current.year, current.month + 1, 1)
+    return months
+
+
+# ---------------------------------------------------------------------------
+# Rörlig genomsnittslön
+# ---------------------------------------------------------------------------
+
+
+def calculate_variable_avg_daily(
+    user: "User",
+    session,
+    earning_start: datetime.date,
+    earning_end: datetime.date,
+) -> float | None:
+    """
+    Beräknar genomsnittlig daglig rörlig lön under intjänandeåret.
+
+    Rörlig lön = OB-tillägg + beredskapsersättning + övertid.
+    Nämnaren är faktiska arbetsdagar (skift N1/N2/N3/OC/OT),
+    ej OFF-, SEM- eller dagar innan anställningsstart.
+
+    Returns:
+        Genomsnittlig rörlig lön per dag i SEK, eller None om data saknas.
+    """
+    from app.core.schedule.period import generate_period_data
+    from app.core.schedule.summary import summarize_month_for_person
+
+    person_id = user.rotation_person_id
+    if not person_id or not (1 <= person_id <= 10):
+        return None
+
+    # Räkna faktiska arbetsdagar via period-data (ej OB-beräkning — den görs nedan via summary)
+    try:
+        all_days = generate_period_data(
+            start_date=earning_start,
+            end_date=earning_end,
+            person_id=person_id,
+            session=session,
+        )
+    except Exception:
+        return None
+
+    working_days = 0
+    for day in all_days:
+        if day.get("before_employment"):
+            continue
+        shift = day.get("shift")
+        shift_code = shift.code if shift else None
+        if shift_code in ("OFF", "SEM", None):
+            continue
+        working_days += 1
+
+    if working_days == 0:
+        return None
+
+    # Summera rörliga lönedelar per månad (samma mönster som vacation.py)
+    ob_total = 0.0
+    ot_total = 0.0
+    oncall_total = 0.0
+
+    for year, month in _iter_months(earning_start, earning_end):
+        try:
+            summary = summarize_month_for_person(
+                year=year,
+                month=month,
+                person_id=person_id,
+                session=session,
+                fetch_tax_table=False,
+                wage_user_id=user.id,
+            )
+            ob_pay_dict = summary.get("ob_pay", {})
+            ob_total += sum(ob_pay_dict.values())
+            ot_total += summary.get("ot_pay", 0.0)
+            oncall_total += summary.get("oncall_pay", 0.0)
+        except Exception:
+            pass
+
+    total_variable = ob_total + ot_total + oncall_total
+    if total_variable == 0.0:
+        return None
+
+    return round(total_variable / working_days, 4)
+
+
+# ---------------------------------------------------------------------------
+# Semesterutlösning (semesterlagen — sammalöneregeln)
+# ---------------------------------------------------------------------------
+
+
+def calculate_consultant_vacation_payout(
+    transition: "EmploymentTransition",
+    user: "User",
+    session,
+) -> dict:
+    """
+    Beräknar semesterutlösning vid konsultanställningens slut.
+
+    Formel (semesterlagen, sammalöneregeln):
+        Grundkomponent:  (månadslön / 21,75) × dagar × (1 + tilläggsprocent)
+        Rörlig komponent: genomsnittlig daglig rörlig lön × dagar
+
+    Args:
+        transition: EmploymentTransition-objekt för användaren
+        user: User-objekt
+        session: SQLAlchemy-session
+
+    Returns:
+        Dict med nedbruten beräkning:
+        {
+            "vacation_days": float,
+            "monthly_salary": int,
+            "base_per_day": float,
+            "supplement_pct": float,
+            "base_with_supplement_per_day": float,
+            "base_payout": float,
+            "variable_avg_daily": float | None,
+            "variable_auto_calculated": bool,
+            "variable_payout": float,
+            "total": float,
+            "earning_year_start": date,
+            "earning_year_end": date,
+        }
+    """
+    from app.core.schedule.wages import get_user_wage
+
+    earning_start, earning_end = get_earning_year(transition)
+    days = transition.consultant_vacation_days
+    supplement_pct = transition.consultant_supplement_pct
+
+    # Konsultlön: lönen dagen innan övergången (från WageHistory eller User.wage)
+    last_consultant_day = transition.transition_date - datetime.timedelta(days=1)
+    monthly_salary = get_user_wage(session, user.id, fallback=user.wage, effective_date=last_consultant_day)
+
+    # Grundkomponent: sammalöneregeln
+    base_per_day = monthly_salary / 21.75
+    base_with_supplement_per_day = round(base_per_day * (1 + supplement_pct), 4)
+    base_payout = round(base_with_supplement_per_day * days, 2)
+
+    # Rörlig komponent
+    variable_auto_calculated = transition.variable_avg_daily_override is None
+    if variable_auto_calculated:
+        avg_daily = calculate_variable_avg_daily(user, session, earning_start, earning_end)
+    else:
+        avg_daily = transition.variable_avg_daily_override
+
+    variable_payout = round((avg_daily or 0.0) * days, 2)
+    total = round(base_payout + variable_payout, 2)
+
+    return {
+        "vacation_days": days,
+        "monthly_salary": monthly_salary,
+        "base_per_day": round(base_per_day, 4),
+        "supplement_pct": supplement_pct,
+        "base_with_supplement_per_day": base_with_supplement_per_day,
+        "base_payout": base_payout,
+        "variable_avg_daily": avg_daily,
+        "variable_auto_calculated": variable_auto_calculated,
+        "variable_payout": variable_payout,
+        "total": total,
+        "earning_year_start": earning_start,
+        "earning_year_end": earning_end,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Övergångsmånadens löneuppdelning
+# ---------------------------------------------------------------------------
+
+
+def calculate_transition_month_summary(
+    transition: "EmploymentTransition",
+    user: "User",
+    session,
+) -> dict:
+    """
+    Beräknar förväntad löneutbetalning för övergångsmånaden, uppdelad per arbetsgivare.
+
+    Regler:
+    - TRAILING (släpande konsultlön):
+        Konsultarbetsgivare betalar: sista konsultmånadens grundlön + semesterutlösning
+        Direktarbetsgivare betalar: innestående grundlön för övergångsmånaden
+    - CURRENT (innestående konsultlön):
+        Konsultarbetsgivare betalar: semesterutlösning (ingen extra grundlön)
+        Direktarbetsgivare betalar: innestående grundlön för övergångsmånaden
+
+    Notering: Handels rörliga delar (OB/beredskap) i övergångsmånaden
+    betalas ut månaden efter (släpande rörliga), ej inkluderat här.
+
+    Returns:
+        {
+            "transition_year": int,
+            "transition_month": int,
+            "transition_date": date,
+            "consultant_salary_type": str,
+            "consultant_employer": {
+                "trailing_base": float | None,     # Sista konsultmånadens grundlön (om TRAILING)
+                "trailing_variable": float | None, # Sista konsultmånadens rörliga (OB+OC+OT, om TRAILING)
+                "trailing_variable_breakdown": dict | None,  # {ob, oncall, ot}
+                "vacation_payout": dict,            # Semesterutlösning (se calculate_consultant_vacation_payout)
+                "total": float,
+            },
+            "direct_employer": {
+                "base_salary": int,                # Innestående grundlön övergångsmånaden
+                "note_variable": str,              # Förklaring om varför rörliga ej ingår
+            },
+            "grand_total_gross": float,            # Summa brutto båda arbetsgivarna
+        }
+    """
+    from app.core.schedule.summary import summarize_month_for_person
+    from app.core.schedule.wages import get_user_wage
+    from app.database.database import ConsultantSalaryType
+
+    t_date = transition.transition_date
+    last_consultant_day = t_date - datetime.timedelta(days=1)
+
+    # Konsultlön (lönen dagen innan övergången)
+    consultant_monthly = get_user_wage(session, user.id, fallback=user.wage, effective_date=last_consultant_day)
+
+    # Direktlön (lönen på/efter övergångsdatumet)
+    direct_monthly = get_user_wage(session, user.id, fallback=user.wage, effective_date=t_date)
+
+    # Semesterutlösning från konsultarbetsgivaren
+    vacation_payout = calculate_consultant_vacation_payout(transition, user, session)
+
+    # Konsultarbetsgivaren betalar ev. släpande grundlön + rörliga delar
+    trailing_base: float | None = None
+    trailing_variable: float | None = None
+    trailing_variable_breakdown: dict | None = None
+
+    if transition.consultant_salary_type == ConsultantSalaryType.TRAILING:
+        trailing_base = float(consultant_monthly)
+
+        # Rörliga delar från sista konsultmånaden (månaden för last_consultant_day)
+        person_id = user.rotation_person_id
+        if person_id and 1 <= person_id <= 10:
+            try:
+                last_summary = summarize_month_for_person(
+                    year=last_consultant_day.year,
+                    month=last_consultant_day.month,
+                    person_id=person_id,
+                    session=session,
+                    fetch_tax_table=False,
+                    wage_user_id=user.id,
+                )
+                ob_pay = round(sum(last_summary.get("ob_pay", {}).values()), 2)
+                oncall_pay = round(last_summary.get("oncall_pay", 0.0), 2)
+                ot_pay = round(last_summary.get("ot_pay", 0.0), 2)
+                trailing_variable = round(ob_pay + oncall_pay + ot_pay, 2)
+                trailing_variable_breakdown = {
+                    "ob": ob_pay,
+                    "oncall": oncall_pay,
+                    "ot": ot_pay,
+                }
+            except Exception:
+                pass
+
+    consultant_total = round(
+        (trailing_base or 0.0) + (trailing_variable or 0.0) + vacation_payout["total"],
+        2,
+    )
+
+    return {
+        "transition_year": t_date.year,
+        "transition_month": t_date.month,
+        "transition_date": t_date,
+        "consultant_salary_type": transition.consultant_salary_type.value,
+        "consultant_employer": {
+            "trailing_base": trailing_base,
+            "trailing_variable": trailing_variable,
+            "trailing_variable_breakdown": trailing_variable_breakdown,
+            "vacation_payout": vacation_payout,
+            "total": consultant_total,
+        },
+        "direct_employer": {
+            "base_salary": direct_monthly,
+            "note_variable": (
+                "OB och beredskap från övergångsmånaden betalas av ICA månaden efter (släpande rörliga delar)."
+            ),
+        },
+        "grand_total_gross": round(consultant_total + direct_monthly, 2),
+    }

--- a/app/main.py
+++ b/app/main.py
@@ -30,6 +30,7 @@ from app.routes.schedule_api import router as schedule_api_router
 from app.routes.schedule_personal import router as schedule_personal_router
 from app.routes.shift_swap import router as shift_swap_router
 from app.routes.statistics import router as statistics_router
+from app.routes.transition import router as transition_router
 
 # Setup logging FIRST (before any other imports that might log)
 setup_logging()
@@ -240,6 +241,7 @@ app.include_router(shift_swap_router)
 app.include_router(statistics_router)
 app.include_router(auth_router)
 app.include_router(admin_router)
+app.include_router(transition_router)
 
 
 @app.get("/health", tags=["health"])

--- a/app/routes/transition.py
+++ b/app/routes/transition.py
@@ -1,0 +1,259 @@
+# app/routes/transition.py
+"""
+Anställningsövergång — routes för konsult → direktanställning.
+
+Tillgänglig för inloggad användare via /profile/transition.
+"""
+
+import datetime
+
+from fastapi import APIRouter, Depends, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from sqlalchemy.orm import Session
+
+from app.auth.auth import get_current_user
+from app.database.database import ConsultantSalaryType, EmploymentTransition, User, get_db
+from app.routes.shared import templates
+
+router = APIRouter(tags=["transition"])
+
+
+def _get_transition_context(
+    request: Request,
+    user: User,
+    db: Session,
+    error: str | None = None,
+) -> dict:
+    """Bygg template-kontext för transition-sidan."""
+    from app.core.schedule.transition import (
+        calculate_consultant_vacation_days,
+        calculate_transition_month_summary,
+        calculate_variable_avg_daily,
+        get_earning_year,
+    )
+
+    transition = db.query(EmploymentTransition).filter(EmploymentTransition.user_id == user.id).first()
+
+    # Auto-beräkna rörlig genomsnittslön och semesterdagar om transition finns
+    auto_variable_avg = None
+    auto_consultant_vacation_days = None
+    preview = None
+    if transition:
+        earning_start, earning_end = get_earning_year(transition)
+        if transition.variable_avg_daily_override is None:
+            auto_variable_avg = calculate_variable_avg_daily(user, db, earning_start, earning_end)
+        auto_consultant_vacation_days = calculate_consultant_vacation_days(user, transition)
+        try:
+            preview = calculate_transition_month_summary(transition, user, db)
+        except Exception:
+            preview = None
+
+    return {
+        "request": request,
+        "user": user,
+        "transition": transition,
+        "salary_types": [
+            ("trailing", "Släpande (lön för föregående månad)"),
+            ("current", "Innestående (lön för aktuell månad)"),
+        ],
+        "auto_variable_avg": auto_variable_avg,
+        "auto_consultant_vacation_days": auto_consultant_vacation_days,
+        "preview": preview,
+        "error": error,
+    }
+
+
+@router.get("/profile/transition", response_class=HTMLResponse, name="transition_page")
+async def transition_page(
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Visa inställningssida för anställningsövergång."""
+    ctx = _get_transition_context(request, current_user, db)
+    return templates.TemplateResponse("transition.html", ctx)
+
+
+@router.post("/profile/transition", name="transition_save")
+async def transition_save(
+    request: Request,
+    transition_date: str = Form(...),
+    consultant_salary_type: str = Form(...),
+    consultant_vacation_days: str = Form(""),
+    consultant_supplement_pct: float = Form(...),
+    variable_avg_daily_override: str = Form(""),
+    earning_year_start: str = Form(""),
+    earning_year_end: str = Form(""),
+    notes: str = Form(""),
+    new_direct_salary: str = Form(""),
+    reset_rates_to_default: str = Form(""),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Spara eller uppdatera anställningsövergång. PRG-redirect."""
+    # Validering
+    try:
+        t_date = datetime.date.fromisoformat(transition_date)
+    except ValueError:
+        ctx = _get_transition_context(request, current_user, db, error="Ogiltigt övergångsdatum.")
+        return templates.TemplateResponse("transition.html", ctx, status_code=400)
+
+    if consultant_salary_type not in ("trailing", "current"):
+        ctx = _get_transition_context(request, current_user, db, error="Ogiltig lönetyp.")
+        return templates.TemplateResponse("transition.html", ctx, status_code=400)
+
+    if not (0 < consultant_supplement_pct < 1):
+        ctx = _get_transition_context(
+            request, current_user, db, error="Tilläggsprocent måste vara mellan 0 och 1 (t.ex. 0.0043)."
+        )
+        return templates.TemplateResponse("transition.html", ctx, status_code=400)
+
+    # Parsning av optionella fält
+    variable_override: float | None = None
+    if variable_avg_daily_override.strip():
+        try:
+            variable_override = float(variable_avg_daily_override.strip())
+        except ValueError:
+            ctx = _get_transition_context(request, current_user, db, error="Ogiltig rörlig genomsnittslön.")
+            return templates.TemplateResponse("transition.html", ctx, status_code=400)
+
+    earning_start: datetime.date | None = None
+    earning_end: datetime.date | None = None
+    if earning_year_start.strip():
+        try:
+            earning_start = datetime.date.fromisoformat(earning_year_start.strip())
+        except ValueError:
+            ctx = _get_transition_context(request, current_user, db, error="Ogiltigt startdatum för intjänandeår.")
+            return templates.TemplateResponse("transition.html", ctx, status_code=400)
+    if earning_year_end.strip():
+        try:
+            earning_end = datetime.date.fromisoformat(earning_year_end.strip())
+        except ValueError:
+            ctx = _get_transition_context(request, current_user, db, error="Ogiltigt slutdatum för intjänandeår.")
+            return templates.TemplateResponse("transition.html", ctx, status_code=400)
+
+    # Semesterdagar: manuell override eller auto-beräknat från anställningsdatum
+    parsed_vacation_days: float
+    if consultant_vacation_days.strip():
+        try:
+            parsed_vacation_days = float(consultant_vacation_days.strip())
+        except ValueError:
+            ctx = _get_transition_context(request, current_user, db, error="Ogiltigt antal semesterdagar.")
+            return templates.TemplateResponse("transition.html", ctx, status_code=400)
+    else:
+        from types import SimpleNamespace
+
+        from app.core.schedule.transition import calculate_consultant_vacation_days
+
+        temp = SimpleNamespace(
+            transition_date=t_date,
+            earning_year_start=earning_start,
+            earning_year_end=earning_end,
+        )
+        parsed_vacation_days = float(calculate_consultant_vacation_days(current_user, temp) or 0)
+
+    salary_type = ConsultantSalaryType(consultant_salary_type)
+
+    # Hämta eller skapa transition-post
+    transition = db.query(EmploymentTransition).filter(EmploymentTransition.user_id == current_user.id).first()
+    if transition is None:
+        transition = EmploymentTransition(user_id=current_user.id)
+        db.add(transition)
+
+    transition.transition_date = t_date
+    transition.consultant_salary_type = salary_type
+    transition.consultant_vacation_days = parsed_vacation_days
+    transition.consultant_supplement_pct = consultant_supplement_pct
+    transition.variable_avg_daily_override = variable_override
+    transition.earning_year_start = earning_start
+    transition.earning_year_end = earning_end
+    transition.notes = notes.strip() or None
+    transition.updated_at = datetime.datetime.utcnow()
+
+    try:
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+
+    # Sätt ny direktlön från övergångsdatum
+    if new_direct_salary.strip():
+        try:
+            salary_int = int(new_direct_salary.strip())
+            from app.core.schedule import add_new_wage, clear_schedule_cache
+            from app.database.database import WageHistory
+
+            existing_wage = (
+                db.query(WageHistory)
+                .filter(
+                    WageHistory.user_id == current_user.id,
+                    WageHistory.effective_from == t_date,
+                )
+                .first()
+            )
+            if existing_wage:
+                existing_wage.wage = salary_int
+                db.commit()
+            else:
+                add_new_wage(
+                    session=db,
+                    user_id=current_user.id,
+                    new_wage=salary_int,
+                    effective_from=t_date,
+                    created_by=current_user.id,
+                )
+            clear_schedule_cache()
+        except (ValueError, Exception):
+            pass
+
+    # Återgå till standardsatser (OB/OT/beredskap) från övergångsdatum
+    if reset_rates_to_default.strip():
+        from app.core.rates import add_new_rates
+        from app.core.schedule import clear_schedule_cache
+
+        add_new_rates(
+            session=db,
+            user_id=current_user.id,
+            rates={},
+            effective_from=t_date,
+            created_by=current_user.id,
+        )
+        clear_schedule_cache()
+
+    return RedirectResponse(url="/profile/transition", status_code=302)
+
+
+@router.post("/profile/transition/delete", name="transition_delete")
+async def transition_delete(
+    request: Request,
+    cleanup_wage: str = Form(""),
+    cleanup_rates: str = Form(""),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Ta bort transition-konfiguration och valfritt associerade lon/sats-poster."""
+    from app.core.schedule import clear_schedule_cache
+    from app.database.database import RateHistory, WageHistory
+
+    transition = db.query(EmploymentTransition).filter(EmploymentTransition.user_id == current_user.id).first()
+    if transition:
+        t_date = transition.transition_date
+        if cleanup_wage.strip():
+            db.query(WageHistory).filter(
+                WageHistory.user_id == current_user.id,
+                WageHistory.effective_from == t_date,
+            ).delete()
+        if cleanup_rates.strip():
+            db.query(RateHistory).filter(
+                RateHistory.user_id == current_user.id,
+                RateHistory.effective_from == t_date,
+            ).delete()
+        db.delete(transition)
+        try:
+            db.commit()
+            clear_schedule_cache()
+        except Exception:
+            db.rollback()
+            raise
+
+    return RedirectResponse(url="/profile/transition", status_code=302)

--- a/app/static/css/components.css
+++ b/app/static/css/components.css
@@ -291,3 +291,94 @@ input, select {
   line-height: 1.6;
 }
 
+/* ===== Forms ===== */
+.form-group { margin-bottom: 1rem; }
+.form-label { display: block; margin-bottom: 0.375rem; color: var(--muted); font-size: 0.9rem; }
+.form-input { width: 100%; box-sizing: border-box; }
+.form-input--disabled { opacity: 0.6; }
+.form-hint { display: block; margin-top: 0.25rem; font-size: 0.8rem; color: var(--muted); }
+.form-section-divider { border: none; border-top: 1px solid var(--table-border); margin: 1.25rem 0; }
+.form-section-title {
+  margin: 0 0 0.75rem 0;
+  font-size: 0.8rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 600;
+}
+
+/* ===== Alerts / Info Boxes ===== */
+.alert {
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius);
+  border: 1px solid var(--table-border);
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+.alert--danger  { background: rgba(239,68,68,0.12);  border-color: var(--danger); }
+.alert--success { background: rgba(123,211,137,0.09); border-color: var(--accent-2); }
+.alert--warning { background: rgba(255,165,0,0.09);  border-color: var(--warning); }
+.alert--info    { background: rgba(64,169,255,0.08); border-color: var(--accent); }
+
+/* ===== Anställningsövergång ===== */
+.transition-employer {
+  border: 1px solid var(--table-border);
+  border-radius: var(--radius);
+  padding: 0.875rem;
+  margin-bottom: 1rem;
+}
+.transition-employer--consultant { background: rgba(255,165,0,0.06); }
+.transition-employer--direct     { background: rgba(123,211,137,0.06); }
+
+.transition-employer h4 { margin: 0 0 0.625rem 0; font-size: 0.95rem; }
+.transition-employer--consultant h4 { color: var(--warning); }
+.transition-employer--direct     h4 { color: var(--accent-2); }
+
+.transition-breakdown { border-top: 1px solid var(--table-border); margin-top: 0.625rem; padding-top: 0.625rem; }
+.transition-breakdown__label { font-size: 0.8rem; color: var(--muted); margin-bottom: 0.5rem; text-transform: uppercase; letter-spacing: 0.04em; }
+
+.transition-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  margin-bottom: 0.25rem;
+  font-size: 0.9rem;
+}
+.transition-row span:first-child { color: var(--muted); }
+.transition-row--total {
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--table-border);
+  font-weight: 700;
+}
+.transition-row--total span:first-child { color: var(--text); }
+
+.transition-grand-total {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.75rem 0.875rem;
+  background: rgba(255,255,255,0.04);
+  border-radius: var(--radius);
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.transition-note { font-size: 0.8rem; color: var(--muted); margin-top: 0.5rem; }
+.transition-tax-note { font-size: 0.8rem; color: var(--muted); margin-top: 0.625rem; line-height: 1.5; }
+
+.auto-hint {
+  padding: 0.625rem 0.875rem;
+  border: 1px solid var(--table-border);
+  border-radius: var(--radius);
+  background: rgba(123,211,137,0.06);
+  font-size: 0.875rem;
+  margin-bottom: 0.75rem;
+}
+.auto-hint--missing { background: rgba(255,165,0,0.06); }
+
+/* Year view: transition row highlight */
+.transition-year-row { border-left: 3px solid var(--warning); }
+

--- a/app/templates/admin_user_edit.html
+++ b/app/templates/admin_user_edit.html
@@ -120,7 +120,7 @@
                                     <button type="submit" class="btn danger" style="padding: 4px 8px; font-size: 0.875rem;">Ta bort</button>
                                 </form>
                             {% else %}
-                                <span style="color: var(--muted); font-size: 0.875rem;">—</span>
+                                <span style="color: var(--muted); font-size: 0.875rem;">-</span>
                             {% endif %}
                         </td>
                     </tr>
@@ -340,6 +340,137 @@
     {% set rates_form_action = "/admin/users/" ~ edit_user.id ~ "/update-rates" %}
     {% set rates_delete_prefix = "/admin/users/" ~ edit_user.id ~ "/delete-rate/" %}
     {% include "rates_form.html" with context %}
+
+    <!-- Övertag -->
+    <div class="card" style="margin-top: 16px;">
+        <h3>&#214;vertag</h3>
+
+        {% if edit_transition %}
+        <p class="form-hint">
+            &#214;vertagsdatum: <strong>{{ edit_transition.transition_date }}</strong>,
+            {{ "Sl&#228;pande" if edit_transition.consultant_salary_type.value == "trailing" else "Innest&#229;ende" }} konsultl&#246;n
+        </p>
+        {% if admin_auto_variable_avg is not none %}
+        <div class="auto-hint">
+            Auto-ber&#228;knad r&#246;rlig genomsnittsl&#246;n: <strong>{{ "%.2f"|format(admin_auto_variable_avg) }} kr/dag</strong>
+        </div>
+        {% endif %}
+        {% else %}
+        <p class="form-hint">Inget &#246;vertag konfigurerat.</p>
+        {% endif %}
+
+        <form method="POST" action="/admin/users/{{ edit_user.id }}/transition">
+
+            <div class="form-group">
+                <label for="adm_transition_date" class="form-label">&#214;vertagsdatum</label>
+                <input type="date" id="adm_transition_date" name="transition_date" class="form-input"
+                       value="{{ edit_transition.transition_date.isoformat() if edit_transition else '' }}" required>
+            </div>
+
+            <div class="form-group">
+                <label for="adm_salary_type" class="form-label">Konsultl&#246;netyp</label>
+                <select id="adm_salary_type" name="consultant_salary_type" class="form-input">
+                    {% for value, label in salary_types %}
+                    <option value="{{ value }}"
+                        {% if edit_transition and edit_transition.consultant_salary_type.value == value %}selected{% endif %}>
+                        {{ label }}
+                    </option>
+                    {% endfor %}
+                </select>
+            </div>
+
+            <div class="form-group">
+                <label class="form-label">Intj&#228;nade semesterdagar (fr&#229;n konsultanst&#228;llningen)</label>
+                {% if admin_auto_vacation_days is not none %}
+                <div class="auto-hint">
+                    Auto-ber&#228;knat: <strong>{{ admin_auto_vacation_days }} dagar</strong>
+                    <span class="form-hint">Pro-ratat fr&#229;n anst&#228;llningsdagen inom intj&#228;nande&#229;ret</span>
+                </div>
+                {% elif edit_transition %}
+                <div class="auto-hint auto-hint--missing">
+                    Kan inte ber&#228;knas, saknar anst&#228;llningsdatum. Sparat: {{ edit_transition.consultant_vacation_days }} dagar.
+                </div>
+                {% endif %}
+                <label class="form-label" style="margin-top: 0.4rem;">
+                    Manuell override (tomt = anv&#228;nd auto)
+                </label>
+                <input type="number" id="adm_vacation_days" name="consultant_vacation_days" class="form-input"
+                       value="{{ edit_transition.consultant_vacation_days if edit_transition and edit_transition.consultant_vacation_days != admin_auto_vacation_days else '' }}"
+                       min="0" step="0.5"
+                       placeholder="{{ admin_auto_vacation_days if admin_auto_vacation_days is not none else '' }}">
+            </div>
+
+            <div class="form-group">
+                <label for="adm_supplement_pct" class="form-label">Semestertill&#228;ggsprocent (semesterlagen)</label>
+                <input type="number" id="adm_supplement_pct" name="consultant_supplement_pct" class="form-input"
+                       value="{{ edit_transition.consultant_supplement_pct if edit_transition else 0.0043 }}"
+                       min="0" max="0.99" step="0.0001" required>
+            </div>
+
+            <div class="form-group">
+                <label for="adm_variable_override" class="form-label">R&#246;rlig genomsnittsl&#246;n override kr/dag (tomt = auto)</label>
+                <input type="number" id="adm_variable_override" name="variable_avg_daily_override" class="form-input"
+                       value="{{ edit_transition.variable_avg_daily_override if edit_transition and edit_transition.variable_avg_daily_override is not none else '' }}"
+                       min="0" step="0.01"
+                       placeholder="{{ '%.2f'|format(admin_auto_variable_avg) if admin_auto_variable_avg else '' }}">
+            </div>
+
+            <div class="form-group">
+                <label for="adm_earning_start" class="form-label">Intj&#228;nande&#229;r start (tomt = auto)</label>
+                <input type="date" id="adm_earning_start" name="earning_year_start" class="form-input"
+                       value="{{ edit_transition.earning_year_start.isoformat() if edit_transition and edit_transition.earning_year_start else '' }}">
+            </div>
+
+            <div class="form-group">
+                <label for="adm_earning_end" class="form-label">Intj&#228;nande&#229;r slut (tomt = auto)</label>
+                <input type="date" id="adm_earning_end" name="earning_year_end" class="form-input"
+                       value="{{ edit_transition.earning_year_end.isoformat() if edit_transition and edit_transition.earning_year_end else '' }}">
+            </div>
+
+            <div class="form-group">
+                <label for="adm_notes" class="form-label">Anteckningar</label>
+                <textarea id="adm_notes" name="notes" rows="2" class="form-input"
+                          style="padding: 0.5rem; resize: vertical;">{{ edit_transition.notes if edit_transition and edit_transition.notes else '' }}</textarea>
+            </div>
+
+            <hr class="form-section-divider">
+            <p class="form-section-title">Vid sparande (eng&#229;ngs&#229;tg&#228;rder)</p>
+
+            <div class="form-group">
+                <label for="adm_new_direct_salary" class="form-label">S&#228;tt ny direktl&#246;n fr&#229;n &#246;vertagsdatum (kr/m&#229;nad, tomt = ingen &#228;ndring)</label>
+                <input type="number" id="adm_new_direct_salary" name="new_direct_salary" class="form-input"
+                       min="1" step="1" placeholder="t.ex. 32000">
+            </div>
+
+            <div class="form-group">
+                <label class="form-label">
+                    <input type="checkbox" name="reset_rates_to_default" value="on">
+                    &#197;terg&#229; till standard OB/OT/beredskap-satser fr&#229;n &#246;vertagsdatum
+                </label>
+            </div>
+
+            <button type="submit" class="btn btn-primary">Spara &#246;vertag</button>
+        </form>
+
+        {% if edit_transition %}
+        <hr class="form-section-divider">
+        <form method="POST" action="/admin/users/{{ edit_user.id }}/transition/delete">
+            <div class="form-group">
+                <label class="form-label">
+                    <input type="checkbox" name="cleanup_wage" value="on" checked>
+                    Ta &#228;ven bort l&#246;nepost fr&#229;n &#246;vertagsdatumet ({{ edit_transition.transition_date }})
+                </label>
+            </div>
+            <div class="form-group">
+                <label class="form-label">
+                    <input type="checkbox" name="cleanup_rates" value="on" checked>
+                    Ta &#228;ven bort satspost fr&#229;n &#246;vertagsdatumet ({{ edit_transition.transition_date }})
+                </label>
+            </div>
+            <button type="submit" class="btn btn-danger">Ta bort inst&#228;llningar</button>
+        </form>
+        {% endif %}
+    </div>
 </div>
 
 {% endblock %}

--- a/app/templates/day.html
+++ b/app/templates/day.html
@@ -542,7 +542,7 @@
                         let html = '<option value="">-- Välj pass --</option>';
                         data.shifts.forEach(s => {
                             const ob = s.ob_hours > 0 ? ' (' + s.ob_hours + 'h OB)' : '';
-                            html += '<option value="' + s.date + '">' + s.date_display + ' — ' + s.label + ob + '</option>';
+                            html += '<option value="' + s.date + '">' + s.date_display + ': ' + s.label + ob + '</option>';
                         });
                         targetSelect.innerHTML = html;
                         targetSelect.disabled = false;

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -82,6 +82,16 @@
             <p style="color: var(--muted);">Hantera dina semesterveckor.</p>
             <a href="/profile/vacation" class="btn">Hantera semester</a>
         </div>
+
+        <!-- Övertag länk -->
+        <div class="card" style="margin-top: 16px;">
+            <h3 style="margin-top: 0;">&#214;vertag</h3>
+            <p style="color: var(--muted);">Konfigurera &#246;vertag fr&#229;n konsult till direktanst&#228;llning.</p>
+            {% if user.employment_transition %}
+            <span class="badge" style="margin-bottom: 0.75rem; display: inline-block;">Konfigurerad</span><br>
+            {% endif %}
+            <a href="/profile/transition" class="btn">{{ "Redigera" if user.employment_transition else "Konfigurera" }}</a>
+        </div>
     </div>
 
 </div>
@@ -127,7 +137,7 @@
                                         <button type="submit" class="btn danger" style="padding: 4px 8px; font-size: 0.875rem;">Ta bort</button>
                                     </form>
                                 {% else %}
-                                    <span style="color: var(--muted); font-size: 0.875rem;">—</span>
+                                    <span style="color: var(--muted); font-size: 0.875rem;">-</span>
                                 {% endif %}
                             </td>
                         </tr>

--- a/app/templates/rates_form.html
+++ b/app/templates/rates_form.html
@@ -1,4 +1,4 @@
-{# Shared rates form — used by admin_user_edit.html and profile.html #}
+{# Shared rates form, used by admin_user_edit.html and profile.html #}
 {# Expects: rate_defaults, custom_rates, rates_form_action, rates_delete_prefix, rate_history #}
 
 <!-- Rate History -->
@@ -146,7 +146,7 @@
                         <input type="number" class="input rate-factor" placeholder="&times; faktor" step="0.01" min="0"
                                style="flex: 1; min-width: 0;">
                         <span style="color: var(--muted); font-size: 0.8rem;">=</span>
-                        <span class="rate-computed" style="font-size: 0.75rem; font-weight: 600; color: var(--accent); white-space: nowrap; min-width: 28px;">&#8212;</span>
+                        <span class="rate-computed" style="font-size: 0.75rem; font-weight: 600; color: var(--accent); white-space: nowrap; min-width: 28px;">-</span>
                     </div>
                 </div>
             </div>
@@ -170,7 +170,7 @@
                 <div style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
                     <input type="number" class="input rate-factor" placeholder="faktor" step="0.01" min="0" style="width: 100px;">
                     <span style="color: var(--muted);">=</span>
-                    <span class="rate-computed" style="font-weight: 600; color: var(--accent);">&#8212;</span>
+                    <span class="rate-computed" style="font-weight: 600; color: var(--accent);">-</span>
                     <span style="color: var(--muted); font-size: 0.85rem;">kr/tim</span>
                 </div>
             </div>
@@ -195,7 +195,7 @@
                         <input type="number" class="input rate-factor" placeholder="&times; faktor" step="0.01" min="0"
                                style="flex: 1; min-width: 0;">
                         <span style="color: var(--muted); font-size: 0.8rem;">=</span>
-                        <span class="rate-computed" style="font-size: 0.75rem; font-weight: 600; color: var(--accent); white-space: nowrap; min-width: 28px;">&#8212;</span>
+                        <span class="rate-computed" style="font-size: 0.75rem; font-weight: 600; color: var(--accent); white-space: nowrap; min-width: 28px;">-</span>
                     </div>
                 </div>
             </div>

--- a/app/templates/transition.html
+++ b/app/templates/transition.html
@@ -1,0 +1,250 @@
+{# app/templates/transition.html #}
+{% extends "base.html" %}
+
+{% block page_content %}
+
+<div class="page-header">
+    <div class="page-header-left">
+        <a href="/profile" class="btn secondary">&larr; Min profil</a>
+    </div>
+</div>
+
+<h2 class="page-title">&#214;vertag</h2>
+
+<p class="form-hint">Konfigurera &#246;vertaget fr&#229;n konsultanst&#228;llning till direktanst&#228;llning med Handelns tj&#228;nstemannaavtal.</p>
+
+{% if error %}
+<div class="alert alert--danger">{{ error }}</div>
+{% endif %}
+
+<div class="row" style="gap: 1.5rem; flex-wrap: wrap; align-items: flex-start;">
+
+    {# === Inställningskort === #}
+    <div class="col" style="min-width: 320px; flex: 1;">
+        <div class="card">
+            <h3>Inst&#228;llningar</h3>
+
+            <form method="POST" action="/profile/transition">
+
+                <div class="form-group">
+                    <label for="transition_date" class="form-label">&#214;vertagsdatum (f&#246;rsta dag som direktanst&#228;lld)</label>
+                    <input type="date" id="transition_date" name="transition_date" class="form-input"
+                           value="{{ transition.transition_date.isoformat() if transition else '' }}" required>
+                </div>
+
+                <div class="form-group">
+                    <label for="consultant_salary_type" class="form-label">Konsultl&#246;netyp</label>
+                    <select id="consultant_salary_type" name="consultant_salary_type" class="form-input">
+                        {% for value, label in salary_types %}
+                        <option value="{{ value }}"
+                            {% if transition and transition.consultant_salary_type.value == value %}selected{% endif %}>
+                            {{ label }}
+                        </option>
+                        {% endfor %}
+                    </select>
+                    <span class="form-hint">S&#228;tter om konsultarbetsgivaren betalar extra grundl&#246;n i &#246;vertagesm&#229;naden</span>
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label">Intj&#228;nade semesterdagar (fr&#229;n konsultanst&#228;llningen)</label>
+                    {% if auto_consultant_vacation_days is not none %}
+                    <div class="auto-hint">
+                        Auto-ber&#228;knat: <strong>{{ auto_consultant_vacation_days }} dagar</strong>
+                        <span class="form-hint">Pro-ratat fr&#229;n anst&#228;llningsdagen inom intj&#228;nande&#229;ret</span>
+                    </div>
+                    {% elif transition %}
+                    <div class="auto-hint auto-hint--missing">
+                        Kan inte ber&#228;knas, saknar anst&#228;llningsdatum. Sparad: {{ transition.consultant_vacation_days }} dagar.
+                    </div>
+                    {% endif %}
+                    <label class="form-label" style="margin-top: 0.4rem;">
+                        Manuell override (tomt = anv&#228;nd auto)
+                    </label>
+                    <input type="number" id="consultant_vacation_days" name="consultant_vacation_days" class="form-input"
+                           value="{{ transition.consultant_vacation_days if transition and transition.consultant_vacation_days != auto_consultant_vacation_days else '' }}"
+                           min="0" step="0.5" placeholder="{{ auto_consultant_vacation_days if auto_consultant_vacation_days is not none else '' }}">
+                </div>
+
+                <div class="form-group">
+                    <label for="consultant_supplement_pct" class="form-label">Semestertill&#228;ggsprocent per dag (semesterlagen)</label>
+                    <input type="number" id="consultant_supplement_pct" name="consultant_supplement_pct" class="form-input"
+                           value="{{ transition.consultant_supplement_pct if transition else 0.0043 }}"
+                           min="0" max="0.99" step="0.0001" required>
+                    <span class="form-hint">Minimum 0.0043 (0.43%) per semesterlagen. H&#246;j om arbetsgivaren betalar mer.</span>
+                </div>
+
+                <hr class="form-section-divider">
+                <p class="form-section-title">Intj&#228;nande&#229;r (optionellt)</p>
+
+                <div class="form-group">
+                    <label for="earning_year_start" class="form-label">Start (tomt = auto: 1 april)</label>
+                    <input type="date" id="earning_year_start" name="earning_year_start" class="form-input"
+                           value="{{ transition.earning_year_start.isoformat() if transition and transition.earning_year_start else '' }}">
+                </div>
+
+                <div class="form-group">
+                    <label for="earning_year_end" class="form-label">Slut (tomt = auto: dagen f&#246;re &#246;vertaget)</label>
+                    <input type="date" id="earning_year_end" name="earning_year_end" class="form-input"
+                           value="{{ transition.earning_year_end.isoformat() if transition and transition.earning_year_end else '' }}">
+                </div>
+
+                <hr class="form-section-divider">
+                <p class="form-section-title">R&#246;rlig genomsnittsl&#246;n (optionellt)</p>
+
+                {% if auto_variable_avg is not none %}
+                <div class="auto-hint">
+                    Auto-ber&#228;knat: <strong>{{ "%.2f"|format(auto_variable_avg) }} kr/dag</strong>
+                    <span class="form-hint">OB + beredskap + &#246;vertid fr&#229;n intj&#228;nande&#229;ret / faktiska arbetsdagar</span>
+                </div>
+                {% elif transition %}
+                <div class="auto-hint auto-hint--missing">
+                    Ingen historik hittades, ange manuellt nedan om k&#228;nt.
+                </div>
+                {% endif %}
+
+                <div class="form-group">
+                    <label for="variable_avg_daily_override" class="form-label">Manuell override kr/dag (tomt = anv&#228;nd auto)</label>
+                    <input type="number" id="variable_avg_daily_override" name="variable_avg_daily_override" class="form-input"
+                           value="{{ transition.variable_avg_daily_override if transition and transition.variable_avg_daily_override is not none else '' }}"
+                           min="0" step="0.01"
+                           placeholder="{{ '%.2f'|format(auto_variable_avg) if auto_variable_avg else '' }}">
+                </div>
+
+                <div class="form-group">
+                    <label for="notes" class="form-label">Anteckningar (optionellt)</label>
+                    <textarea id="notes" name="notes" rows="2" class="form-input"
+                              style="padding: 0.5rem; resize: vertical;">{{ transition.notes if transition and transition.notes else '' }}</textarea>
+                </div>
+
+                <hr class="form-section-divider">
+                <p class="form-section-title">Vid sparande (enl&#229;ngs&#229;tg&#228;rder)</p>
+
+                <div class="form-group">
+                    <label for="new_direct_salary" class="form-label">S&#228;tt ny direktl&#246;n fr&#229;n &#246;vertagsdatum (kr/m&#229;nad, tomt = ingen &#228;ndring)</label>
+                    <input type="number" id="new_direct_salary" name="new_direct_salary" class="form-input"
+                           min="1" step="1" placeholder="t.ex. 32000">
+                    <span class="form-hint">Skapar en ny l&#246;nepost i l&#246;nehistoriken med &#246;vertagsdatum som startdatum.</span>
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label">
+                        <input type="checkbox" name="reset_rates_to_default" value="on">
+                        &#197;terg&#229; till standard OB/OT/beredskap-satser fr&#229;n &#246;vertagsdatum
+                    </label>
+                    <span class="form-hint">Skapar en ny satspost med standardv&#228;rden enligt Handelns tj&#228;nstemannaavtal g&#228;llande fr&#229;n &#246;vertagsdatumet.</span>
+                </div>
+
+                <button type="submit" class="btn btn-primary">Spara inst&#228;llningar</button>
+            </form>
+
+            {% if transition %}
+            <hr class="form-section-divider">
+            <form method="POST" action="/profile/transition/delete">
+                <div class="form-group">
+                    <label class="form-label">
+                        <input type="checkbox" name="cleanup_wage" value="on" checked>
+                        Ta &#228;ven bort l&#246;nepost fr&#229;n &#246;vertagsdatumet ({{ transition.transition_date }})
+                    </label>
+                </div>
+                <div class="form-group">
+                    <label class="form-label">
+                        <input type="checkbox" name="cleanup_rates" value="on" checked>
+                        Ta &#228;ven bort satspost fr&#229;n &#246;vertagsdatumet ({{ transition.transition_date }})
+                    </label>
+                </div>
+                <button type="submit" class="btn btn-danger">Ta bort inst&#228;llningar</button>
+            </form>
+            {% endif %}
+        </div>
+    </div>
+
+    {# === Beräkningskort === #}
+    {% if preview %}
+    <div class="col" style="min-width: 320px; flex: 1;">
+        <div class="card">
+            <h3>F&#246;rv&#228;ntad utbetalning: {{ preview.transition_month }}/{{ preview.transition_year }}</h3>
+
+            {# Konsultarbetsgivare #}
+            <div class="transition-employer transition-employer--consultant">
+                <h4>Konsultarbetsgivare</h4>
+
+                {% if preview.consultant_employer.trailing_base %}
+                <div class="transition-row">
+                    <span>Sl&#228;pande grundl&#246;n (sista konsultm&#229;naden)</span>
+                    <strong>{{ "{:,.0f}".format(preview.consultant_employer.trailing_base).replace(",", "\u00a0") }} kr</strong>
+                </div>
+                {% endif %}
+
+                {% if preview.consultant_employer.trailing_variable %}
+                {% set vb = preview.consultant_employer.trailing_variable_breakdown %}
+                <div class="transition-row">
+                    <span>
+                        Sl&#228;pande r&#246;rliga (sista konsultm&#229;naden)
+                        {% if vb %}
+                        <span class="form-hint">OB&#160;{{ "{:,.0f}".format(vb.ob).replace(",","\u00a0") }}&#160;+ beredskap&#160;{{ "{:,.0f}".format(vb.oncall).replace(",","\u00a0") }}{% if vb.ot %} + &#246;vertid&#160;{{ "{:,.0f}".format(vb.ot).replace(",","\u00a0") }}{% endif %} kr</span>
+                        {% endif %}
+                    </span>
+                    <strong>{{ "{:,.0f}".format(preview.consultant_employer.trailing_variable).replace(",", "\u00a0") }} kr</strong>
+                </div>
+                {% endif %}
+
+                {% set vp = preview.consultant_employer.vacation_payout %}
+                <div class="transition-breakdown">
+                    <p class="transition-breakdown__label">Semesterutl&#246;sning ({{ vp.vacation_days }} dagar)</p>
+
+                    <div class="transition-row">
+                        <span>Grundkomponent (l&#246;n&#160;/&#160;21,75&#160;&#215;&#160;{{ "%.4f"|format(1 + vp.supplement_pct) }})</span>
+                        <span>{{ "{:,.0f}".format(vp.base_payout).replace(",", "\u00a0") }} kr</span>
+                    </div>
+
+                    {% if vp.variable_avg_daily %}
+                    <div class="transition-row">
+                        <span>
+                            R&#246;rlig komponent ({{ "%.2f"|format(vp.variable_avg_daily) }} kr/dag
+                            <span class="form-hint">{{ "auto" if vp.variable_auto_calculated else "manuell" }}</span>)
+                        </span>
+                        <span>{{ "{:,.0f}".format(vp.variable_payout).replace(",", "\u00a0") }} kr</span>
+                    </div>
+                    {% else %}
+                    <p class="transition-note">R&#246;rlig komponent: saknas (ingen historik / ej angivet)</p>
+                    {% endif %}
+
+                    <div class="transition-row transition-row--total">
+                        <span>Semesterutl&#246;sning totalt</span>
+                        <span>{{ "{:,.0f}".format(vp.total).replace(",", "\u00a0") }} kr</span>
+                    </div>
+                </div>
+
+                <div class="transition-row transition-row--total">
+                    <span>Totalt fr&#229;n konsultarbetsgivare</span>
+                    <strong>{{ "{:,.0f}".format(preview.consultant_employer.total).replace(",", "\u00a0") }} kr</strong>
+                </div>
+            </div>
+
+            {# Direktarbetsgivare #}
+            <div class="transition-employer transition-employer--direct">
+                <h4>Direktarbetsgivare (ICA)</h4>
+                <div class="transition-row">
+                    <span>Innest&#229;ende grundl&#246;n (&#246;vertagesm&#229;naden)</span>
+                    <strong>{{ "{:,.0f}".format(preview.direct_employer.base_salary).replace(",", "\u00a0") }} kr</strong>
+                </div>
+                <p class="transition-note">&#9432; {{ preview.direct_employer.note_variable }}</p>
+            </div>
+
+            {# Totalt #}
+            <div class="transition-grand-total">
+                <span>Totalt brutto &#246;vertagesm&#229;naden</span>
+                <span>{{ "{:,.0f}".format(preview.grand_total_gross).replace(",", "\u00a0") }} kr</span>
+            </div>
+            <p class="transition-tax-note">
+                Utbetalas som tv&#229; separata nettol&#246;ner, en per arbetsgivare.
+                Skatten hanteras av respektive arbetsgivare.
+                Ev. skatteskillnad regleras i deklarationen.
+            </p>
+        </div>
+    </div>
+    {% endif %}
+
+</div>
+
+{% endblock %}

--- a/app/templates/year.html
+++ b/app/templates/year.html
@@ -59,12 +59,14 @@
             </thead>
             <tbody>
                 {% for m in months_list %}
-                <tr class="shift-row">
+                <tr class="shift-row{% if m.transition_direct %} transition-year-row{% endif %}">
                     <td class="td_center" data-label="Utbetalning">
                         {{ m.payment_date.strftime('%Y-%m-%d') }}
                     </td>
                     <td class="td_center" data-label="Arbetsmånad">
-                        {% if show_salary %}
+                        {% if m.transition_direct %}
+                            <a href="/profile/transition">Direktl&#246;n (&#246;verg.) &#8594;</a>
+                        {% elif show_salary %}
                             <a href="/month/{{ person_id }}?year={{ m.year }}&month={{ m.month }}">
                                 {{ m.year }}-{{ '%02d'|format(m.month) }}
                             </a>

--- a/migrate_add_employment_transition.py
+++ b/migrate_add_employment_transition.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Migration script to create employment_transitions table."""
+
+import sqlite3
+import sys
+from pathlib import Path
+
+
+def migrate(db_path: str = "app/database/schedule.db"):
+    """Create employment_transitions table and ensure all columns exist."""
+    path = Path(db_path)
+    if not path.exists():
+        print(f"Error: Database not found at {path}")
+        sys.exit(1)
+
+    conn = sqlite3.connect(path)
+    cursor = conn.cursor()
+
+    try:
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='employment_transitions'")
+        if not cursor.fetchone():
+            print("Creating employment_transitions table...")
+            cursor.execute("""
+                CREATE TABLE employment_transitions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id INTEGER NOT NULL REFERENCES users(id),
+                    transition_date DATE NOT NULL,
+                    consultant_salary_type VARCHAR(10) NOT NULL,
+                    consultant_vacation_days REAL NOT NULL DEFAULT 0.0,
+                    consultant_supplement_pct REAL NOT NULL DEFAULT 0.0043,
+                    variable_avg_daily_override REAL,
+                    earning_year_start DATE,
+                    earning_year_end DATE,
+                    notes TEXT,
+                    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                    CONSTRAINT uq_employment_transitions_user_id UNIQUE (user_id)
+                )
+            """)
+            cursor.execute("CREATE INDEX idx_employment_transitions_user ON employment_transitions(user_id)")
+            conn.commit()
+            print("Successfully created employment_transitions table.")
+        else:
+            print("Table 'employment_transitions' already exists.")
+
+        # Add advance_vacation_days column if missing (added after initial migration)
+        cursor.execute("PRAGMA table_info(employment_transitions)")
+        columns = [row[1] for row in cursor.fetchall()]
+        if "advance_vacation_days" not in columns:
+            print("Adding column advance_vacation_days...")
+            cursor.execute("ALTER TABLE employment_transitions ADD COLUMN advance_vacation_days INTEGER")
+            conn.commit()
+            print("Column advance_vacation_days added.")
+        else:
+            print("Column advance_vacation_days already exists.")
+
+    except sqlite3.Error as e:
+        print(f"Error during migration: {e}")
+        conn.rollback()
+        sys.exit(1)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("Migration: Create employment_transitions table")
+    print("=" * 60)
+    db = sys.argv[1] if len(sys.argv) > 1 else "app/database/schedule.db"
+    migrate(db)
+    print("\nMigration completed successfully!")


### PR DESCRIPTION
## Summary

- Ny sida `/profile/transition` för att konfigurera övertag från konsult till direktanställning med Handelns tjänstemannaavtal
- Beräkningsmotor för semesterutlösning (sammalöneregeln), rörlig genomsnittslön och övergångsmånadens löneuppdelning per arbetsgivare
- Semesterdagar auto-beräknas från anställningsdatum, förskottssemester hanteras automatiskt från faktisk användning
- Semestersaldo använder övergångsdatum som start för Handels-intjänande
- Årsöversikten visar övergångsmånadens utbetalning som extra tabellrad
- Statistiksidan inkluderar övergångsutbetalning i rätt månad
- Buggfix: off-by-one i intjänandeårsberäkning för övergångar i jan-apr
- Buggfix: övertidstimmar räknades inte in i total_hours i summary