### PR TITLE
Add partial-day absence and fix user_id/rotation mismatch in batch fetches

### DIFF
--- a/app/core/schedule/period.py
+++ b/app/core/schedule/period.py
@@ -570,9 +570,34 @@ def _build_person_day_basic(
         absence = session.query(Absence).filter(Absence.user_id == person_id, Absence.date == date).first()
 
     if absence:
-        # VACATION absences use the SEM shift (same as week-based vacation)
         from app.database.database import AbsenceType
 
+        # Partiell frånvaro: visa originalskiftet men med trunkerad sluttid
+        if absence.left_at is not None and absence.absence_type != AbsenceType.VACATION:
+            result = determine_shift_for_date(date, person_id)
+            if result and result[0]:
+                original_shift, rotation_week = result
+                hours, start, end = calculate_shift_hours(date, original_shift.code)
+                if start is not None and absence.left_at:
+                    left_time = datetime.datetime.strptime(absence.left_at, "%H:%M").time()
+                    end = datetime.datetime.combine(date, left_time)
+                    if end <= start:
+                        end = start  # säkerhetsventil
+                    hours = (end - start).total_seconds() / 3600.0
+                return {
+                    "person_id": person_id,
+                    "person_name": person_name,
+                    "shift": original_shift,
+                    "original_shift": original_shift,
+                    "rotation_week": rotation_week,
+                    "rotation_length": rotation_length,
+                    "hours": hours,
+                    "start": start,
+                    "end": end,
+                    "partial_absence": absence,
+                }
+
+        # VACATION absences use the SEM shift (same as week-based vacation)
         if absence.absence_type == AbsenceType.VACATION:
             absence_shift = vacation_shift
         else:
@@ -809,9 +834,46 @@ def _populate_single_person_day(
         absence = session.query(Absence).filter(Absence.user_id == person_id, Absence.date == current_day).first()
 
     if absence:
-        # VACATION absences use the SEM shift (same as week-based vacation)
         from app.database.database import AbsenceType
 
+        # Partiell frånvaro: beräkna OB och timmar för jobbad del av passet
+        if absence.left_at is not None and absence.absence_type != AbsenceType.VACATION:
+            result = determine_shift_for_date(current_day, person_id)
+            if result and result[0]:
+                original_shift, rotation_week = result
+                hours, start, end = calculate_shift_hours(current_day, original_shift.code)
+                if start is not None and absence.left_at:
+                    left_time = datetime.datetime.strptime(absence.left_at, "%H:%M").time()
+                    end = datetime.datetime.combine(current_day, left_time)
+                    if end <= start:
+                        end = start
+                    hours = (end - start).total_seconds() / 3600.0
+                    ob = calculate_ob_hours(start, end, combined_ob_rules) if original_shift.code != "OC" else {}
+                else:
+                    ob = {}
+
+                day_info.update(
+                    {
+                        "person_id": person_id,
+                        "person_name": person_name,
+                        "shift": original_shift,
+                        "original_shift": original_shift,
+                        "rotation_week": rotation_week,
+                        "hours": hours,
+                        "start": start,
+                        "end": end,
+                        "ob": ob,
+                        "oncall_pay": 0.0,
+                        "oncall_details": {},
+                        "ot_pay": 0.0,
+                        "ot_hours": 0.0,
+                        "ot_details": {},
+                        "partial_absence": absence,
+                    }
+                )
+                return
+
+        # VACATION absences use the SEM shift (same as week-based vacation)
         if absence.absence_type == AbsenceType.VACATION:
             absence_shift = vacation_shift
         else:

--- a/app/core/schedule/period.py
+++ b/app/core/schedule/period.py
@@ -62,11 +62,13 @@ def build_week_data(
     persons = _get_persons()
     shift_types = get_shift_types()
 
+    rotation_to_user_id = _build_rotation_to_user_map(session, person_ids)
+
     # Batch fetch absences, overtime, oncall overrides, and swaps for the week
-    absence_map = _batch_fetch_absences(session, person_ids, monday, sunday)
-    ot_shift_map = _batch_fetch_ot_shifts(session, person_ids, monday, sunday)
-    oncall_override_map = _batch_fetch_oncall_overrides(session, person_ids, monday, sunday)
-    swap_map = _batch_fetch_swap_map(session, person_ids, monday, sunday)
+    absence_map = _batch_fetch_absences(session, person_ids, monday, sunday, rotation_to_user_id)
+    ot_shift_map = _batch_fetch_ot_shifts(session, person_ids, monday, sunday, rotation_to_user_id)
+    oncall_override_map = _batch_fetch_oncall_overrides(session, person_ids, monday, sunday, rotation_to_user_id)
+    swap_map = _batch_fetch_swap_map(session, person_ids, monday, sunday, rotation_to_user_id)
 
     days_in_week = []
 
@@ -206,11 +208,16 @@ def generate_period_data(
     # Förbered person-lista
     person_ids = [person_id] if person_id is not None else list(PERSON_IDS)
 
+    # Bygg mappning rotation_position -> user_id (hanterar Peter/Rickard som har olika user_id)
+    rotation_to_user_id = _build_rotation_to_user_map(session, person_ids)
+
     # Batch fetch absences, overtime shifts, oncall overrides, and swaps for the entire period
-    absence_map = _batch_fetch_absences(session, person_ids, effective_start, end_date)
-    ot_shift_map = _batch_fetch_ot_shifts(session, person_ids, effective_start, end_date)
-    oncall_override_map = _batch_fetch_oncall_overrides(session, person_ids, effective_start, end_date)
-    swap_map = _batch_fetch_swap_map(session, person_ids, effective_start, end_date)
+    absence_map = _batch_fetch_absences(session, person_ids, effective_start, end_date, rotation_to_user_id)
+    ot_shift_map = _batch_fetch_ot_shifts(session, person_ids, effective_start, end_date, rotation_to_user_id)
+    oncall_override_map = _batch_fetch_oncall_overrides(
+        session, person_ids, effective_start, end_date, rotation_to_user_id
+    )
+    swap_map = _batch_fetch_swap_map(session, person_ids, effective_start, end_date, rotation_to_user_id)
 
     # Generera dagdata
     persons = _get_persons()
@@ -323,36 +330,60 @@ def _load_vacation_dates(years: set[int]) -> dict[int, set[datetime.date]]:
     return vacation_dates
 
 
+def _build_rotation_to_user_map(session, rotation_positions: list[int]) -> dict[int, int]:
+    """
+    Bygger mappning rotation_position -> user_id för användare där de skiljer sig.
+    Returnerar rotation_position -> rotation_position som fallback om ingen match.
+    """
+    result = {p: p for p in rotation_positions}
+    if not session:
+        return result
+    from app.database.database import User
+
+    users = session.query(User).filter(User.person_id.in_(rotation_positions)).all()
+    for u in users:
+        if u.person_id is not None:
+            result[u.person_id] = u.id
+    return result
+
+
 def _batch_fetch_absences(
     session,
     person_ids: list[int],
     start_date: datetime.date,
     end_date: datetime.date,
+    rotation_to_user_id: dict[int, int] | None = None,
 ) -> dict[tuple[int, datetime.date], object]:
     """
     Batch-hämtar frånvaro för flera personer och en period.
 
     Returns:
-        Dict med (person_id, date) -> Absence
+        Dict med (rotation_position, date) -> Absence
     """
     if not session:
         return {}
 
     from app.database.database import Absence
 
-    # Hämta alla frånvaro för alla personer i perioden
+    # Hämta faktiska user_ids (kan skilja sig från rotationsposition)
+    if rotation_to_user_id:
+        user_ids = list({rotation_to_user_id.get(p, p) for p in person_ids})
+        user_id_to_rotation = {v: k for k, v in rotation_to_user_id.items()}
+    else:
+        user_ids = person_ids
+        user_id_to_rotation = {}
+
     absences = (
         session.query(Absence)
         .filter(
-            Absence.user_id.in_(person_ids),
+            Absence.user_id.in_(user_ids),
             Absence.date >= start_date,
             Absence.date <= end_date,
         )
         .all()
     )
 
-    # Skapa lookup-dict
-    return {(absence.user_id, absence.date): absence for absence in absences}
+    return {(user_id_to_rotation.get(a.user_id, a.user_id), a.date): a for a in absences}
 
 
 def _batch_fetch_ot_shifts(
@@ -360,34 +391,40 @@ def _batch_fetch_ot_shifts(
     person_ids: list[int],
     start_date: datetime.date,
     end_date: datetime.date,
+    rotation_to_user_id: dict[int, int] | None = None,
 ) -> dict[tuple[int, datetime.date], object]:
     """
     Batch-hämtar övertidspass för flera personer och en period.
 
     Returns:
-        Dict med (person_id, date) -> OvertimeShift
+        Dict med (rotation_position, date) -> OvertimeShift
     """
     if not session:
         return {}
 
     from app.database.database import OvertimeShift
 
+    if rotation_to_user_id:
+        user_ids = list({rotation_to_user_id.get(p, p) for p in person_ids})
+        user_id_to_rotation = {v: k for k, v in rotation_to_user_id.items()}
+    else:
+        user_ids = person_ids
+        user_id_to_rotation = {}
+
     # Hämta också dagen före start_date för att fånga OT som går över midnatt
     fetch_start = start_date - datetime.timedelta(days=1)
 
-    # Hämta alla OT-pass för alla personer i perioden
     ot_shifts = (
         session.query(OvertimeShift)
         .filter(
-            OvertimeShift.user_id.in_(person_ids),
+            OvertimeShift.user_id.in_(user_ids),
             OvertimeShift.date >= fetch_start,
             OvertimeShift.date <= end_date,
         )
         .all()
     )
 
-    # Skapa lookup-dict
-    return {(shift.user_id, shift.date): shift for shift in ot_shifts}
+    return {(user_id_to_rotation.get(s.user_id, s.user_id), s.date): s for s in ot_shifts}
 
 
 def _batch_fetch_oncall_overrides(
@@ -395,31 +432,37 @@ def _batch_fetch_oncall_overrides(
     person_ids: list[int],
     start_date: datetime.date,
     end_date: datetime.date,
+    rotation_to_user_id: dict[int, int] | None = None,
 ) -> dict[tuple[int, datetime.date], object]:
     """
     Batch-hämtar on-call overrides för flera personer och en period.
 
     Returns:
-        Dict med (person_id, date) -> OnCallOverride
+        Dict med (rotation_position, date) -> OnCallOverride
     """
     if not session:
         return {}
 
     from app.database.database import OnCallOverride
 
-    # Hämta alla overrides för alla personer i perioden
+    if rotation_to_user_id:
+        user_ids = list({rotation_to_user_id.get(p, p) for p in person_ids})
+        user_id_to_rotation = {v: k for k, v in rotation_to_user_id.items()}
+    else:
+        user_ids = person_ids
+        user_id_to_rotation = {}
+
     overrides = (
         session.query(OnCallOverride)
         .filter(
-            OnCallOverride.user_id.in_(person_ids),
+            OnCallOverride.user_id.in_(user_ids),
             OnCallOverride.date >= start_date,
             OnCallOverride.date <= end_date,
         )
         .all()
     )
 
-    # Skapa lookup-dict
-    return {(override.user_id, override.date): override for override in overrides}
+    return {(user_id_to_rotation.get(o.user_id, o.user_id), o.date): o for o in overrides}
 
 
 def _batch_fetch_swap_map(
@@ -427,28 +470,31 @@ def _batch_fetch_swap_map(
     person_ids: list[int],
     start_date: datetime.date,
     end_date: datetime.date,
+    rotation_to_user_id: dict[int, int] | None = None,
 ) -> dict[tuple[int, datetime.date], str]:
     """
     Batch-hämtar accepterade skiftbyten för flera personer och en period.
 
     Returns:
-        Dict med (person_id, date) -> new_shift_code
-        Each accepted swap produces two entries:
-        - (requester_id, requester_date) -> target_shift_code
-        - (target_id, target_date) -> requester_shift_code
+        Dict med (rotation_position, date) -> new_shift_code
     """
     if not session:
         return {}
 
-    from app.database.database import ShiftSwap, SwapStatus
+    from app.database.database import ShiftSwap, SwapStatus, User
 
-    # A swap affects both people on both dates, so we need swaps where:
-    # - either person is in our person_ids AND either date is in our range
+    if rotation_to_user_id:
+        user_ids = list({rotation_to_user_id.get(p, p) for p in person_ids})
+        user_id_to_rotation = {v: k for k, v in rotation_to_user_id.items()}
+    else:
+        user_ids = person_ids
+        user_id_to_rotation = {}
+
     swaps = (
         session.query(ShiftSwap)
         .filter(
             ShiftSwap.status == SwapStatus.ACCEPTED,
-            (ShiftSwap.requester_id.in_(person_ids) | ShiftSwap.target_id.in_(person_ids)),
+            (ShiftSwap.requester_id.in_(user_ids) | ShiftSwap.target_id.in_(user_ids)),
             (
                 ShiftSwap.requester_date.between(start_date, end_date)
                 | ShiftSwap.target_date.between(start_date, end_date)
@@ -457,42 +503,39 @@ def _batch_fetch_swap_map(
         .all()
     )
 
-    # Build user_id → rotation_person_id mapping for shift lookups
-    from app.database.database import User
-
-    all_user_ids = set()
+    # Build full user_id -> rotation_person_id mapping for all swap participants
+    all_swap_user_ids = set()
     for swap in swaps:
-        all_user_ids.update([swap.requester_id, swap.target_id])
-    user_rotation = {}
-    if all_user_ids:
-        for u in session.query(User).filter(User.id.in_(all_user_ids)).all():
-            user_rotation[u.id] = u.rotation_person_id
+        all_swap_user_ids.update([swap.requester_id, swap.target_id])
+    user_rotation = dict(user_id_to_rotation)  # start from known mappings
+    if all_swap_user_ids:
+        for u in session.query(User).filter(User.id.in_(all_swap_user_ids)).all():
+            if u.id not in user_rotation:
+                user_rotation[u.id] = u.person_id if u.person_id else u.id
 
-    pid_set = set(person_ids)
+    rotation_set = set(person_ids)
     swap_map = {}
     for swap in swaps:
         req_rot = user_rotation.get(swap.requester_id, swap.requester_id)
         tgt_rot = user_rotation.get(swap.target_id, swap.target_id)
 
         # On requester_date: they swap shifts
-        if swap.requester_id in pid_set:
+        if req_rot in rotation_set:
             # Requester gets what target normally has on this date
             tgt_result = determine_shift_for_date(swap.requester_date, tgt_rot)
-            swap_map[(swap.requester_id, swap.requester_date)] = (
-                tgt_result[0].code if tgt_result and tgt_result[0] else "OFF"
-            )
-        if swap.target_id in pid_set:
+            swap_map[(req_rot, swap.requester_date)] = tgt_result[0].code if tgt_result and tgt_result[0] else "OFF"
+        if tgt_rot in rotation_set:
             # Target gets requester's shift on this date
-            swap_map[(swap.target_id, swap.requester_date)] = swap.requester_shift_code or "OFF"
+            swap_map[(tgt_rot, swap.requester_date)] = swap.requester_shift_code or "OFF"
 
         # On target_date: they swap shifts
-        if swap.target_id in pid_set:
+        if tgt_rot in rotation_set:
             # Target gets what requester normally has on this date
             req_result = determine_shift_for_date(swap.target_date, req_rot)
-            swap_map[(swap.target_id, swap.target_date)] = req_result[0].code if req_result and req_result[0] else "OFF"
-        if swap.requester_id in pid_set:
+            swap_map[(tgt_rot, swap.target_date)] = req_result[0].code if req_result and req_result[0] else "OFF"
+        if req_rot in rotation_set:
             # Requester gets target's shift on this date
-            swap_map[(swap.requester_id, swap.target_date)] = swap.target_shift_code or "OFF"
+            swap_map[(req_rot, swap.target_date)] = swap.target_shift_code or "OFF"
 
     return swap_map
 

--- a/app/core/schedule/summary.py
+++ b/app/core/schedule/summary.py
@@ -322,6 +322,7 @@ def build_calendar_grid_for_month(
             "end": day.get("end"),
             "weekday_name": day.get("weekday_name"),
             "is_current_month": is_current_month,
+            "partial_absence": day.get("partial_absence"),
         }
 
         # Add coworkers if requested

--- a/app/core/schedule/wages.py
+++ b/app/core/schedule/wages.py
@@ -1,6 +1,7 @@
 """Lönehantering från databas."""
 
-from datetime import date
+import datetime
+from datetime import date, timedelta
 
 from sqlalchemy.orm import Session
 
@@ -115,8 +116,16 @@ def get_all_user_wages(session) -> dict[int, int]:
     return wages
 
 
+KARENS_HOURS = 8.0  # Total karensbudget per sjukperiod (= 20% av normal arbetsvecka)
+
+
 def calculate_absence_deduction(
-    monthly_wage: int, absence_type: str, shift_hours: float = 8.5, is_first_sick_day: bool = False
+    monthly_wage: int,
+    absence_type: str,
+    shift_hours: float = 8.5,
+    is_first_sick_day: bool = False,
+    absent_hours: float | None = None,
+    karens_remaining: float | None = None,
 ) -> float:
     """
     Beräknar löneavdrag för frånvaro baserat på timmar.
@@ -124,78 +133,162 @@ def calculate_absence_deduction(
     Args:
         monthly_wage: Månadslön i SEK
         absence_type: Typ av frånvaro (SICK, VAB, LEAVE, OFF)
-        shift_hours: Antal timmar för skiftet (default 8.5)
-        is_first_sick_day: Om det är första sjukdagen (karensdag)
+        shift_hours: Antal timmar för skiftet (default 8.5), används om absent_hours saknas
+        is_first_sick_day: Om det är första sjukdagen (används om karens_remaining saknas)
+        absent_hours: Faktiska frånvarotimmar vid partiell dag (None = heldag = shift_hours)
+        karens_remaining: Återstående karenstimmar i sjukperioden (None = beräkna från is_first_sick_day)
 
     Returns:
         Avdrag i SEK
 
     Regler:
-        - SICK: Första dagen (karensdag) = 100% avdrag, därefter 20% avdrag (80% sjuklön från arbetsgivaren)
-        - VAB: 100% avdrag (ersättning kommer från Försäkringskassan, inte arbetsgivaren)
+        - SICK: karensbudget = 8h per sjukperiod, fördelas dag för dag tills slut
+          Varje dag: karens_idag = min(frånvarotimmar, karens_kvar)
+                     sjuklön_idag = frånvarotimmar - karens_idag (20% avdrag)
+        - VAB: 100% avdrag (FK betalar ersättning, inte arbetsgivaren)
         - LEAVE: 100% avdrag (obetald ledighet)
         - OFF: 0% avdrag (betald ledighet)
     """
-    # Beräkna timlön (månadslön / 173.33 timmar per månad enligt svensk standard)
     hourly_wage = monthly_wage / 173.33
-
-    # Beräkna lön för skiftet
-    shift_wage = hourly_wage * shift_hours
+    hours = absent_hours if absent_hours is not None else shift_hours
 
     if absence_type == "SICK":
-        if is_first_sick_day:
-            # Karensdag - 100% avdrag
-            return shift_wage
+        if karens_remaining is not None:
+            # Distribuerad karens: förbruka budget tills den är slut
+            karens_today = min(hours, karens_remaining)
+            sjuklon_hours = hours - karens_today
+            return hourly_wage * karens_today + hourly_wage * sjuklon_hours * 0.2
+        elif is_first_sick_day:
+            # Fallback (äldre anrop): dag 1 = hela karensbudgeten eller frånvarotimmar
+            karens_h = hours if absent_hours is not None else KARENS_HOURS
+            return hourly_wage * karens_h
         else:
-            # Sjuklön - 20% avdrag (arbetsgivaren betalar 80%)
-            return shift_wage * 0.2
+            return hourly_wage * hours * 0.2
     elif absence_type == "VAB":
-        # VAB - 100% avdrag (FK betalar ersättning, inte arbetsgivaren)
-        return shift_wage
+        return hourly_wage * hours
     elif absence_type == "LEAVE":
-        # Obetald ledighet - 100% avdrag
-        return shift_wage
+        return hourly_wage * hours
     elif absence_type == "OFF":
-        # Ledig - inget löneavdrag (betald ledighet)
         return 0.0
     else:
-        # Okänd frånvarotyp - inget avdrag
         return 0.0
 
 
-def get_shift_hours_for_date(session: Session, user_id: int, absence_date: date) -> float:
+def get_karens_consumed_before_date(session, user_id: int, sick_date: "date") -> float:
     """
-    Hämtar antal timmar för det skift som skulle ha jobbats på given dag.
+    Beräknar hur många karenstimmar som redan förbrukats i den pågående sjukperioden
+    INNAN sick_date.
 
-    Args:
-        session: SQLAlchemy session
-        user_id: Användar-ID
-        absence_date: Datum för frånvaron
+    En sjukperiod bryts om det är mer än 5 dagars uppehåll mellan sjukdagar.
 
     Returns:
-        Antal timmar för skiftet (default 8.5 om inget skift hittas)
+        Förbrukade karenstimmar (0.0 om sick_date är första dagen i perioden)
     """
-    from app.core.schedule import calculate_shift_hours, determine_shift_for_date
-    from app.database.database import User
+    from app.database.database import Absence, AbsenceType
 
-    # Resolve user_id → rotation position
-    rotation_position = user_id  # fallback
+    # Hämta alla sjukdagar bakåt från sick_date (upp till 30 dagar bakåt är tillräckligt)
+    lookback = sick_date - timedelta(days=30)
+    prev_sick_days = (
+        session.query(Absence)
+        .filter(
+            Absence.user_id == user_id,
+            Absence.absence_type == AbsenceType.SICK,
+            Absence.date >= lookback,
+            Absence.date < sick_date,
+        )
+        .order_by(Absence.date.desc())
+        .all()
+    )
+
+    if not prev_sick_days:
+        return 0.0
+
+    # Gå bakåt och samla dagar i samma sjukperiod (gap <= 5 dagar)
+    period_days: list = []
+    prev_date = sick_date
+    for absence in prev_sick_days:
+        gap = (prev_date - absence.date).days
+        if gap > 5:
+            break  # Ny sjukperiod - sluta leta
+        period_days.append(absence)
+        prev_date = absence.date
+
+    if not period_days:
+        return 0.0
+
+    # Räkna förbrukad karens (kronologisk ordning)
+    period_days.reverse()
+    consumed = 0.0
+    for absence in period_days:
+        if consumed >= KARENS_HOURS:
+            break
+        # Hämta frånvarotimmar för denna dag
+        _, _, shift_end_dt = get_shift_times_for_date(session, user_id, absence.date)
+        shift_h = get_shift_hours_for_date(session, user_id, absence.date)
+        absent_h = get_absent_hours_from_left_at(absence.left_at, shift_end_dt, shift_h)
+        karens_this_day = min(absent_h, KARENS_HOURS - consumed)
+        consumed += karens_this_day
+
+    return consumed
+
+
+def _get_rotation_position(session, user_id: int) -> int:
+    """Hämtar rotation_person_id för en användare (fallback = user_id)."""
     if session:
+        from app.database.database import User
+
         user = session.query(User).filter(User.id == user_id).first()
         if user:
-            rotation_position = user.rotation_person_id
+            return user.rotation_person_id
+    return user_id
 
-    # Hämta vilket skift personen skulle ha jobbat
+
+def get_shift_times_for_date(
+    session, user_id: int, absence_date: date
+) -> tuple[float, datetime.datetime | None, datetime.datetime | None]:
+    """
+    Hämtar (hours, start_dt, end_dt) för skiftet en person skulle ha jobbat.
+    Returnerar (8.5, None, None) som fallback.
+    """
+    from app.core.schedule import calculate_shift_hours, determine_shift_for_date
+
+    rotation_position = _get_rotation_position(session, user_id)
     result = determine_shift_for_date(absence_date, start_week=rotation_position)
-
     if result and result[0]:
         shift, _ = result
         if shift and shift.code not in ["OFF", "SEM"]:
-            hours, _, _ = calculate_shift_hours(absence_date, shift.code)
-            return hours if hours > 0 else 8.5
+            hours, start_dt, end_dt = calculate_shift_hours(absence_date, shift.code)
+            if hours > 0:
+                return hours, start_dt, end_dt
+    return 8.5, None, None
 
-    # Default till 8.5 timmar om vi inte kan bestämma skiftet
-    return 8.5
+
+def get_shift_hours_for_date(session, user_id: int, absence_date: date) -> float:
+    """
+    Hämtar antal timmar för det skift som skulle ha jobbats på given dag.
+    Default 8.5 om inget skift hittas.
+    """
+    hours, _, _ = get_shift_times_for_date(session, user_id, absence_date)
+    return hours
+
+
+def get_absent_hours_from_left_at(left_at: str, shift_end_dt: datetime.datetime | None, shift_hours: float) -> float:
+    """
+    Beräknar antal frånvarotimmar utifrån left_at ("HH:MM") och skiftets sluttid.
+    Returnerar shift_hours som fallback om sluttid saknas.
+    """
+    if not left_at or shift_end_dt is None:
+        return shift_hours
+    try:
+        left_time = datetime.datetime.strptime(left_at, "%H:%M").time()
+        left_dt = datetime.datetime.combine(shift_end_dt.date(), left_time)
+        # Hantera fall där left_at är nästa dag (t.ex. nattskift)
+        if left_dt >= shift_end_dt:
+            return 0.0
+        absent = (shift_end_dt - left_dt).total_seconds() / 3600.0
+        return max(0.0, absent)
+    except ValueError:
+        return shift_hours
 
 
 def get_absence_deductions_for_month(session: Session, user_id: int, year: int, month: int, monthly_wage: int) -> dict:
@@ -251,39 +344,55 @@ def get_absence_deductions_for_month(session: Session, user_id: int, year: int, 
     off_hours = 0.0
     details = []
 
-    # Håll koll på om vi har haft karensdag för sjukperiod
-    last_sick_date = None
+    # Spåra karensbudget och sjukperiod
+    last_sick_date: date | None = None
+    karens_consumed_in_period = 0.0
 
     for absence in absences:
-        is_first_sick_day = False
-
         # Hämta antal timmar för det skift som skulle ha jobbats
         shift_hours = get_shift_hours_for_date(session, user_id, absence.date)
-        total_hours += shift_hours
+        _, _, shift_end_dt = get_shift_times_for_date(session, user_id, absence.date)
+        absent_hours = get_absent_hours_from_left_at(absence.left_at, shift_end_dt, shift_hours)
+        total_hours += absent_hours
 
         if absence.absence_type == AbsenceType.SICK:
             sick_days += 1
-            sick_hours += shift_hours
+            sick_hours += absent_hours
 
-            # Kolla om det är en ny sjukperiod (mer än 5 dagar sedan senaste sjukdag)
+            # Ny sjukperiod om gap > 5 dagar
             if last_sick_date is None or (absence.date - last_sick_date).days > 5:
-                is_first_sick_day = True
+                karens_consumed_in_period = 0.0
 
+            karens_remaining = max(0.0, KARENS_HOURS - karens_consumed_in_period)
+            karens_today = min(absent_hours, karens_remaining)
+            karens_consumed_in_period += karens_today
             last_sick_date = absence.date
 
-        elif absence.absence_type == AbsenceType.VAB:
-            vab_days += 1
-            vab_hours += shift_hours
-        elif absence.absence_type == AbsenceType.LEAVE:
-            leave_days += 1
-            leave_hours += shift_hours
-        elif absence.absence_type == AbsenceType.OFF:
-            off_days += 1
-            off_hours += shift_hours
+            deduction = calculate_absence_deduction(
+                monthly_wage,
+                absence.absence_type.value,
+                shift_hours,
+                absent_hours=absent_hours,
+                karens_remaining=karens_remaining,
+            )
+            is_karens = karens_today > 0
 
-        deduction = calculate_absence_deduction(
-            monthly_wage, absence.absence_type.value, shift_hours, is_first_sick_day
-        )
+        else:
+            karens_today = 0.0
+            is_karens = False
+            if absence.absence_type == AbsenceType.VAB:
+                vab_days += 1
+                vab_hours += absent_hours
+            elif absence.absence_type == AbsenceType.LEAVE:
+                leave_days += 1
+                leave_hours += absent_hours
+            elif absence.absence_type == AbsenceType.OFF:
+                off_days += 1
+                off_hours += absent_hours
+
+            deduction = calculate_absence_deduction(
+                monthly_wage, absence.absence_type.value, shift_hours, absent_hours=absent_hours
+            )
 
         total_deduction += deduction
 
@@ -291,9 +400,12 @@ def get_absence_deductions_for_month(session: Session, user_id: int, year: int, 
             {
                 "date": absence.date,
                 "type": absence.absence_type.value,
-                "hours": shift_hours,
+                "hours": absent_hours,
                 "deduction": deduction,
-                "is_karens": is_first_sick_day,
+                "is_karens": is_karens,
+                "karens_hours": karens_today,
+                "is_partial": absence.left_at is not None,
+                "left_at": absence.left_at,
             }
         )
 

--- a/app/database/database.py
+++ b/app/database/database.py
@@ -153,13 +153,21 @@ class Absence(Base):
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     date = Column(Date, nullable=False)
     absence_type = Column(SQLEnum(AbsenceType), nullable=False)
+    left_at = Column(String(5), nullable=True)  # "HH:MM" - klockslag när de slutade jobba (None = heldag)
     created_at = Column(DateTime, default=datetime.utcnow)
 
     # Relationships
     user = relationship("User", foreign_keys=[user_id])
 
+    @property
+    def is_partial_day(self) -> bool:
+        return self.left_at is not None
+
     def __repr__(self):
-        return f"<Absence(id={self.id}, user_id={self.user_id}, date={self.date}, type={self.absence_type})>"
+        return (
+            f"<Absence(id={self.id}, user_id={self.user_id}, date={self.date}, "
+            f"type={self.absence_type}, left_at={self.left_at})>"
+        )
 
 
 class OnCallOverride(Base):

--- a/app/routes/dashboard.py
+++ b/app/routes/dashboard.py
@@ -27,7 +27,13 @@ from app.core.schedule import (
     ob_rules,
     rotation_start_date,
 )
-from app.core.schedule.wages import calculate_absence_deduction, get_shift_hours_for_date
+from app.core.schedule.wages import (
+    KARENS_HOURS,
+    calculate_absence_deduction,
+    get_absent_hours_from_left_at,
+    get_karens_consumed_before_date,
+    get_shift_times_for_date,
+)
 from app.core.storage import calculate_tax_from_table
 from app.core.utils import get_safe_today, get_today
 from app.database.database import Absence, OnCallOverride, OnCallOverrideType, ShiftSwap, SwapStatus, User, get_db
@@ -47,22 +53,22 @@ def _query_absence_and_deduction(
     absence = db.query(Absence).filter(Absence.user_id == user_id, Absence.date == check_date).first()
     deduction = 0.0
     if absence and show_salary:
-        shift_hours = get_shift_hours_for_date(db, user_id, check_date)
-        five_days_ago = check_date - timedelta(days=5)
-        previous_sick = None
+        shift_hours, _, shift_end_dt = get_shift_times_for_date(db, user_id, check_date)
+        absent_hours = get_absent_hours_from_left_at(absence.left_at, shift_end_dt, shift_hours)
         if absence.absence_type.value == "SICK":
-            previous_sick = (
-                db.query(Absence)
-                .filter(
-                    Absence.user_id == user_id,
-                    Absence.date >= five_days_ago,
-                    Absence.date < check_date,
-                    Absence.absence_type == absence.absence_type,
-                )
-                .first()
+            karens_consumed = get_karens_consumed_before_date(db, user_id, check_date)
+            karens_remaining = max(0.0, KARENS_HOURS - karens_consumed)
+            deduction = calculate_absence_deduction(
+                user_wage,
+                absence.absence_type.value,
+                shift_hours,
+                absent_hours=absent_hours,
+                karens_remaining=karens_remaining,
             )
-        is_karens = previous_sick is None if absence.absence_type.value == "SICK" else False
-        deduction = calculate_absence_deduction(user_wage, absence.absence_type.value, shift_hours, is_karens)
+        else:
+            deduction = calculate_absence_deduction(
+                user_wage, absence.absence_type.value, shift_hours, absent_hours=absent_hours
+            )
     return absence, deduction
 
 

--- a/app/routes/profile.py
+++ b/app/routes/profile.py
@@ -535,6 +535,7 @@ async def add_absence(
     user_id: int = Form(...),
     date_str: str = Form(..., alias="date"),
     absence_type: str = Form(...),
+    left_at: str = Form(default=""),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -554,6 +555,16 @@ async def add_absence(
     except ValueError:
         raise HTTPException(status_code=400, detail=f"Ogiltig frånvarotyp: {absence_type}") from None
 
+    # Validera left_at-format HH:MM (valfritt, tomt = heldag)
+    parsed_left_at: str | None = None
+    stripped = left_at.strip()
+    if stripped:
+        import re
+
+        if not re.match(r"^\d{2}:\d{2}$", stripped):
+            raise HTTPException(status_code=400, detail="Ogiltigt klockslags-format, använd HH:MM") from None
+        parsed_left_at = stripped
+
     if current_user.role == UserRole.ADMIN:
         target_user_id = user_id
     else:
@@ -563,9 +574,15 @@ async def add_absence(
 
     if existing:
         existing.absence_type = absence_type_enum
+        existing.left_at = parsed_left_at
         db.commit()
     else:
-        new_absence = Absence(user_id=target_user_id, date=absence_date, absence_type=absence_type_enum)
+        new_absence = Absence(
+            user_id=target_user_id,
+            date=absence_date,
+            absence_type=absence_type_enum,
+            left_at=parsed_left_at,
+        )
         db.add(new_absence)
         db.commit()
 

--- a/app/routes/schedule_personal.py
+++ b/app/routes/schedule_personal.py
@@ -244,6 +244,19 @@ async def show_day_for_person(
     # Absences are stored per user_id
     absence = db.query(Absence).filter(Absence.user_id == user_id_for_wages, Absence.date == date_obj).first()
 
+    # Partiell frånvaro: trunkera end_dt till left_at och räkna om OB
+    if absence and absence.left_at and start_dt is not None and end_dt is not None:
+        left_time = datetime.strptime(absence.left_at, "%H:%M").time()
+        truncated_end = datetime.combine(date_obj, left_time)
+        if truncated_end > start_dt:
+            end_dt = truncated_end
+            hours = (end_dt - start_dt).total_seconds() / 3600.0
+            if not is_full_ot and not is_effective_oc:
+                ob_hours = calculate_ob_hours(start_dt, end_dt, combined_rules)
+                ob_pay = calculate_ob_pay(
+                    start_dt, end_dt, combined_rules, monthly_salary, rate_overrides=_user_rates["ob"]
+                )
+
     if ot_shift and not absence:  # Skip OT if there's an absence
         from app.core.models import ShiftType
         from app.core.storage import load_shift_types
@@ -411,33 +424,44 @@ async def show_day_for_person(
     absence_deduction = 0.0
     absence_shift_hours = 0.0
     is_karens = False
+    karens_hours_today = 0.0
+    sjuklon_hours_today = 0.0
 
     if absence and show_salary:
-        from app.core.schedule.wages import calculate_absence_deduction, get_shift_hours_for_date
-
-        # Get shift hours for the day (uses rotation_position for schedule)
-        absence_shift_hours = get_shift_hours_for_date(db, rotation_position, date_obj)
-
-        # Check if this is a karensdag (first sick day in a period)
-        if absence.absence_type.value == "SICK":
-            # Check if there was a sick day within the last 5 days
-            five_days_ago = date_obj - timedelta(days=5)
-            previous_sick = (
-                db.query(Absence)
-                .filter(
-                    Absence.user_id == user_id_for_wages,
-                    Absence.date >= five_days_ago,
-                    Absence.date < date_obj,
-                    Absence.absence_type == absence.absence_type,
-                )
-                .first()
-            )
-            is_karens = previous_sick is None
-
-        # Calculate deduction
-        absence_deduction = calculate_absence_deduction(
-            monthly_salary, absence.absence_type.value, absence_shift_hours, is_karens
+        from app.core.schedule.wages import (
+            KARENS_HOURS,
+            calculate_absence_deduction,
+            get_absent_hours_from_left_at,
+            get_karens_consumed_before_date,
+            get_shift_times_for_date,
         )
+
+        # Get shift hours and times for the day
+        full_shift_hours, _, shift_end_dt = get_shift_times_for_date(db, rotation_position, date_obj)
+        absent_hours = get_absent_hours_from_left_at(absence.left_at, shift_end_dt, full_shift_hours)
+        # absence_shift_hours visas i templaten
+        absence_shift_hours = absent_hours
+
+        if absence.absence_type.value == "SICK":
+            karens_consumed = get_karens_consumed_before_date(db, user_id_for_wages, date_obj)
+            karens_remaining = max(0.0, KARENS_HOURS - karens_consumed)
+            karens_hours_today = min(absent_hours, karens_remaining)
+            sjuklon_hours_today = absent_hours - karens_hours_today
+            is_karens = karens_hours_today > 0
+            absence_deduction = calculate_absence_deduction(
+                monthly_salary,
+                absence.absence_type.value,
+                full_shift_hours,
+                absent_hours=absent_hours,
+                karens_remaining=karens_remaining,
+            )
+        else:
+            is_karens = False
+            karens_hours_today = 0.0
+            sjuklon_hours_today = absent_hours
+            absence_deduction = calculate_absence_deduction(
+                monthly_salary, absence.absence_type.value, full_shift_hours, absent_hours=absent_hours
+            )
 
     # Get coworkers for this day
     from app.core.schedule import generate_period_data
@@ -507,9 +531,11 @@ async def show_day_for_person(
             "ot_shift": ot_details if show_salary and ot_details else None,
             "ot_shift_id": ot_shift_id,
             "absence": absence,  # Pass absence data to template
-            "absence_deduction": absence_deduction,  # Deduction amount in SEK
-            "absence_shift_hours": absence_shift_hours,  # Hours for the shift
-            "is_karens": is_karens,  # Whether this is a karensdag
+            "absence_deduction": absence_deduction,
+            "absence_shift_hours": absence_shift_hours,
+            "is_karens": is_karens,
+            "karens_hours_today": karens_hours_today,
+            "sjuklon_hours_today": sjuklon_hours_today,
             "before_employment": before_employment,
             "coworkers": coworkers if not before_employment else [],
             "all_working_persons": persons_today_with_shift if not before_employment else [],

--- a/app/templates/day.html
+++ b/app/templates/day.html
@@ -280,6 +280,9 @@
                                     {% else %}
                                         {{ absence.absence_type.value }}
                                     {% endif %}
+                                    {% if absence.left_at is not none %}
+                                        <span style="color: var(--text-muted); font-size: 0.9em;">(slutade {{ absence.left_at }})</span>
+                                    {% endif %}
                                 </td>
                                 <td>
                                     {% if absence.absence_type.value == 'SICK' %}
@@ -290,6 +293,9 @@
                                         <span class="badge" style="background: #a855f7; color: white;">{{ t.day_absence_leave }}</span>
                                     {% elif absence.absence_type.value == 'OFF' %}
                                         <span class="badge" style="background: #888888; color: white;">{{ t.day_absence_off }}</span>
+                                    {% endif %}
+                                    {% if absence.left_at is not none %}
+                                        <span class="badge" style="background: #0ea5e9; color: white;">Deldag</span>
                                     {% endif %}
                                 </td>
                                 <td>
@@ -313,11 +319,36 @@
                         </thead>
                         <tbody>
                             <tr>
-                                <td>{{ "%.2f"|format(absence_shift_hours) }} h</td>
+                                <td>
+                                    {% if absence.absence_type.value == 'SICK' %}
+                                        {% if karens_hours_today > 0 and sjuklon_hours_today > 0 %}
+                                            {{ "%.1f"|format(karens_hours_today) }} h karens + {{ "%.1f"|format(sjuklon_hours_today) }} h sjuklön
+                                        {% elif karens_hours_today > 0 %}
+                                            {% if absence.left_at is not none %}
+                                                {{ "%.1f"|format(karens_hours_today) }} h (karens, slutade {{ absence.left_at }})
+                                            {% else %}
+                                                8,0 h (karens)
+                                            {% endif %}
+                                        {% else %}
+                                            {% if absence.left_at is not none %}
+                                                {{ "%.1f"|format(sjuklon_hours_today) }} h (slutade {{ absence.left_at }})
+                                            {% else %}
+                                                {{ "%.2f"|format(absence_shift_hours) }} h
+                                            {% endif %}
+                                        {% endif %}
+                                    {% elif absence.left_at is not none %}
+                                        {{ "%.1f"|format(absence_shift_hours) }} h (slutade {{ absence.left_at }})
+                                    {% else %}
+                                        {{ "%.2f"|format(absence_shift_hours) }} h
+                                    {% endif %}
+                                </td>
                                 <td>{{ "%.2f"|format(absence_deduction) }} kr</td>
                                 <td>
                                     {% if absence.absence_type.value == 'SICK' %}
-                                        {% if is_karens %}
+                                        {% if karens_hours_today > 0 and sjuklon_hours_today > 0 %}
+                                            <span class="badge" style="background: #dc2626; color: white;">{{ t.day_karens }}</span>
+                                            + {{ t.day_sick_deduction }}
+                                        {% elif karens_hours_today > 0 %}
                                             <span class="badge" style="background: #dc2626; color: white;">{{ t.day_karens }}</span>
                                         {% else %}
                                             {{ t.day_sick_deduction }}
@@ -352,6 +383,11 @@
                                 <option value="LEAVE">{{ t.day_absence_leave }}</option>
                                 <option value="OFF">{{ t.day_absence_off }}</option>
                             </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="left_at">Slutade (lämna tomt = heldag)</label>
+                            <input type="time" id="left_at" name="left_at"
+                                   placeholder="HH:MM">
                         </div>
                     </div>
 

--- a/app/templates/month.html
+++ b/app/templates/month.html
@@ -155,10 +155,15 @@
                                     {% else %}
                                         <span class="badge badge-off calendar-badge">OFF</span>
                                     {% endif %}
+                                    {% if day_data.partial_absence %}
+                                        <span class="badge" style="background:#ef4444;color:white;font-size:0.6rem;padding:1px 4px;" title="Sjuk deldag (slutade {{ day_data.partial_absence.left_at }})">SJ</span>
+                                    {% endif %}
 
                                     {% if day_data.shift and day_data.shift.code != 'OC' %}
                                         {% if day_data.shift.code == 'OT' and day_data.start and day_data.end %}
                                             <div class="calendar-time">{{ day_data.start | time_format }} - {{ day_data.end | time_format }}</div>
+                                        {% elif day_data.partial_absence and day_data.start and day_data.end %}
+                                            <div class="calendar-time">{{ day_data.start | time_format }} - {{ day_data.partial_absence.left_at }}</div>
                                         {% elif day_data.shift.start_time is not none %}
                                             <div class="calendar-time">{{ day_data.shift.start_time }} - {{ day_data.shift.end_time }}</div>
                                         {% endif %}

--- a/migrate_absence_add_hours.py
+++ b/migrate_absence_add_hours.py
@@ -1,0 +1,34 @@
+"""
+Migration: Lägg till left_at-kolumn på absences-tabellen.
+
+left_at = NULL    => heldag frånvaro (befintligt beteende)
+left_at = "HH:MM" => partiell frånvaro, klockslag när personen slutade jobba
+
+Kör: python migrate_absence_add_hours.py
+"""
+
+import os
+import sqlite3
+
+DB_PATH = os.environ.get("DATABASE_PATH", "app/database/schedule.db")
+
+
+def main():
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+
+    cursor.execute("PRAGMA table_info(absences)")
+    columns = [row[1] for row in cursor.fetchall()]
+
+    if "left_at" not in columns:
+        cursor.execute("ALTER TABLE absences ADD COLUMN left_at TEXT")
+        print("Kolumnen 'left_at' har lagts till i absences-tabellen.")
+    else:
+        print("Kolumnen 'left_at' finns redan, hoppar över.")
+
+    conn.commit()
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds support for partial-day absence registration via a new `left_at` (HH:MM) field on absences — enables recording when a colleague goes home sick mid-shift
- OB recalculates for only the worked portion of the shift
- Karens (8h budget) distributes correctly across multi-day sick periods (e.g. 5.5h day 1 → 2.5h remaining day 2)
- Month view shows an **SJ** badge on partial-day sick shifts so they are distinguishable from normal shifts
- Fixes a pre-existing bug where users with `user_id != rotation_person_id` (Peter, Rickard) had OT shifts, absences, on-call overrides, and swaps silently missed in month/week views