### PR TITLE
Add manual shift override (N1/N2/N3) for OFF/OC days

### DIFF
--- a/app/core/schedule/period.py
+++ b/app/core/schedule/period.py
@@ -64,11 +64,12 @@ def build_week_data(
 
     rotation_to_user_id = _build_rotation_to_user_map(session, person_ids)
 
-    # Batch fetch absences, overtime, oncall overrides, and swaps for the week
+    # Batch fetch absences, overtime, oncall overrides, swaps, and shift overrides for the week
     absence_map = _batch_fetch_absences(session, person_ids, monday, sunday, rotation_to_user_id)
     ot_shift_map = _batch_fetch_ot_shifts(session, person_ids, monday, sunday, rotation_to_user_id)
     oncall_override_map = _batch_fetch_oncall_overrides(session, person_ids, monday, sunday, rotation_to_user_id)
     swap_map = _batch_fetch_swap_map(session, person_ids, monday, sunday, rotation_to_user_id)
+    shift_override_map = _batch_fetch_shift_overrides(session, person_ids, monday, sunday, rotation_to_user_id)
 
     days_in_week = []
 
@@ -93,6 +94,7 @@ def build_week_data(
                     absence_map,
                     oncall_override_map,
                     swap_map,
+                    shift_override_map=shift_override_map,
                 )
                 for pid in person_ids
             ]
@@ -110,6 +112,7 @@ def build_week_data(
                     oncall_override_map,
                     swap_map,
                     employment_start=employment_start,
+                    shift_override_map=shift_override_map,
                 )
             )
 
@@ -211,13 +214,16 @@ def generate_period_data(
     # Bygg mappning rotation_position -> user_id (hanterar Peter/Rickard som har olika user_id)
     rotation_to_user_id = _build_rotation_to_user_map(session, person_ids)
 
-    # Batch fetch absences, overtime shifts, oncall overrides, and swaps for the entire period
+    # Batch fetch absences, overtime shifts, oncall overrides, swaps, and shift overrides for the entire period
     absence_map = _batch_fetch_absences(session, person_ids, effective_start, end_date, rotation_to_user_id)
     ot_shift_map = _batch_fetch_ot_shifts(session, person_ids, effective_start, end_date, rotation_to_user_id)
     oncall_override_map = _batch_fetch_oncall_overrides(
         session, person_ids, effective_start, end_date, rotation_to_user_id
     )
     swap_map = _batch_fetch_swap_map(session, person_ids, effective_start, end_date, rotation_to_user_id)
+    shift_override_map = _batch_fetch_shift_overrides(
+        session, person_ids, effective_start, end_date, rotation_to_user_id
+    )
 
     # Generera dagdata
     persons = _get_persons()
@@ -245,6 +251,7 @@ def generate_period_data(
                     absence_map,
                     oncall_override_map,
                     swap_map,
+                    shift_override_map=shift_override_map,
                 )
                 for pid in person_ids
             ]
