### PR TITLE
Fix week view showing rotation position instead of person name

### DIFF
--- a/app/routes/schedule_personal.py
+++ b/app/routes/schedule_personal.py
@@ -548,10 +548,13 @@ async def show_week_for_person(
 
         user_id_for_wages = person_id
         rotation_position = target_user.rotation_person_id
+        person_name = target_user.name
     else:
         person_id = validate_person_id(person_id)
         user_id_for_wages = person_id
         rotation_position = person_id
+        pos_user = db.query(User).filter(User.person_id == rotation_position, User.is_active == 1).first()
+        person_name = pos_user.name if pos_user else None
 
     safe_today = get_safe_today(rotation_start_date)
     iso_year, iso_week, _ = safe_today.isocalendar()
@@ -586,6 +589,7 @@ async def show_week_for_person(
             "week": week,
             "days": days_in_week,
             "person_id": person_id,
+            "person_name": person_name,
             "today": real_today,
             "storhelg_dates": storhelg_dates,
             "holiday_dates": holiday_dates,

--- a/app/templates/week.html
+++ b/app/templates/week.html
@@ -26,7 +26,7 @@
     </div>
 </div>
 
-<h2 class="page-title">Week {{ week }} {{ year }} - Person {{ person_id }}</h2>
+<h2 class="page-title">Week {{ week }} {{ year }}{% if person_name %} - {{ person_name }}{% endif %}</h2>
 
 {# Calendar grid view for week #}
 {% set weekday_names_short = ['Mån', 'Tis', 'Ons', 'Tor', 'Fre', 'Lör', 'Sön'] %}


### PR DESCRIPTION
## Summary
- `show_week_for_person()` was not passing `person_name` to the template context
- `week.html` was displaying `Person {{ person_id }}` (a rotation position number) instead of the actual name
- Fixes both URL formats: legacy rotation position (`/week/6`) and user_id (`/week/11`)

## Changes
- `schedule_personal.py`: set `person_name = target_user.name` when `person_id > 10`, and look up active user by `User.person_id` for legacy rotation position URLs
- `week.html`: render `{{ person_name }}` with a guard so the dash is omitted when name is unavailable

Closes #153