### PR TITLE
Add changelog page and fix deploy untracked file conflict

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -24,6 +24,7 @@ from app.routes.admin import router as admin_router
 from app.routes.admin_users import router as admin_users_router
 from app.routes.api_v1 import create_admin_api_app, create_api_app
 from app.routes.auth_routes import router as auth_router
+from app.routes.changelog import router as changelog_router
 from app.routes.dashboard import router as dashboard_router
 from app.routes.oncall import router as oncall_router
 from app.routes.overtime import router as overtime_router
@@ -281,6 +282,7 @@ app.include_router(profile_router)
 app.include_router(admin_users_router)
 app.include_router(admin_router)
 app.include_router(transition_router)
+app.include_router(changelog_router)
 
 
 @app.get("/health", tags=["health"])

--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -1,0 +1,167 @@
+# app/routes/changelog.py
+"""
+Changelog / version history page.
+"""
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse
+from sqlalchemy.orm import Session
+
+from app.auth.auth import get_current_user_optional
+from app.database.database import get_db
+from app.routes.shared import render
+
+router = APIRouter()
+
+VERSIONS = [
+    {
+        "version": "0.0.20",
+        "date": "2026-04-23",
+        "entries": [
+            {
+                "type": "nyhet",
+                "text": "Externt REST API v1 med API-nyckelautentisering för integration mot tredjepartssystem",
+            },
+            {"type": "nyhet", "text": "OB-ersättning beräknas nu korrekt vid sjukfrånvaro (sick-OB)"},
+            {"type": "nyhet", "text": "Passbyte på samma dag är nu möjligt"},
+        ],
+    },
+    {
+        "version": "0.0.19",
+        "date": "2026-04-08",
+        "entries": [
+            {
+                "type": "nyhet",
+                "text": "Partiell frånvaro: registrera 'left_at' för halvdagsfrånvaro med karens-fördelning",
+            },
+            {"type": "nyhet", "text": "Förbättrad dashboard-navigering och schemavisning"},
+        ],
+    },
+    {
+        "version": "0.0.18",
+        "date": "2026-03-19",
+        "entries": [
+            {"type": "nyhet", "text": "Jourövertid och övertid visas nu i separata rader i månadsvyn"},
+            {"type": "nyhet", "text": "Offentlig månads- och veckovy tillgänglig utan inloggning"},
+            {"type": "nyhet", "text": "Excel-export för månadsvy"},
+            {"type": "nyhet", "text": "Semesterveckoväljarens hoppar nu automatiskt förbi ledigdagar"},
+            {"type": "nyhet", "text": "Flerspråkigt gränssnitt: Svenska / Engelska väljs per användare"},
+            {"type": "nyhet", "text": "Samarbetsstatistik-sida (gemensamma pass med kollegor)"},
+            {"type": "fix", "text": "Kollegors synlighet i passbyteslistan rättad"},
+            {"type": "fix", "text": "Personhistorik hämtar nu schema baserat på rätt datum"},
+            {"type": "fix", "text": "Semesterdagsavmarkering fungerar korrekt"},
+        ],
+    },
+    {
+        "version": "0.0.17",
+        "date": "2026-02-21",
+        "entries": [
+            {"type": "nyhet", "text": "Anställningstransition: stöd för att byta anställningstyp mitt i en period"},
+            {"type": "nyhet", "text": "Anpassningsbara faktorer för OB-, övertids- och joursatser per användare"},
+            {"type": "nyhet", "text": "Övertidsförlängning: pass kan förlängas med övertid direkt i schemat"},
+            {"type": "nyhet", "text": "Anpassade ersättningssatser (OB, OT, jour) per person"},
+            {"type": "nyhet", "text": "Månadsbrytningsvy med detaljerad uppdelning av ersättningstyper"},
+            {
+                "type": "nyhet",
+                "text": "Sparade semesterdagar: möjlighet att spara och ta ut semester över räkenskapsår",
+            },
+            {"type": "nyhet", "text": "Semesterförbättringar: automatisk stängning av passerade semesterår"},
+            {"type": "nyhet", "text": "Storhelgsindikator i schemavy"},
+            {"type": "nyhet", "text": "Personhistorik: visa hur en persons schema sett ut historiskt"},
+            {"type": "fix", "text": "Rättad beräkning av jourövertid vid midnattspassering"},
+        ],
+    },
+    {
+        "version": "0.0.15",
+        "date": "2026-01-25",
+        "entries": [
+            {"type": "nyhet", "text": "Dashboard-förbättringar: bättre översikt med kommande pass och ersättningar"},
+            {"type": "nyhet", "text": "Jouröverride: möjlighet att manuellt överskriva vem som har jour"},
+            {"type": "nyhet", "text": "Betalningsvy per månad och år med summerat utfall"},
+            {"type": "nyhet", "text": "Uppdaterade joursatser för OC_WEEKEND och OC_HOLIDAY"},
+            {"type": "nyhet", "text": "Konsekvent tabellformatering i alla vyer"},
+            {"type": "nyhet", "text": "Kollegor visas i dagvyn och personliga vyer"},
+            {"type": "fix", "text": "Jouröverride rättad i dashboardens dagsvy"},
+        ],
+    },
+    {
+        "version": "0.0.14",
+        "date": "2025-12-30",
+        "entries": [
+            {"type": "nyhet", "text": "Lönehistorik: hantering av löneändringar över tid"},
+            {"type": "nyhet", "text": "Rotationsperioder: schema kan konfigureras med flera rotationserar"},
+            {"type": "nyhet", "text": "Angränsande månader visas i kalendervy"},
+            {"type": "nyhet", "text": "Hälsokontrollendpoint med databas-status"},
+            {"type": "fix", "text": "Övertids- och frånvaroberäkning rättad"},
+            {"type": "fix", "text": "Datumkonsistens förbättrad i hela applikationen"},
+            {"type": "fix", "text": "Konfigurationsvalidering vid uppstart"},
+        ],
+    },
+    {
+        "version": "0.0.12",
+        "date": "2025-12-23",
+        "entries": [
+            {"type": "nyhet", "text": "OB-koder visas som etiketter i schema- och dagvyer"},
+            {"type": "fix", "text": "Jourberedskap separeras korrekt från ordinarie pass i dashboarden"},
+            {"type": "fix", "text": "Storhelgsbricka baseras nu på datum istället för veckotyp"},
+            {"type": "fix", "text": "Jourtimmar räknas inte längre dubbelt i passlistan"},
+        ],
+    },
+    {
+        "version": "0.0.11",
+        "date": "2025-12-22",
+        "entries": [
+            {"type": "nyhet", "text": "Datumväljare i dagvyn för snabb navigering"},
+            {"type": "nyhet", "text": "Skattetabellintegration: nettolön beräknas med korrekt skattetabell"},
+        ],
+    },
+    {
+        "version": "0.0.9",
+        "date": "2025-12-21",
+        "entries": [
+            {"type": "nyhet", "text": "Frånvarotypen 'Tjänstledigt' lagd till"},
+            {"type": "nyhet", "text": "Komplett frånvarohantering med karens och OB-justering"},
+            {"type": "nyhet", "text": "Automatisk databasbackup vid driftsättning"},
+        ],
+    },
+    {
+        "version": "0.0.7",
+        "date": "2025-12-19",
+        "entries": [
+            {"type": "nyhet", "text": "iCal-export: exportera ditt schema till kalenderapp"},
+            {"type": "nyhet", "text": "Veckovy med rutnätslayout"},
+        ],
+    },
+    {
+        "version": "0.0.1",
+        "date": "2025-12-08",
+        "entries": [
+            {"type": "nyhet", "text": "Initial release: schemavisning per år, månad och vecka"},
+            {"type": "nyhet", "text": "OB-ersättningsberäkning baserad på rotationsschema"},
+            {"type": "nyhet", "text": "Personlig vy med daglig lön och ersättning"},
+            {"type": "nyhet", "text": "Administratörsgränssnitt för användare och inställningar"},
+            {"type": "nyhet", "text": "Passbyte mellan kollegor"},
+            {"type": "nyhet", "text": "Inloggning med cookie-baserad session"},
+        ],
+    },
+]
+
+
+@router.get("/changelog", response_class=HTMLResponse)
+async def changelog_page(
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    from app.core.utils import get_today
+
+    user = await get_current_user_optional(request, db)
+    return render(
+        "changelog.html",
+        {
+            "request": request,
+            "user": user,
+            "now": get_today(),
+            "versions": VERSIONS,
+            "current_version": VERSIONS[0]["version"],
+        },
+    )

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -100,5 +100,9 @@
             {% block page_content %}
             {% endblock %}
         </main>
+
+        <footer style="text-align: center; padding: 1.5rem 1rem 1rem; color: var(--muted); font-size: 0.78rem;">
+            <a href="/changelog" style="color: var(--muted); text-decoration: none;" title="Nyheter &amp; versioner">Periodical v0.0.20</a>
+        </footer>
     </body>
 </html>

--- a/app/templates/changelog.html
+++ b/app/templates/changelog.html
@@ -1,0 +1,38 @@
+{# app/templates/changelog.html #}
+{% extends "base.html" %}
+
+{% block title %}Periodical – Nyheter & Versioner{% endblock %}
+
+{% block page_content %}
+<section>
+    <div style="max-width: 720px;">
+        <h2 style="margin-bottom: 0.25rem;">Nyheter &amp; Versioner</h2>
+        <p style="color: var(--muted); margin-top: 0; margin-bottom: 2rem;">Aktuell version: <strong>v{{ current_version }}</strong></p>
+
+        {% for v in versions %}
+        <div class="card" style="margin-bottom: 1.5rem;">
+            <div style="display: flex; align-items: baseline; gap: 1rem; flex-wrap: wrap; margin-bottom: 0.75rem;">
+                <span style="font-size: 1.1rem; font-weight: 600; color: var(--text);">v{{ v.version }}</span>
+                <span style="color: var(--muted); font-size: 0.85rem;">{{ v.date }}</span>
+                {% if loop.first %}
+                <span style="background: var(--accent, #4f9cf9); color: #fff; font-size: 0.72rem; font-weight: 600; padding: 0.1rem 0.5rem; border-radius: 99px; letter-spacing: 0.04em;">SENASTE</span>
+                {% endif %}
+            </div>
+
+            <ul style="margin: 0; padding: 0; list-style: none; display: flex; flex-direction: column; gap: 0.45rem;">
+                {% for entry in v.entries %}
+                <li style="display: flex; gap: 0.6rem; align-items: baseline;">
+                    {% if entry.type == "nyhet" %}
+                    <span style="flex-shrink: 0; font-size: 0.7rem; font-weight: 700; letter-spacing: 0.05em; background: var(--muted-bg, #2a2a35); color: var(--accent, #4f9cf9); padding: 0.1rem 0.45rem; border-radius: 4px; text-transform: uppercase;">Nyhet</span>
+                    {% else %}
+                    <span style="flex-shrink: 0; font-size: 0.7rem; font-weight: 700; letter-spacing: 0.05em; background: var(--muted-bg, #2a2a35); color: var(--warning, #e0a84e); padding: 0.1rem 0.45rem; border-radius: 4px; text-transform: uppercase;">Fix</span>
+                    {% endif %}
+                    <span style="color: var(--text); line-height: 1.5;">{{ entry.text }}</span>
+                </li>
+                {% endfor %}
+            </ul>
+        </div>
+        {% endfor %}
+    </div>
+</section>
+{% endblock %}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -69,8 +69,21 @@ fi
 
 # 3. Git Pull
 log "📥 Hämtar senaste koden..."
-if ! git pull; then
-    error_exit "Git pull misslyckades. Kontrollera nätverk eller konflikter."
+git fetch origin
+
+# Ta bort ospårade filer som konfliktar med inkommande commits
+# (händer t.ex. när filer flyttas i repot men redan existerar lokalt)
+CONFLICTING=$(git diff --name-status HEAD origin/main 2>/dev/null \
+    | awk '$1=="A" || $1=="R100" {print $NF}' \
+    | while read -r f; do [ -f "$f" ] && echo "$f"; done)
+if [ -n "$CONFLICTING" ]; then
+    warn "Tar bort lokala ospårade filer som konfliktar med origin/main:"
+    echo "$CONFLICTING" | while read -r f; do warn "  - $f"; done
+    echo "$CONFLICTING" | xargs rm -f
+fi
+
+if ! git merge --ff-only origin/main; then
+    error_exit "Git merge misslyckades. Kontrollera nätverk eller konflikter."
 fi
 
 # Aktivera virtual environment (Kritiskt steg)


### PR DESCRIPTION
## Summary

- Ny sida `/changelog` med versionshistorik från v0.0.1 till v0.0.20, tillgänglig utan inloggning
- Diskret footer-länk ("Periodical v0.0.20") på alla sidor som leder till changelog-sidan
- Fix i `deploy.sh`: ersätter `git pull` med `git fetch` + selektiv rensning av ospårade filer som konfliktar med inkommande commits, följt av `git merge --ff-only` — löser det deployment-fel som uppstod när migrationsfiler flyttades till `migrations/`

## Test plan

- [x] Besök `/changelog` inloggad och utloggad — sidan ska laddas i båda fallen
- [x] Kontrollera att footer-länken syns på alla sidor
- [x] Trigga en deployment och verifiera att `git merge` lyckas utan konflikt