@@ -465,6 +472,43 @@ def _batch_fetch_oncall_overrides(
     return {(user_id_to_rotation.get(o.user_id, o.user_id), o.date): o for o in overrides}
 
 
+def _batch_fetch_shift_overrides(
+    session,
+    person_ids: list[int],
+    start_date: datetime.date,
+    end_date: datetime.date,
+    rotation_to_user_id: dict[int, int] | None = None,
+) -> dict[tuple[int, datetime.date], str]:
+    """Batch-hämtar manuella passöverrides för flera personer och en period.
+
+    Returns:
+        Dict med (rotation_position, date) -> shift_code
+    """
+    if not session:
+        return {}
+
+    from app.database.database import ShiftOverride
+
+    if rotation_to_user_id:
+        user_ids = list({rotation_to_user_id.get(p, p) for p in person_ids})
+        user_id_to_rotation = {v: k for k, v in rotation_to_user_id.items()}
+    else:
+        user_ids = person_ids
+        user_id_to_rotation = {}
+
+    overrides = (
+        session.query(ShiftOverride)
+        .filter(
+            ShiftOverride.user_id.in_(user_ids),
+            ShiftOverride.date >= start_date,
+            ShiftOverride.date <= end_date,
+        )
+        .all()
+    )
+
+    return {(user_id_to_rotation.get(o.user_id, o.user_id), o.date): o.shift_code for o in overrides}
+
+
 def _batch_fetch_swap_map(
     session,
     person_ids: list[int],
@@ -552,6 +596,7 @@ def _build_person_day_basic(
     oncall_override_map: dict[tuple[int, datetime.date], object] | None = None,
     swap_map: dict[tuple[int, datetime.date], str] | None = None,
     employment_start: datetime.date | None = None,
+    shift_override_map: dict[tuple[int, datetime.date], str] | None = None,
 ) -> dict:
     """Bygger grundläggande dagdata för en person."""
     vacation_shift = get_vacation_shift()
@@ -675,6 +720,27 @@ def _build_person_day_basic(
             "start": None,
             "end": None,
         }
+
+    # Kolla manuell passöverride (admin-tilldelat N1/N2/N3 som ersätter rotation)
+    if shift_override_map is not None:
+        override_code = shift_override_map.get((person_id, date))
+        if override_code:
+            result = determine_shift_for_date(date, person_id)
+            original_shift, rotation_week = result if result else (None, None)
+            override_shift = next((s for s in shift_types if s.code == override_code), None)
+            if override_shift:
+                hours, start, end = calculate_shift_hours(date, override_shift.code)
+                return {
+                    "person_id": person_id,
+                    "person_name": person_name,
+                    "shift": override_shift,
+                    "original_shift": original_shift,
+                    "rotation_week": rotation_week,
+                    "rotation_length": rotation_length,
+                    "hours": hours,
+                    "start": start,
+                    "end": end,
+                }
 
     # Kolla skiftbyte
     if swap_map is not None:

--- a/app/core/translations.py
+++ b/app/core/translations.py
@@ -507,6 +507,17 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "day_no_ob_hours": "Inga OB-timmar denna dag.",
         "day_no_ob_pay": "Ingen OB-ersättning denna dag.",
         "day_no_ob_rules": "Inga speciella OB-regler aktiva denna dag.",
+        # ── Day edit panel ─────────────────────────────────────────
+        "day_edit_toggle": "Ändra dag/skift",
+        "day_edit_close": "Stäng",
+        # ── Shift override ─────────────────────────────────────────
+        "day_shift_override_title": "Manuellt pass",
+        "day_shift_override_current": "Tilldelat pass",
+        "day_shift_override_remove": "Ta bort",
+        "day_shift_override_remove_confirm": "Ta bort det manuella passet?",
+        "day_shift_override_add": "Tilldela pass",
+        "day_shift_override_label": "Pass",
+        "day_shift_override_note": "Manuellt tilldelat pass åsidosätter rotationen och visas som ett ordinarie pass.",
         # ── Handover view ──────────────────────────────────────────
         "handover_title": "Överlämning",
         "handover_prev": "Föregående",
@@ -1394,6 +1405,17 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "day_no_ob_hours": "No OB hours this day.",
         "day_no_ob_pay": "No OB compensation this day.",
         "day_no_ob_rules": "No special OB rules active this day.",
+        # ── Day edit panel ─────────────────────────────────────────
+        "day_edit_toggle": "Edit day/shift",
+        "day_edit_close": "Close",
+        # ── Shift override ─────────────────────────────────────────
+        "day_shift_override_title": "Manual shift",
+        "day_shift_override_current": "Assigned shift",
+        "day_shift_override_remove": "Remove",
+        "day_shift_override_remove_confirm": "Remove the manual shift assignment?",
+        "day_shift_override_add": "Assign shift",
+        "day_shift_override_label": "Shift",
+        "day_shift_override_note": "A manually assigned shift overrides the rotation and appears as a regular shift.",
         # ── Handover view ──────────────────────────────────────────
         "handover_title": "Handover",
         "handover_prev": "Previous",

--- a/app/database/database.py
+++ b/app/database/database.py
@@ -192,6 +192,25 @@ class OnCallOverride(Base):
         return f"<OnCallOverride(id={self.id}, user_id={self.user_id}, date={self.date}, type={self.override_type})>"
 
 
+class ShiftOverride(Base):
+    """Manual shift assignment that overrides the rotation for a given day."""
+
+    __tablename__ = "shift_overrides"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    date = Column(Date, nullable=False)
+    shift_code = Column(String(10), nullable=False)  # N1, N2, N3
+    created_at = Column(DateTime, default=datetime.utcnow)
+    created_by = Column(Integer, ForeignKey("users.id"), nullable=True)
+
+    user = relationship("User", foreign_keys=[user_id])
+    creator = relationship("User", foreign_keys=[created_by])
+
+    def __repr__(self):
+        return f"<ShiftOverride(id={self.id}, user_id={self.user_id}, date={self.date}, shift_code={self.shift_code})>"
+
+
 class WageHistory(Base):
     """Wage history model for tracking wage changes over time with temporal validity."""
 

--- a/app/main.py
+++ b/app/main.py
@@ -32,6 +32,7 @@ from app.routes.profile import router as profile_router
 from app.routes.schedule_all import router as schedule_all_router
 from app.routes.schedule_api import router as schedule_api_router
 from app.routes.schedule_personal import router as schedule_personal_router
+from app.routes.shift_override import router as shift_override_router
 from app.routes.shift_swap import router as shift_swap_router
 from app.routes.statistics import router as statistics_router
 from app.routes.transition import router as transition_router
@@ -276,6 +277,7 @@ app.include_router(schedule_api_router)
 app.include_router(overtime_router)
 app.include_router(oncall_router)
 app.include_router(shift_swap_router)
+app.include_router(shift_override_router)
 app.include_router(statistics_router)
 app.include_router(auth_router)
 app.include_router(profile_router)

--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -15,6 +15,22 @@ router = APIRouter()
 
 VERSIONS = [
     {
+        "version": "0.15.0",
+        "date": "2026-04-25",
+        "entries": [
+            {
+                "type": "nyhet",
+                "sv": "Manuellt pass: tilldela N1/N2/N3 på en ledig dag – visas som ordinarie pass i överlämning, kollegor och API",
+                "en": "Manual shift: assign N1/N2/N3 on a day off – appears as a regular shift in handover, coworkers and API",
+            },
+            {
+                "type": "nyhet",
+                "sv": "Dagvyn samlar alla ändringsfunktioner bakom en 'Ändra dag/skift'-knapp",
+                "en": "Day view consolidates all edit options behind an 'Edit day/shift' toggle button",
+            },
+        ],
+    },
+    {
         "version": "0.14.2",
         "date": "2026-04-25",
         "entries": [

--- a/app/routes/schedule_personal.py
+++ b/app/routes/schedule_personal.py
@@ -48,7 +48,7 @@ from app.core.schedule import (
 from app.core.schedule.vacation import calculate_vacation_balance
 from app.core.utils import get_navigation_dates, get_ot_shift_display_code, get_safe_today, get_today
 from app.core.validators import validate_date_params, validate_person_id
-from app.database.database import Absence, OnCallOverride, OnCallOverrideType, User, UserRole, get_db
+from app.database.database import Absence, OnCallOverride, OnCallOverrideType, ShiftOverride, User, UserRole, get_db
 from app.routes.shared import redirect_if_not_own_data, templates
 
 logger = get_logger(__name__)
@@ -156,6 +156,21 @@ async def show_day_for_person(
     is_effective_oc = (
         has_rotation_oc and not (oncall_override and oncall_override.override_type == OnCallOverrideType.REMOVE)
     ) or (oncall_override and oncall_override.override_type == OnCallOverrideType.ADD)
+
+    # Fetch and apply manual shift override (N1/N2/N3 assigned by admin)
+    shift_override = (
+        db.query(ShiftOverride)
+        .filter(ShiftOverride.user_id == user_id_for_wages, ShiftOverride.date == date_obj)
+        .first()
+    )
+    if shift_override:
+        from app.core.storage import load_shift_types
+
+        all_shifts = load_shift_types()
+        override_shift = next((s for s in all_shifts if s.code == shift_override.shift_code), None)
+        if override_shift:
+            shift = override_shift
+            is_effective_oc = False  # Override takes priority over OC
 
     hours: float = 0.0
     start_dt: datetime | None = None
@@ -571,9 +586,10 @@ async def show_day_for_person(
             "swap_users": db.query(User)
             .filter(User.is_active == 1, User.id != current_user.id, User.role != UserRole.ADMIN)
             .all(),
-            "oncall_override": oncall_override,  # On-call override data
-            "has_rotation_oc": has_rotation_oc,  # Whether person has OC in rotation
-            "is_effective_oc": is_effective_oc,  # Whether this is effectively an OC shift
+            "oncall_override": oncall_override,
+            "has_rotation_oc": has_rotation_oc,
+            "is_effective_oc": is_effective_oc,
+            "shift_override": shift_override,
             **nav,
         },
         user=current_user,

--- a/app/routes/shift_override.py
+++ b/app/routes/shift_override.py
@@ -1,0 +1,85 @@
+# app/routes/shift_override.py
+"""Routes for manual shift overrides (adding/removing a regular shift for a day)."""
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Form, HTTPException
+from fastapi.responses import RedirectResponse
+from sqlalchemy.orm import Session
+
+from app.auth.auth import get_current_user
+from app.core.schedule import clear_schedule_cache
+from app.database.database import ShiftOverride, User, UserRole, get_db
+
+router = APIRouter(prefix="/shift-override", tags=["shift_override"])
+
+_ALLOWED_CODES = {"N1", "N2", "N3"}
+
+
+@router.post("/add")
+async def add_shift_override(
+    user_id: int = Form(...),
+    date: str = Form(...),
+    shift_code: str = Form(...),
+    session: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    if current_user.role != UserRole.ADMIN and current_user.id != user_id:
+        raise HTTPException(status_code=403, detail="Du kan bara lägga till manuella pass för dig själv")
+
+    if shift_code not in _ALLOWED_CODES:
+        raise HTTPException(status_code=400, detail="Ogiltigt skiftkod, använd N1/N2/N3")
+
+    override_date = datetime.strptime(date, "%Y-%m-%d").date()
+
+    existing = (
+        session.query(ShiftOverride)
+        .filter(ShiftOverride.user_id == user_id, ShiftOverride.date == override_date)
+        .first()
+    )
+    if existing:
+        existing.shift_code = shift_code
+        existing.created_by = current_user.id
+    else:
+        session.add(
+            ShiftOverride(
+                user_id=user_id,
+                date=override_date,
+                shift_code=shift_code,
+                created_by=current_user.id,
+            )
+        )
+
+    session.commit()
+    clear_schedule_cache()
+
+    return RedirectResponse(
+        url=f"/day/{user_id}/{override_date.year}/{override_date.month}/{override_date.day}",
+        status_code=303,
+    )
+
+
+@router.post("/{override_id}/delete")
+async def delete_shift_override(
+    override_id: int,
+    session: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    override = session.query(ShiftOverride).filter(ShiftOverride.id == override_id).first()
+    if not override:
+        raise HTTPException(status_code=404, detail="Override hittades inte")
+
+    if current_user.role != UserRole.ADMIN and current_user.id != override.user_id:
+        raise HTTPException(status_code=403, detail="Du kan bara ta bort dina egna manuella pass")
+
+    redirect_date = override.date
+    redirect_user = override.user_id
+
+    session.delete(override)
+    session.commit()
+    clear_schedule_cache()
+
+    return RedirectResponse(
+        url=f"/day/{redirect_user}/{redirect_date.year}/{redirect_date.month}/{redirect_date.day}",
+        status_code=303,
+    )

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -102,7 +102,7 @@
         </main>
 
         <footer style="text-align: center; padding: 1.5rem 1rem 1rem; color: var(--muted); font-size: 0.78rem;">
-            <a href="/changelog" style="color: var(--muted); text-decoration: none;" title="Nyheter &amp; versioner">Periodical v0.14.2</a>
+            <a href="/changelog" style="color: var(--muted); text-decoration: none;" title="Nyheter &amp; versioner">Periodical v0.15.0</a>
         </footer>
     </body>
 </html>

--- a/app/templates/day.html
+++ b/app/templates/day.html
@@ -103,6 +103,12 @@
                 </tbody>
             </table>
 
+            {% set has_active = ot_shift or absence or oncall_override or shift_override %}
+            <button id="day-edit-btn" class="btn secondary" style="margin-top:1rem;"
+                    onclick="toggleDayEdit()">{{ t.day_edit_toggle }} ▾</button>
+
+            <div id="day-edit-panel" style="display:{% if has_active %}block{% else %}none{% endif %};">
+
             <h3>{{ t.day_overtime }}</h3>
 
             {% if ot_shift %}
@@ -508,6 +514,60 @@
             {% endif %}
         {% endif %}
 
+        {# Manuellt pass – visa om override finns, eller om personen är OFF/OC och saknar frånvaro #}
+        {% if user and (user.id == person_id or user.id == 0) %}
+            {% if shift_override or (not absence and shift and shift.code in ('OFF', 'OC')) %}
+                <h3>{{ t.day_shift_override_title }}</h3>
+
+                {% if shift_override %}
+                    <div class="oncall-override-display">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>{{ t.day_shift_override_current }}</th>
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <span class="badge" style="background: #3b82f6; color: white;">{{ shift_override.shift_code }}</span>
+                                    </td>
+                                    <td>
+                                        <form method="POST" action="/shift-override/{{ shift_override.id }}/delete" style="display: inline;">
+                                            <button type="submit" class="btn btn-danger" onclick="return confirm('{{ t.day_shift_override_remove_confirm }}')">{{ t.day_shift_override_remove }}</button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                {% else %}
+                    <form method="POST" action="/shift-override/add">
+                        <input type="hidden" name="user_id" value="{{ person_id }}">
+                        <input type="hidden" name="date" value="{{ date }}">
+
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label for="shift_code">{{ t.day_shift_override_label }}</label>
+                                <select id="shift_code" name="shift_code" required>
+                                    <option value="N1">N1 – {{ t.handover_morning }}</option>
+                                    <option value="N2">N2 – {{ t.handover_evening }}</option>
+                                    <option value="N3">N3 – {{ t.handover_night }}</option>
+                                </select>
+                            </div>
+                        </div>
+
+                        <button type="submit" class="btn btn-primary">{{ t.day_shift_override_add }}</button>
+                    </form>
+
+                    <p class="info-text">{{ t.day_shift_override_note }}</p>
+                {% endif %}
+            {% endif %}
+        {% endif %}
+
+            </div>{# /day-edit-panel #}
+
         <h3>{{ t.day_all_working }}</h3>
         {% if all_working_persons and all_working_persons|length > 0 %}
             <table>
@@ -753,5 +813,15 @@
 
 
     </div>
+
+<script>
+function toggleDayEdit() {
+    var panel = document.getElementById('day-edit-panel');
+    var btn = document.getElementById('day-edit-btn');
+    var open = panel.style.display !== 'none';
+    panel.style.display = open ? 'none' : 'block';
+    btn.textContent = open ? '{{ t.day_edit_toggle }} ▾' : '{{ t.day_edit_close }} ▲';
+}
+</script>
 
 {% endblock %}

--- a/migrations/migrate_add_shift_overrides.py
+++ b/migrations/migrate_add_shift_overrides.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""
+Migration: Add shift_overrides table.
+
+Enables manual shift assignments (N1/N2/N3) that override the rotation
+for a given day, displayed as regular shifts (not overtime).
+
+Run: python migrations/migrate_add_shift_overrides.py
+"""
+
+import sqlite3
+import sys
+
+DB_PATH = sys.argv[1] if len(sys.argv) > 1 else "app/database/schedule.db"
+
+conn = sqlite3.connect(DB_PATH)
+cur = conn.cursor()
+
+cur.execute("""
+    CREATE TABLE IF NOT EXISTS shift_overrides (
+        id         INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id    INTEGER NOT NULL REFERENCES users(id),
+        date       DATE    NOT NULL,
+        shift_code TEXT    NOT NULL,
+        created_at DATETIME DEFAULT (datetime('now')),
+        created_by INTEGER REFERENCES users(id)
+    )
+""")
+
+conn.commit()
+conn.close()
+print("Done: shift_overrides table created.")


### PR DESCRIPTION
## Summary
- Ny funktion: admin eller personen själv kan tilldela N1/N2/N3 på en dag som annars är OFF eller OC
- Overriden visas som ett ordinarie pass (inte ÖT) i överlämningsrapport, kollegalista och API
- Dagvyn samlar alla redigeringssektioner (ÖT, frånvaro, beredskap, manuellt pass) bakom en "Ändra dag/skift"-knapp – panelen öppnas automatiskt om aktiv data finns
- Migrationsscript: `migrations/migrate_add_shift_overrides.py`