### PR TITLE
Fix handover report and day view OT/translation issues

### DIFF
--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -15,6 +15,17 @@ router = APIRouter()
 
 VERSIONS = [
     {
+        "version": "0.14.2",
+        "date": "2026-04-25",
+        "entries": [
+            {
+                "type": "fix",
+                "sv": "Överlämningsrapport: övertidspersonal visas nu med rätt passgrupp och markeras med (ÖT)",
+                "en": "Handover report: overtime workers now appear under the correct shift group and are marked with (ÖT)",
+            },
+        ],
+    },
+    {
         "version": "0.14.1",
         "date": "2026-04-25",
         "entries": [

--- a/app/routes/schedule_all.py
+++ b/app/routes/schedule_all.py
@@ -20,6 +20,7 @@ from app.core.schedule import (
     generate_month_data,
     generate_year_data,
     get_all_user_wages,
+    get_shift_types,
     rotation_start_date,
     summarize_month_for_person,
 )
@@ -249,10 +250,23 @@ async def show_handover(
 
     if day_data and "persons" in day_data:
         code_to_group = {g["code"]: g for g in shift_groups}
+        end_time_to_code = {
+            s.end_time: s.code for s in get_shift_types() if s.end_time and s.code in ("N1", "N2", "N3")
+        }
         for person in day_data["persons"]:
             shift = person.get("shift")
-            if shift and shift.code in code_to_group:
+            if not shift:
+                continue
+            if shift.code in code_to_group:
                 code_to_group[shift.code]["persons"].append(person["person_name"])
+            elif shift.code == "OT":
+                end_dt = person.get("end")
+                matched_code = end_time_to_code.get(end_dt.strftime("%H:%M")) if end_dt else None
+                name = f"{person['person_name']} (ÖT)"
+                if matched_code:
+                    code_to_group[matched_code]["persons"].append(name)
+                else:
+                    code_to_group["N1"]["persons"].append(name)
 
     return render_template(
         templates,

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -102,7 +102,7 @@
         </main>
 
         <footer style="text-align: center; padding: 1.5rem 1rem 1rem; color: var(--muted); font-size: 0.78rem;">
-            <a href="/changelog" style="color: var(--muted); text-decoration: none;" title="Nyheter &amp; versioner">Periodical v0.14.1</a>
+            <a href="/changelog" style="color: var(--muted); text-decoration: none;" title="Nyheter &amp; versioner">Periodical v0.14.2</a>
         </footer>
     </body>
 </html>

--- a/app/templates/day.html
+++ b/app/templates/day.html
@@ -27,7 +27,7 @@
         </div>
 
         <div class="day-buttons-right">
-            <a href="/handover?date={{ date }}" class="btn secondary">Överlämning</a>
+            <a href="/handover?date={{ date }}" class="btn secondary">{{ t.handover_title }}</a>
             {# Navigering mellan personer - endast för admin #}
             {% if user and user.role.value == 'admin' %}
                 {% for i in person_ids %}


### PR DESCRIPTION
## Summary
- Överlämningsrapport: övertidspersonal (is_extension=False) visas nu under rätt passgrupp markerade med (ÖT), matchning sker via skiftets sluttid
- Knappen till överlämningsrapporten i dagvyn använder nu översättningsnyckeln `t.handover_title` istället för hårdkodad svenska