### PR TITLE
Person history date-aware schedule views

### DIFF
--- a/app/core/schedule/period.py
+++ b/app/core/schedule/period.py
@@ -22,7 +22,7 @@ from .core import (
 )
 from .ob import calculate_ob_hours, get_combined_rules_for_year
 from .overtime import get_overtime_shift_for_date
-from .person_history import get_current_person_for_position
+from .person_history import get_current_person_for_position, get_person_for_date
 from .vacation import get_vacation_dates_for_year
 from .wages import get_all_user_wages
 
@@ -503,19 +503,25 @@ def _build_person_day_basic(
     vacation_shift = get_vacation_shift()
     rotation_length = get_rotation_length_for_date(date)
 
-    # Get person name via PersonHistory (shows current holder of position)
-    # Also check if date is before their employment started
+    # Get person name via PersonHistory (shows correct person for this specific date)
+    # Also check if date is before any person's employment at this position
     person_name = persons[person_id - 1].name  # Default fallback
     show_off_before_employment = False
 
     if session:
-        # Get the current person at this position
-        current_person = get_current_person_for_position(session, person_id)
-        if current_person:
-            person_name = current_person["name"]
-            # Check if date is before this person's employment started
-            if current_person.get("effective_from") and date < current_person["effective_from"]:
-                show_off_before_employment = True
+        # First check who held this position on this specific date
+        date_person = get_person_for_date(session, person_id, date)
+        if date_person:
+            # Someone held this position on this date - use their name, no OFF
+            person_name = date_person["name"]
+        else:
+            # No one held the position on this date - check if there's a future person
+            current_person = get_current_person_for_position(session, person_id)
+            if current_person:
+                person_name = current_person["name"]
+                # Only show OFF if date is before the current person's employment started
+                if current_person.get("effective_from") and date < current_person["effective_from"]:
+                    show_off_before_employment = True
 
     # If date is before current person's employment, show OFF
     if show_off_before_employment:
@@ -719,18 +725,24 @@ def _populate_single_person_day(
     vacation_shift = get_vacation_shift()
     shift_types = get_shift_types()
 
-    # Get person name via PersonHistory (shows current holder of position)
+    # Get person name via PersonHistory (shows correct person for this specific date)
     person_name = persons[person_id - 1].name  # Default fallback
     show_off_before_employment = False
 
     if session:
-        # Get the current person at this position
-        current_person = get_current_person_for_position(session, person_id)
-        if current_person:
-            person_name = current_person["name"]
-            # Check if date is before this person's employment started
-            if current_person.get("effective_from") and current_day < current_person["effective_from"]:
-                show_off_before_employment = True
+        # First check who held this position on this specific date
+        date_person = get_person_for_date(session, person_id, current_day)
+        if date_person:
+            # Someone held this position on this date - use their name, no OFF
+            person_name = date_person["name"]
+        else:
+            # No one held the position on this date - check if there's a future person
+            current_person = get_current_person_for_position(session, person_id)
+            if current_person:
+                person_name = current_person["name"]
+                # Only show OFF if date is before the current person's employment started
+                if current_person.get("effective_from") and current_day < current_person["effective_from"]:
+                    show_off_before_employment = True
 
     # If date is before current person's employment, show OFF
     if show_off_before_employment:

--- a/app/core/schedule/period.py
+++ b/app/core/schedule/period.py
@@ -42,6 +42,7 @@ def build_week_data(
     person_id: int | None = None,
     session=None,
     include_coworkers: bool = False,
+    employment_start: datetime.date | None = None,
 ) -> list[dict]:
     """
     Bygger veckodata för ett år/vecka.
@@ -106,6 +107,7 @@ def build_week_data(
                     absence_map,
                     oncall_override_map,
                     swap_map,
+                    employment_start=employment_start,
                 )
             )
 
@@ -123,6 +125,9 @@ def build_week_data(
 
         # Add coworkers to each day
         for day_info in days_in_week:
+            if day_info.get("before_employment"):
+                day_info["coworkers"] = []
+                continue
             current_date = day_info["date"]
             actual_shift = day_info.get("shift")
 
@@ -503,6 +508,7 @@ def _build_person_day_basic(
     absence_map: dict[tuple[int, datetime.date], object] | None = None,
     oncall_override_map: dict[tuple[int, datetime.date], object] | None = None,
     swap_map: dict[tuple[int, datetime.date], str] | None = None,
+    employment_start: datetime.date | None = None,
 ) -> dict:
     """Bygger grundläggande dagdata för en person."""
     vacation_shift = get_vacation_shift()
@@ -527,6 +533,14 @@ def _build_person_day_basic(
                 # Only show OFF if date is before the current person's employment started
                 if current_person.get("effective_from") and date < current_person["effective_from"]:
                     show_off_before_employment = True
+
+    # Override: if the viewing user hasn't started yet, show before_employment
+    if employment_start and date < employment_start and not show_off_before_employment:
+        if session:
+            current_person = get_current_person_for_position(session, person_id)
+            if current_person:
+                person_name = current_person["name"]
+        show_off_before_employment = True
 
     # If date is before current person's employment, show OFF
     if show_off_before_employment:

--- a/app/core/schedule/period.py
+++ b/app/core/schedule/period.py
@@ -157,6 +157,7 @@ def generate_period_data(
     session=None,
     user_wages: dict[int, int] | None = None,
     user_rates_map: dict[int, dict] | None = None,
+    employment_start: datetime.date | None = None,
 ) -> list[dict]:
     """
     Genererar schemadat för en godtycklig period.
@@ -251,6 +252,7 @@ def generate_period_data(
                 oncall_override_map,
                 swap_map,
                 user_rates_map=user_rates_map,
+                employment_start=employment_start,
             )
 
         days_out.append(day_info)
@@ -279,12 +281,15 @@ def generate_month_data(
     session=None,
     user_wages: dict[int, int] | None = None,
     user_rates_map: dict[int, dict] | None = None,
+    employment_start: datetime.date | None = None,
 ) -> list[dict]:
     """Genererar schemadat för en specifik månad."""
     start_date = datetime.date(year, month, 1)
     last_day = calendar.monthrange(year, month)[1]
     end_date = datetime.date(year, month, last_day)
-    return generate_period_data(start_date, end_date, person_id, session, user_wages, user_rates_map)
+    return generate_period_data(
+        start_date, end_date, person_id, session, user_wages, user_rates_map, employment_start=employment_start
+    )
 
 
 # === Privata hjälpfunktioner ===
@@ -720,6 +725,7 @@ def _populate_single_person_day(
     oncall_override_map: dict[tuple[int, datetime.date], object] | None = None,
     swap_map: dict[tuple[int, datetime.date], str] | None = None,
     user_rates_map: dict[int, dict] | None = None,
+    employment_start: datetime.date | None = None,
 ) -> None:
     """Fyller i detaljerad daginfo för en person."""
     vacation_shift = get_vacation_shift()
@@ -743,6 +749,15 @@ def _populate_single_person_day(
                 # Only show OFF if date is before the current person's employment started
                 if current_person.get("effective_from") and current_day < current_person["effective_from"]:
                     show_off_before_employment = True
+
+    # Override: if the viewing user hasn't started yet, show before_employment
+    # regardless of who held the position historically (e.g., their predecessor)
+    if employment_start and current_day < employment_start and not show_off_before_employment:
+        if session:
+            current_person = get_current_person_for_position(session, person_id)
+            if current_person:
+                person_name = current_person["name"]
+        show_off_before_employment = True
 
     # If date is before current person's employment, show OFF
     if show_off_before_employment:

--- a/app/core/schedule/summary.py
+++ b/app/core/schedule/summary.py
@@ -642,9 +642,10 @@ def summarize_year_for_person(
 
         start_date, end_date = get_employment_period(session, current_user.id, person_id)
 
-        # Filter based on PAYMENT month (not work month) since this view
-        # represents the tax year (deklarationsår) – what matters is when
-        # the salary is paid out, not when the work was performed.
+        # Filter on both WORK month and PAYMENT month:
+        # - Work month must not end before employment start (avoids showing
+        #   predecessor's data when salary is paid on trailing basis)
+        # - Payment month must overlap with employment period (tax year view)
         filtered_months = []
         for m in months:
             pay_year = m["payment_year"]
@@ -653,7 +654,13 @@ def summarize_year_for_person(
             last_day = calendar.monthrange(pay_year, pay_month)[1]
             month_end = dt.date(pay_year, pay_month, last_day)
 
-            # Check if there's ANY overlap between employment period and this month
+            # Skip if work month ended before employment started
+            work_last_day = calendar.monthrange(m["year"], m["month"])[1]
+            work_month_end = dt.date(m["year"], m["month"], work_last_day)
+            if start_date > work_month_end:
+                continue
+
+            # Check if there's ANY overlap between employment period and payment month
             if start_date > month_end:
                 continue
             if end_date and end_date < month_start:

--- a/app/core/schedule/summary.py
+++ b/app/core/schedule/summary.py
@@ -259,6 +259,7 @@ def build_calendar_grid_for_month(
     session=None,
     user_wages: dict[int, int] | None = None,
     include_coworkers: bool = False,
+    employment_start=None,
 ) -> dict:
     """
     Bygger en komplett kalendergrid inklusive intilliggande månaders dagar.
@@ -293,7 +294,9 @@ def build_calendar_grid_for_month(
     grid_end = last_day + timedelta(days=(6 - last_weekday))
 
     # Hämta data för extended range
-    extended_days = generate_period_data(grid_start, grid_end, person_id, session=session, user_wages=user_wages)
+    extended_days = generate_period_data(
+        grid_start, grid_end, person_id, session=session, user_wages=user_wages, employment_start=employment_start
+    )
 
     # Fetch all persons' data if coworkers requested
     all_persons_data = None

--- a/app/core/schedule/transition.py
+++ b/app/core/schedule/transition.py
@@ -45,34 +45,86 @@ def calculate_consultant_vacation_days(
     user: "User",
     transition: "EmploymentTransition",
     full_year_days: int = 25,
+    session=None,
 ) -> int | None:
     """
-    Beräknar pro-ratade semesterdagar intjänade under konsultanställningen.
+    Beräknar netto semesterdagar att betala ut vid konsultanställningens slut.
 
     Formel (semesterlagen §7):
         ceil(full_year_days * anställda_dagar / totala_dagar_i_intjänandeåret)
 
-    Anställda dagar = överlappen mellan employment_start_date och dagen före
-    transition_date inom intjänandeåret.
+    Itererar över ALLA intjänandeår (1 april–31 mars) från employment_start_date
+    till dagen före transition_date. Per intjänandeår räknas:
+        intjänade dagar - använda dagar i motsvarande semesterår (fr.o.m. semesterårets
+        start t.o.m. transition_date - 1)
+
+    Om session anges hämtas faktiskt använda dagar från databasen.
+    Utan session returneras brutto (använda dagar räknas ej av).
+
+    Om transition.earning_year_start/end är manuellt satta används de som ett
+    enda anpassat intjänandeår (bakåtkompatibelt med äldre konfigurationer).
 
     Returns:
-        Antal dagar (avrundat uppåt), eller None om data saknas.
+        Netto antal dagar att betala ut (avrundat uppåt per år), eller None om data saknas.
     """
     if not user.employment_start_date:
         return None
 
-    earning_start, earning_end = get_earning_year(transition)
+    last_day = transition.transition_date - datetime.timedelta(days=1)
 
-    overlap_start = max(user.employment_start_date, earning_start)
-    overlap_end = min(transition.transition_date - datetime.timedelta(days=1), earning_end)
+    # Manual override: single custom earning period (legacy / admin-configured)
+    if transition.earning_year_start and transition.earning_year_end:
+        earning_start = transition.earning_year_start
+        earning_end = transition.earning_year_end
+        overlap_start = max(user.employment_start_date, earning_start)
+        overlap_end = min(last_day, earning_end)
+        if overlap_start > overlap_end:
+            return 0
+        employed_days = (overlap_end - overlap_start).days + 1
+        total_days = (earning_end - earning_start).days + 1
+        return math.ceil(full_year_days * employed_days / total_days)
 
-    if overlap_start > overlap_end:
-        return 0
+    # Auto mode: iterate all April–March earning years from employment start to transition
+    from app.core.schedule.vacation import count_vacation_days_used
 
-    employed_days = (overlap_end - overlap_start).days + 1
-    total_days = (earning_end - earning_start).days + 1
+    employment_start = user.employment_start_date
+    april_year = employment_start.year if employment_start.month >= 4 else employment_start.year - 1
+    current_april = datetime.date(april_year, 4, 1)
 
-    return math.ceil(full_year_days * employed_days / total_days)
+    total = 0
+    while current_april <= last_day:
+        next_april = datetime.date(current_april.year + 1, 4, 1)
+        full_year_end = next_april - datetime.timedelta(days=1)  # 31 mars
+
+        period_end = min(full_year_end, last_day)
+        overlap_start = max(employment_start, current_april)
+
+        if overlap_start <= period_end:
+            employed_days = (period_end - overlap_start).days + 1
+            total_days = (full_year_end - current_april).days + 1
+            earned = math.ceil(full_year_days * employed_days / total_days)
+
+            # Deduct vacation days used in the corresponding vacation year (earning year + 1 year)
+            # up to (but not including) the transition date
+            used = 0
+            if session and earned > 0:
+                vac_year_start = next_april  # Semesteråret börjar månaden efter intjänandeårets slut
+                vac_year_end = min(last_day, datetime.date(next_april.year + 1, 4, 1) - datetime.timedelta(days=1))
+                if vac_year_start <= vac_year_end:
+                    used_data = count_vacation_days_used(
+                        user_id=user.id,
+                        year_start=vac_year_start,
+                        year_end=vac_year_end,
+                        db=session,
+                        vacation_json=user.vacation,
+                    )
+                    used = used_data["total"]
+
+            total += max(0, earned - used)
+
+        current_april = next_april
+
+    return total
 
 
 def _iter_months(start: datetime.date, end: datetime.date) -> list[tuple[int, int]]:
@@ -211,7 +263,9 @@ def calculate_consultant_vacation_payout(
     from app.core.schedule.wages import get_user_wage
 
     earning_start, earning_end = get_earning_year(transition)
-    days = transition.consultant_vacation_days
+    # Always dynamically calculate net vacation days (earned minus already used before transition)
+    # so the payout reflects the actual state at the time of calculation.
+    days = calculate_consultant_vacation_days(user, transition, session=session) or 0
     supplement_pct = transition.consultant_supplement_pct
 
     # Konsultlön: lönen dagen innan övergången (från WageHistory eller User.wage)

--- a/app/routes/admin_users.py
+++ b/app/routes/admin_users.py
@@ -132,7 +132,7 @@ async def admin_edit_user_page(
         if edit_transition.variable_avg_daily_override is None:
             earning_start, earning_end = get_earning_year(edit_transition)
             admin_auto_variable_avg = calculate_variable_avg_daily(edit_user, db, earning_start, earning_end)
-        admin_auto_vacation_days = calculate_consultant_vacation_days(edit_user, edit_transition)
+        admin_auto_vacation_days = calculate_consultant_vacation_days(edit_user, edit_transition, session=db)
 
     return render(
         "admin_user_edit.html",
@@ -579,7 +579,7 @@ async def admin_transition_save(
             earning_year_start=None,
             earning_year_end=None,
         )
-        parsed_vacation_days = float(calculate_consultant_vacation_days(edit_user, temp) or 0)
+        parsed_vacation_days = float(calculate_consultant_vacation_days(edit_user, temp, session=db) or 0)
 
     variable_override: float | None = None
     if variable_avg_daily_override.strip():
@@ -690,6 +690,26 @@ async def admin_transition_delete(
                 RateHistory.user_id == user_id,
                 RateHistory.effective_from == t_date,
             ).delete()
+            # Reopen the previous rate entry that was closed when the transition was created
+            prev_rate = (
+                db.query(RateHistory)
+                .filter(
+                    RateHistory.user_id == user_id,
+                    RateHistory.effective_to == t_date - datetime.timedelta(days=1),
+                )
+                .first()
+            )
+            if prev_rate:
+                later = (
+                    db.query(RateHistory)
+                    .filter(
+                        RateHistory.user_id == user_id,
+                        RateHistory.effective_from > prev_rate.effective_from,
+                    )
+                    .first()
+                )
+                if not later:
+                    prev_rate.effective_to = None
         db.delete(transition)
         try:
             db.commit()

--- a/app/routes/schedule_all.py
+++ b/app/routes/schedule_all.py
@@ -169,6 +169,19 @@ async def show_year_all(
     # This makes initial page load much faster (~0.5s instead of 1-3s)
     person_ob_totals = None
 
+    # Build person headers using current active holder for each position
+    # (days[0] would show whoever held the position on the first day of rotation,
+    # which can be a predecessor rather than the current person)
+    from app.core.schedule.person_history import get_current_person_for_position
+
+    person_headers = [
+        {
+            "person_id": pid,
+            "person_name": (cp["name"] if (cp := get_current_person_for_position(db, pid)) else f"Person {pid}"),
+        }
+        for pid in range(1, 11)
+    ]
+
     show_salary = current_user is not None and current_user.role == UserRole.ADMIN
 
     # Calculate and log load time
@@ -191,6 +204,7 @@ async def show_year_all(
             "year": year,
             "days": days_in_year,
             "person_ob_totals": person_ob_totals,
+            "person_headers": person_headers,
             "show_salary": show_salary,
             "storhelg_dates": storhelg_dates,
             "holiday_dates": holiday_dates,

--- a/app/routes/schedule_personal.py
+++ b/app/routes/schedule_personal.py
@@ -103,18 +103,26 @@ async def show_day_for_person(
     original_shift = shift  # Keep track of original shift for OC calculation
 
     # Check if date is before user's employment started - show OFF if so
-    from app.core.schedule.person_history import get_current_person_for_position
+    from app.core.schedule.person_history import get_current_person_for_position, get_employment_period
 
-    current_person = get_current_person_for_position(db, rotation_position)
-    if current_person and current_person.get("effective_from"):
-        if date_obj < current_person["effective_from"]:
-            # Change shift to OFF
-            from app.core.storage import load_shift_types
+    before_employment = False
+    if person_id > 10:
+        emp_start, _ = get_employment_period(db, target_user.id, rotation_position)
+        if emp_start and date_obj < emp_start:
+            before_employment = True
+    else:
+        current_person = get_current_person_for_position(db, rotation_position)
+        if current_person and current_person.get("effective_from"):
+            if date_obj < current_person["effective_from"]:
+                before_employment = True
 
-            all_shifts = load_shift_types()
-            off_shift = next((s for s in all_shifts if s.code == "OFF"), None)
-            if off_shift:
-                shift = off_shift
+    if before_employment:
+        from app.core.storage import load_shift_types
+
+        all_shifts = load_shift_types()
+        off_shift = next((s for s in all_shifts if s.code == "OFF"), None)
+        if off_shift:
+            shift = off_shift
 
     # Fetch oncall override EARLY to apply before hours calculation
     # Use user_id_for_wages since oncall overrides are stored per user
@@ -502,8 +510,9 @@ async def show_day_for_person(
             "absence_deduction": absence_deduction,  # Deduction amount in SEK
             "absence_shift_hours": absence_shift_hours,  # Hours for the shift
             "is_karens": is_karens,  # Whether this is a karensdag
-            "coworkers": coworkers,  # List of coworker names
-            "all_working_persons": persons_today_with_shift,
+            "before_employment": before_employment,
+            "coworkers": coworkers if not before_employment else [],
+            "all_working_persons": persons_today_with_shift if not before_employment else [],
             "swap_users": [
                 u
                 for u in db.query(User)
@@ -567,7 +576,22 @@ async def show_week_for_person(
             return redirect
 
     # Use rotation_position for schedule calculation
-    days_in_week = build_week_data(year, week, person_id=rotation_position, session=db, include_coworkers=True)
+    # For user_id lookups, pass employment start so before-employment days show correctly
+    week_employment_start = None
+    if person_id > 10:
+        from app.core.schedule.person_history import get_employment_period
+
+        week_emp_start, _ = get_employment_period(db, target_user.id, rotation_position)
+        week_employment_start = week_emp_start
+
+    days_in_week = build_week_data(
+        year,
+        week,
+        person_id=rotation_position,
+        session=db,
+        include_coworkers=True,
+        employment_start=week_employment_start,
+    )
 
     monday = date.fromisocalendar(year, week, 1)
     nav = get_navigation_dates("week", monday)

--- a/app/routes/schedule_personal.py
+++ b/app/routes/schedule_personal.py
@@ -655,8 +655,21 @@ async def show_month_for_person(
                 person_name = holder.name if holder else person_list[rotation_position - 1].name
 
     # Use rotation_position for schedule calculation
+    # For user_id lookups, pass the user's employment start so dates before it show as before_employment
+    viewer_employment_start = None
+    if person_id > 10:
+        from app.core.schedule.person_history import get_employment_period
+
+        emp_start, _ = get_employment_period(db, target_user.id, rotation_position)
+        viewer_employment_start = emp_start
+
     calendar_data = build_calendar_grid_for_month(
-        year, month, person_id=rotation_position, session=db, include_coworkers=True
+        year,
+        month,
+        person_id=rotation_position,
+        session=db,
+        include_coworkers=True,
+        employment_start=viewer_employment_start,
     )
     days_in_month = calendar_data["summary"]
     calendar_grid = calendar_data["grid"]
@@ -704,6 +717,14 @@ async def show_month_for_person(
                 except Exception:
                     pass
 
+    # Hide summary stats if the entire month is before the viewer's employment start
+    import calendar as _cal_mod
+    from datetime import date as _date
+
+    before_employment_month = viewer_employment_start is not None and viewer_employment_start > _date(
+        year, month, _cal_mod.monthrange(year, month)[1]
+    )
+
     return render_template(
         templates,
         "month.html",
@@ -719,6 +740,7 @@ async def show_month_for_person(
             "storhelg_dates": storhelg_dates,
             "holiday_dates": holiday_dates,
             "vacation_month": vacation_month,
+            "before_employment_month": before_employment_month,
         },
         user=current_user,
     )

--- a/app/routes/transition.py
+++ b/app/routes/transition.py
@@ -42,7 +42,7 @@ def _get_transition_context(
         earning_start, earning_end = get_earning_year(transition)
         if transition.variable_avg_daily_override is None:
             auto_variable_avg = calculate_variable_avg_daily(user, db, earning_start, earning_end)
-        auto_consultant_vacation_days = calculate_consultant_vacation_days(user, transition)
+        auto_consultant_vacation_days = calculate_consultant_vacation_days(user, transition, session=db)
         try:
             preview = calculate_transition_month_summary(transition, user, db)
         except Exception:
@@ -150,7 +150,7 @@ async def transition_save(
             earning_year_start=earning_start,
             earning_year_end=earning_end,
         )
-        parsed_vacation_days = float(calculate_consultant_vacation_days(current_user, temp) or 0)
+        parsed_vacation_days = float(calculate_consultant_vacation_days(current_user, temp, session=db) or 0)
 
     salary_type = ConsultantSalaryType(consultant_salary_type)
 
@@ -248,6 +248,26 @@ async def transition_delete(
                 RateHistory.user_id == current_user.id,
                 RateHistory.effective_from == t_date,
             ).delete()
+            # Reopen the previous rate entry that was closed when the transition was created
+            prev_rate = (
+                db.query(RateHistory)
+                .filter(
+                    RateHistory.user_id == current_user.id,
+                    RateHistory.effective_to == t_date - datetime.timedelta(days=1),
+                )
+                .first()
+            )
+            if prev_rate:
+                later = (
+                    db.query(RateHistory)
+                    .filter(
+                        RateHistory.user_id == current_user.id,
+                        RateHistory.effective_from > prev_rate.effective_from,
+                    )
+                    .first()
+                )
+                if not later:
+                    prev_rate.effective_to = None
         db.delete(transition)
         try:
             db.commit()

--- a/app/templates/month.html
+++ b/app/templates/month.html
@@ -48,7 +48,8 @@
 <h2 class="page-title">{{ t.month_page_title.replace('{month}', month|string).replace('{year}', year|string).replace('{name}', person_name) }}</h2>
 
 
-    {# Summary row - visa bara lönedata om show_salary #}
+    {# Summary row - visa bara lönedata om show_salary, dölj helt om månaden är före anställningsstart #}
+    {% if not before_employment_month %}
     <table class="summary">
         {% if show_salary %}
         <thead>
@@ -100,6 +101,7 @@
         <span style="color: var(--muted);">({{ "%.0f"|format(vacation_month.supplement_per_day) }} kr/dag)</span>
     </div>
     {% endif %}
+    {% endif %}{# /before_employment_month #}
 
     {# Calendar grid view #}
     {% set weekday_names_short = t.week_day_names | from_json %}

--- a/app/templates/year_all.html
+++ b/app/templates/year_all.html
@@ -34,36 +34,32 @@
                     <tr id="totals-row">
                         <th></th>
                         <th></th>
-                        {% if days and days|length > 0 %}
-                            {% for p in days[0].persons %}
-                                <th class="num" id="total-{{ p.person_id }}">
-                                    <span class="loading-spinner" style="color: #999; font-size: 0.9em;">...</span>
-                                </th>
-                            {% endfor %}
-                        {% endif %}
+                        {% for p in person_headers %}
+                            <th class="num" id="total-{{ p.person_id }}">
+                                <span class="loading-spinner" style="color: #999; font-size: 0.9em;">...</span>
+                            </th>
+                        {% endfor %}
                     </tr>
                 {% endif %}
                 <tr>
                     <th class="w-md">{{ t.month_all_day_col }}</th>
                     <th class="w-lg">{{ t.month_all_date_col }}</th>
-                    {% if days and days|length > 0 %}
-                        {% for p in days[0].persons %}
-                            <th class="person-header">
-                                {# Länka bara till egen sida eller om admin #}
-                                {% if user and (user.role.value == 'admin' or user.rotation_person_id == p.person_id) %}
-                                    {# Om det är användarens egen position, länka till user.id, annars person_id #}
-                                    {% set link_id = user.id if user.rotation_person_id == p.person_id else p.person_id %}
-                                    <a href="/year/{{ link_id }}?year={{ year }}">
-                                        {{ p.person_name }}<br>
-                                        <small>(#{{ p.person_id }})</small>
-                                    </a>
-                                {% else %}
+                    {% for p in person_headers %}
+                        <th class="person-header">
+                            {# Länka bara till egen sida eller om admin #}
+                            {% if user and (user.role.value == 'admin' or user.rotation_person_id == p.person_id) %}
+                                {# Om det är användarens egen position, länka till user.id, annars person_id #}
+                                {% set link_id = user.id if user.rotation_person_id == p.person_id else p.person_id %}
+                                <a href="/year/{{ link_id }}?year={{ year }}">
                                     {{ p.person_name }}<br>
                                     <small>(#{{ p.person_id }})</small>
-                                {% endif %}
-                            </th>
-                        {% endfor %}
-                    {% endif %}
+                                </a>
+                            {% else %}
+                                {{ p.person_name }}<br>
+                                <small>(#{{ p.person_id }})</small>
+                            {% endif %}
+                        </th>
+                    {% endfor %}
                 </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
## Summary

- **Date-aware person lookup**: Schedule generation now uses `get_person_for_date` as primary lookup so each day shows whoever actually held that rotation position on that specific date (e.g. predecessor shows correctly in month_all for months before the new person started)
- **Before-employment views**: Month, week, day and year personal views now detect when the viewing user hasn't started yet and show before-employment OFF instead of the predecessor's data. Summary stats, salary rows and coworker lists are hidden for those periods.
- **Year view work-month filter**: The trailing salary model caused a predecessor's work month to appear in the new employee's year summary. Added a work-month check alongside the existing payment-month filter.
- **Consultant vacation calculation**: Iterates all April-March earning years from employment start to transition date; uses full year length as denominator per semesterlagen §7; deducts already-used vacation days per corresponding vacation year.
- **Dynamic vacation payout**: `calculate_consultant_vacation_payout` now always calculates net days dynamically instead of relying on the stored `consultant_vacation_days` field.
- **Rate history cleanup**: Deleting a transition now reopens the previous rate history entry (clears its `effective_to`) when the deleted rates were the only newer entry.
- **Year_all header names**: Header now uses `get_current_person_for_position` so it always shows the currently active holder rather than whoever held the position on the first day of the rotation.

## Test plan

- [x] `/month?year=2026&month=3` shows predecessor's schedule (not OFF) for positions with mid-year transitions
- [x] `/month/12?year=2026&month=3` shows OFF with no salary summary for a user starting 2026-04-01
- [x] `/week/12?year=2026&week=12` shows all days as OFF with no coworkers
- [x] `/day/12/2026/3/19` shows OFF with no "Working with" entries
- [x] `/year/12?year=2026` excludes the predecessor's work months from the summary table
- [x] `/year?year=2026` header shows current active holders for all positions
- [x] Transition page: vacation days auto-calculated correctly across multiple earning years with used days deducted
- [x] Deleting a transition with rate cleanup reopens the previous rate entry