### PR TITLE
Add same-day shift swaps and ATL rest period validation

### DIFF
--- a/app/routes/schedule_personal.py
+++ b/app/routes/schedule_personal.py
@@ -539,16 +539,9 @@ async def show_day_for_person(
             "before_employment": before_employment,
             "coworkers": coworkers if not before_employment else [],
             "all_working_persons": persons_today_with_shift if not before_employment else [],
-            "swap_users": [
-                u
-                for u in db.query(User)
-                .filter(User.is_active == 1, User.id != current_user.id, User.role != UserRole.ADMIN)
-                .all()
-                if any(
-                    p.get("person_id") == u.rotation_person_id and (not p.get("shift") or p["shift"].code == "OFF")
-                    for p in persons_today
-                )
-            ],
+            "swap_users": db.query(User)
+            .filter(User.is_active == 1, User.id != current_user.id, User.role != UserRole.ADMIN)
+            .all(),
             "oncall_override": oncall_override,  # On-call override data
             "has_rotation_oc": has_rotation_oc,  # Whether person has OC in rotation
             "is_effective_oc": is_effective_oc,  # Whether this is effectively an OC shift

--- a/app/routes/shift_swap.py
+++ b/app/routes/shift_swap.py
@@ -2,6 +2,7 @@
 """Shift swap management routes - propose, accept, reject, cancel swaps."""
 
 from datetime import datetime, timedelta
+from datetime import time as dt_time
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
@@ -9,13 +10,132 @@ from sqlalchemy.orm import Session
 
 from app.auth.auth import get_current_user
 from app.core.helpers import render_template
-from app.core.schedule import build_week_data, clear_schedule_cache
+from app.core.schedule import build_week_data, calculate_shift_hours, clear_schedule_cache
 from app.core.schedule.core import determine_shift_for_date
 from app.core.utils import get_today
 from app.database.database import ShiftSwap, SwapStatus, User, get_db
 from app.routes.shared import templates
 
 router = APIRouter(prefix="/swaps", tags=["shift_swaps"])
+
+_MIN_REST_HOURS = 11
+
+
+def _get_shift_times_from_session(date, rotation_person_id, session):
+    """Return (start_dt, end_dt) for a person's effective shift on date, respecting accepted swaps."""
+    week_data = build_week_data(
+        date.isocalendar()[0], date.isocalendar()[1], person_id=rotation_person_id, session=session
+    )
+    day = next((d for d in week_data if d["date"] == date), None)
+    if not day:
+        return None, None
+    shift = day.get("shift")
+    if not shift or not shift.start_time or not shift.end_time:
+        return None, None
+    _, start_dt, end_dt = calculate_shift_hours(date, shift)
+    return start_dt, end_dt
+
+
+def _check_rest_ok(work_date, shift_code, rotation_person_id, session=None):
+    """Return False if working shift_code on work_date violates 11h rest against adjacent days.
+
+    If session is provided, uses build_week_data (includes accepted swaps) for adjacent days.
+    Otherwise falls back to determine_shift_for_date (raw rotation only).
+    """
+    _, new_start, new_end = calculate_shift_hours(work_date, shift_code)
+    if not new_start or not new_end:
+        return True  # No time data for this shift — cannot validate, allow
+
+    if session:
+        _, prev_end = _get_shift_times_from_session(work_date - timedelta(days=1), rotation_person_id, session)
+        next_start, _ = _get_shift_times_from_session(work_date + timedelta(days=1), rotation_person_id, session)
+    else:
+        prev_result = determine_shift_for_date(work_date - timedelta(days=1), rotation_person_id)
+        if prev_result and prev_result[0] and prev_result[0].code not in ("OFF", "OC"):
+            _, _, prev_end = calculate_shift_hours(work_date - timedelta(days=1), prev_result[0])
+        else:
+            prev_end = None
+        next_result = determine_shift_for_date(work_date + timedelta(days=1), rotation_person_id)
+        if next_result and next_result[0] and next_result[0].code not in ("OFF", "OC"):
+            _, next_start, _ = calculate_shift_hours(work_date + timedelta(days=1), next_result[0])
+        else:
+            next_start = None
+
+    if prev_end and (new_start - prev_end).total_seconds() / 3600 < _MIN_REST_HOURS:
+        return False
+    if next_start and (next_start - new_end).total_seconds() / 3600 < _MIN_REST_HOURS:
+        return False
+
+    return True
+
+
+_MIN_WEEKLY_REST_HOURS = 36
+
+
+def _check_weekly_rest_ok(work_date, new_shift_code, rotation_person_id, original_shift_code=None):
+    """Return False if any rolling 7-day period containing work_date has < 36h consecutive rest
+    that wasn't already violated by the original shift.
+
+    ATL §14 uses rolling sjudagarsperioder (day 1-7, day 2-8, ...).
+    There are 7 possible windows containing work_date: [D-6..D], [D-5..D+1], ..., [D..D+6].
+    All must be checked. OC (beredskap) blocks weekly rest per ATL §14.
+
+    If original_shift_code is provided (same-day swap replacing an existing shift), a window
+    that already violated 36h with the original shift is not counted as a new violation.
+    The swap is blocked only if it makes weekly rest worse than the original schedule.
+    """
+
+    def _max_gap_in_window(shift_code_on_work_date, w_start, w_end):
+        """Compute the longest consecutive rest gap (hours) within [w_start, w_end]."""
+        intervals = []
+        for day_offset in range(-6, 7):
+            d = work_date + timedelta(days=day_offset)
+            if d == work_date:
+                code = shift_code_on_work_date
+            else:
+                result = determine_shift_for_date(d, rotation_person_id)
+                code = result[0].code if result and result[0] else "OFF"
+
+            if code == "OFF":
+                continue
+
+            _, start_dt, end_dt = calculate_shift_hours(d, code)
+            if start_dt and end_dt:
+                clipped_s = max(start_dt, w_start)
+                clipped_e = min(end_dt, w_end)
+                if clipped_s < clipped_e:
+                    intervals.append((clipped_s, clipped_e))
+
+        if not intervals:
+            return 168.0  # No shifts — full week free
+
+        intervals.sort()
+        gap = max(
+            (intervals[0][0] - w_start).total_seconds() / 3600,
+            *((intervals[i + 1][0] - intervals[i][1]).total_seconds() / 3600 for i in range(len(intervals) - 1)),
+            (w_end - intervals[-1][1]).total_seconds() / 3600,
+        )
+        return gap
+
+    for window_start_offset in range(-6, 1):  # windows starting D-6 to D
+        w_start = datetime.combine(work_date + timedelta(days=window_start_offset), dt_time(0, 0))
+        w_end = w_start + timedelta(hours=168)
+
+        new_gap = _max_gap_in_window(new_shift_code, w_start, w_end)
+        if new_gap >= _MIN_WEEKLY_REST_HOURS:
+            continue  # This window is fine
+
+        if original_shift_code is not None:
+            # Same-day swap: only block if the new shift makes weekly rest worse
+            orig_gap = _max_gap_in_window(original_shift_code, w_start, w_end)
+            if new_gap >= orig_gap:
+                continue  # Not worse than before — allow
+            if orig_gap < _MIN_WEEKLY_REST_HOURS:
+                continue  # Window already violated before swap — pre-existing issue
+
+        return False  # New violation introduced by this swap
+
+    return True
 
 
 @router.get("/api/shifts/{user_id}")
@@ -61,6 +181,13 @@ async def get_user_shifts(
 
     MIN_REST_HOURS = 11
 
+    # Determine if requester is working on center (only same-day swap is offered then)
+    center_wk = center.isocalendar()[:2]
+    center_my_info = my_weeks.get(center_wk, {}).get(center, {})
+    center_my_shift = center_my_info.get("shift")
+    center_my_code = center_my_shift.code if center_my_shift else "OFF"
+    requester_working_on_center = center_my_code not in ("OFF", "OC")
+
     def get_my_shift_times(d):
         """Get start/end datetimes for my shift on date d."""
         iso = d.isocalendar()
@@ -84,43 +211,62 @@ async def get_user_shifts(
         my_shift = my_info.get("shift")
         my_code = my_shift.code if my_shift else "OFF"
 
-        if my_code not in ("OFF", "OC"):
-            continue  # I'm working a regular shift — can't take this day
-
         # Check target's shift
         tgt_info = target_weeks[wk].get(d, {})
         tgt_shift = tgt_info.get("shift")
         if not tgt_shift or tgt_shift.code == "OFF":
             continue
 
-        # OC-to-OC: when offering OC, only show target's OC shifts (requester must be OFF)
-        # Regular: when offering a regular shift, only show target's regular shifts
-        if offering == "OC":
-            if tgt_shift.code != "OC":
-                continue  # Offering OC — only interested in target's OC
-            if my_code != "OFF":
-                continue  # Must be OFF to take their OC
+        is_same_day = d == center
+
+        if requester_working_on_center:
+            # Requester is working on center — only same-day swap is relevant
+            if not is_same_day:
+                continue
+            # Same-day swap: both must be working different shifts
+            if not my_shift:
+                continue
+            if tgt_shift.code == my_code:
+                continue  # Same shift code — pointless swap
+            # Don't mix OC and regular shifts
+            if (my_code == "OC") != (tgt_shift.code == "OC"):
+                continue
         else:
-            if tgt_shift.code == "OC":
-                continue  # Offering regular — can't take OC
-            if my_code != "OFF":
-                continue  # Must be OFF to take their shift
+            # Requester is free — can take target's shift on a different day
+
+            # OC-to-OC: when offering OC, only show target's OC shifts (requester must be OFF)
+            # Regular: when offering a regular shift, only show target's regular shifts
+            if offering == "OC":
+                if tgt_shift.code != "OC":
+                    continue  # Offering OC — only interested in target's OC
+                if my_code != "OFF":
+                    continue  # Must be OFF to take their OC
+            else:
+                if tgt_shift.code == "OC":
+                    continue  # Offering regular — can't take OC
+                if my_code != "OFF":
+                    continue  # Must be OFF to take their shift
 
         # Calculate target shift times (the shift I would work)
         _, tgt_start, tgt_end = calculate_shift_hours(d, tgt_shift)
 
-        # 11h rest rule: check against my shifts on adjacent days
-        if tgt_start and tgt_end:
-            rest_ok = True
-            # Check day before: my shift end → target shift start >= 11h
-            prev_start, prev_end = get_my_shift_times(d - timedelta(days=1))
-            if prev_end and (tgt_start - prev_end).total_seconds() / 3600 < MIN_REST_HOURS:
-                rest_ok = False
-            # Check day after: target shift end → my next shift start >= 11h
-            next_start, next_end = get_my_shift_times(d + timedelta(days=1))
-            if rest_ok and next_start and (next_start - tgt_end).total_seconds() / 3600 < MIN_REST_HOURS:
-                rest_ok = False
-            if not rest_ok:
+        # Same-day swaps skip rest checks: both parties already work that day,
+        # only the shift assignment changes.
+        if not is_same_day:
+            # 11h rest rule: check against my shifts on adjacent days
+            if tgt_start and tgt_end:
+                rest_ok = True
+                prev_start, prev_end = get_my_shift_times(d - timedelta(days=1))
+                if prev_end and (tgt_start - prev_end).total_seconds() / 3600 < MIN_REST_HOURS:
+                    rest_ok = False
+                next_start, next_end = get_my_shift_times(d + timedelta(days=1))
+                if rest_ok and next_start and (next_start - tgt_end).total_seconds() / 3600 < MIN_REST_HOURS:
+                    rest_ok = False
+                if not rest_ok:
+                    continue
+
+            # 36h weekly rest rule: OC (beredskap) blocks weekly rest per ATL §14
+            if not _check_weekly_rest_ok(d, tgt_shift.code, my_pid):
                 continue
 
         # Calculate OB hours for the target's shift
@@ -215,6 +361,32 @@ async def propose_swap(
     # Get shift codes for both dates
     req_result = determine_shift_for_date(req_date, start_week=current_user.rotation_person_id)
     tgt_result = determine_shift_for_date(tgt_date, start_week=target_user.rotation_person_id)
+
+    req_shift = req_result[0] if req_result and req_result[0] else None
+    tgt_shift = tgt_result[0] if tgt_result and tgt_result[0] else None
+
+    if not req_shift or req_shift.code in ("OFF",):
+        raise HTTPException(status_code=400, detail="Du jobbar inte det datumet")
+    if not tgt_shift or tgt_shift.code in ("OFF",):
+        raise HTTPException(status_code=400, detail="Kollegan jobbar inte det datumet")
+
+    is_same_day = req_date == tgt_date
+    if is_same_day:
+        if req_shift.code == tgt_shift.code:
+            raise HTTPException(status_code=400, detail="Ni jobbar redan samma pass")
+        if (req_shift.code == "OC") != (tgt_shift.code == "OC"):
+            raise HTTPException(status_code=400, detail="Kan inte blanda OC och vanliga pass")
+
+    # Same-day swaps skip rest checks: both parties already work that day.
+    if not is_same_day:
+        if not _check_rest_ok(tgt_date, tgt_shift.code, current_user.rotation_person_id, session=db):
+            raise HTTPException(status_code=400, detail="Bryter mot 11 timmars dygnsvila (du)")
+        if not _check_rest_ok(req_date, req_shift.code, target_user.rotation_person_id, session=db):
+            raise HTTPException(status_code=400, detail="Bryter mot 11 timmars dygnsvila (kollegan)")
+        if not _check_weekly_rest_ok(tgt_date, tgt_shift.code, current_user.rotation_person_id):
+            raise HTTPException(status_code=400, detail="Bryter mot 36 timmars veckovila (du)")
+        if not _check_weekly_rest_ok(req_date, req_shift.code, target_user.rotation_person_id):
+            raise HTTPException(status_code=400, detail="Bryter mot 36 timmars veckovila (kollegan)")
 
     swap = ShiftSwap(
         requester_id=current_user.id,


### PR DESCRIPTION
## Summary

- Allow colleagues working different shifts on the same day to swap with each other (previously only OFF-day swaps were supported)
- Add 11h daily rest (ATL §13) and 36h weekly rest (ATL §14) validation for different-day swaps, using rolling 7-day windows
- Same-day swaps skip rest checks entirely since only the shift assignment changes
- OC (beredskap) counts toward daily rest but blocks weekly rest per ATL §14
- Server-side validation in `propose_swap` now mirrors the dropdown API, using `build_week_data` so accepted swaps are respected

## Changes

**`app/routes/schedule_personal.py`**
- Removed the OFF-only filter from `swap_users`, all active colleagues are now eligible targets

**`app/routes/shift_swap.py`**
- New helpers: `_get_shift_times_from_session`, `_check_rest_ok`, `_check_weekly_rest_ok`
- Dropdown API (`get_user_shifts`): detects when requester is working on center date and limits options to same-day swap only; wraps rest checks in `if not is_same_day`
- `propose_swap`: added server-side shift existence check, same-shift-code guard, OC-mixing guard, and conditional rest checks