### PR TITLE
Fix iCal export rotation position bug

### DIFF
--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -15,6 +15,17 @@ router = APIRouter()
 
 VERSIONS = [
     {
+        "version": "0.12.1",
+        "date": "2026-04-23",
+        "entries": [
+            {
+                "type": "fix",
+                "sv": "iCal-export använde databas-ID istället för rotationsposition, vilket gav fel schema",
+                "en": "iCal export used database ID instead of rotation position, causing wrong schedule",
+            },
+        ],
+    },
+    {
         "version": "0.12.0",
         "date": "2026-04-23",
         "entries": [

--- a/app/routes/profile.py
+++ b/app/routes/profile.py
@@ -319,7 +319,9 @@ async def export_calendar(
     start_date = get_today()
     end_date = start_date + timedelta(days=180)
 
-    ical_content = generate_ical(person_id=current_user.id, start_date=start_date, end_date=end_date, lang=lang)
+    ical_content = generate_ical(
+        person_id=current_user.rotation_person_id, start_date=start_date, end_date=end_date, lang=lang
+    )
 
     return Response(
         content=ical_content,


### PR DESCRIPTION
## Summary

- `profile.py` skickade `current_user.id` (databas-ID) som `start_week` till `determine_shift_for_date`
- Användare med ID > 10 fick fel schema — Peter (ID 12) fick Adrianas (ID 2) schema eftersom 12 % 10 = 2
- Fix: använd `current_user.rotation_person_id` konsekvent med övrig kodbas