### PR TITLE
Add payslip-style breakdown for hourly wage users in month view

### DIFF
--- a/app/core/schedule/summary.py
+++ b/app/core/schedule/summary.py
@@ -216,6 +216,8 @@ def summarize_month_for_person(
         totals["sick_days"] = absence_info["sick_days"]
         totals["sick_hours"] = absence_info["sick_hours"]
         totals["sick_ob_pay"] = absence_info.get("sick_ob_pay", 0.0)
+        totals["sick_ob_pay_by_code"] = absence_info.get("sick_ob_pay_by_code", {})
+        totals["sick_ob_hours_by_code"] = absence_info.get("sick_ob_hours_by_code", {})
         totals["sick_total_ob"] = absence_info.get("sick_total_ob", 0.0)
         totals["sick_ob_lost"] = absence_info.get("sick_ob_lost", 0.0)
         totals["vab_days"] = absence_info["vab_days"]
@@ -259,6 +261,8 @@ def summarize_month_for_person(
         "sick_days": totals["sick_days"],
         "sick_hours": totals.get("sick_hours", 0.0),
         "sick_ob_pay": totals.get("sick_ob_pay", 0.0),
+        "sick_ob_pay_by_code": totals.get("sick_ob_pay_by_code", {}),
+        "sick_ob_hours_by_code": totals.get("sick_ob_hours_by_code", {}),
         "sick_total_ob": totals.get("sick_total_ob", 0.0),
         "sick_ob_lost": totals.get("sick_ob_lost", 0.0),
         "vab_days": totals["vab_days"],

--- a/app/core/schedule/wages.py
+++ b/app/core/schedule/wages.py
@@ -406,6 +406,8 @@ def get_absence_deductions_for_month(
     sick_days = 0
     sick_hours = 0.0
     sick_ob_pay = 0.0
+    sick_ob_pay_by_code: dict[str, float] = {}
+    sick_ob_hours_by_code: dict[str, float] = {}
     sick_total_ob = 0.0
     vab_days = 0
     vab_hours = 0.0
@@ -469,15 +471,24 @@ def get_absence_deductions_for_month(
                     _ob_overrides = date_rates.get("ob") or ob_rate_overrides
                     _ob_compensation = bool(date_rates.get("sick", {}).get("ob_compensation"))
 
-                full_ob_total = sum(
-                    calculate_ob_pay(
-                        start_dt, shift_end_dt, ob_rules, monthly_wage, rate_overrides=_ob_overrides
-                    ).values()
+                from app.core.schedule.ob import calculate_ob_hours as _calc_ob_hours
+
+                full_ob_by_code = calculate_ob_pay(
+                    start_dt, shift_end_dt, ob_rules, monthly_wage, rate_overrides=_ob_overrides
                 )
+                full_ob_hours_by_code = _calc_ob_hours(start_dt, shift_end_dt, ob_rules)
+                full_ob_total = sum(full_ob_by_code.values())
                 sick_total_ob += full_ob_total * (absent_hours / shift_hours)
 
                 if _ob_compensation and sjuklon_hours > 0:
-                    sick_ob_pay += full_ob_total * (sjuklon_hours / shift_hours) * 0.8
+                    hours_ratio = sjuklon_hours / shift_hours
+                    ratio = hours_ratio * 0.8
+                    sick_ob_pay += full_ob_total * ratio
+                    for code, pay in full_ob_by_code.items():
+                        if pay > 0:
+                            sick_ob_pay_by_code[code] = sick_ob_pay_by_code.get(code, 0.0) + pay * ratio
+                            ob_h = full_ob_hours_by_code.get(code, 0.0) or 0.0
+                            sick_ob_hours_by_code[code] = sick_ob_hours_by_code.get(code, 0.0) + ob_h * hours_ratio
 
         else:
             karens_today = 0.0
@@ -517,6 +528,8 @@ def get_absence_deductions_for_month(
         "sick_days": sick_days,
         "sick_hours": sick_hours,
         "sick_ob_pay": sick_ob_pay,
+        "sick_ob_pay_by_code": sick_ob_pay_by_code,
+        "sick_ob_hours_by_code": sick_ob_hours_by_code,
         "sick_total_ob": sick_total_ob,
         "sick_ob_lost": sick_total_ob - sick_ob_pay,
         "vab_days": vab_days,

--- a/app/main.py
+++ b/app/main.py
@@ -117,10 +117,12 @@ async def lifespan(app: FastAPI):
     logger.info("Application shutting down")
 
 
+from app.routes.changelog import VERSIONS as _VERSIONS  # noqa: E402
+
 app = FastAPI(
     title="Periodical",
     description="Employee shift scheduling and OB pay calculation system",
-    version="0.12.0",
+    version=_VERSIONS[0]["version"],
     lifespan=lifespan,
 )
 
@@ -288,9 +290,7 @@ app.include_router(changelog_router)
 
 
 def _app_version() -> str:
-    from app.routes.changelog import VERSIONS
-
-    return VERSIONS[0]["version"]
+    return _VERSIONS[0]["version"]
 
 
 @app.get("/health", tags=["health"])

--- a/app/main.py
+++ b/app/main.py
@@ -118,6 +118,9 @@ async def lifespan(app: FastAPI):
 
 
 from app.routes.changelog import VERSIONS as _VERSIONS  # noqa: E402
+from app.routes.shared import templates as _templates  # noqa: E402
+
+_templates.env.globals["app_version"] = _VERSIONS[0]["version"]
 
 app = FastAPI(
     title="Periodical",

--- a/app/main.py
+++ b/app/main.py
@@ -287,6 +287,12 @@ app.include_router(transition_router)
 app.include_router(changelog_router)
 
 
+def _app_version() -> str:
+    from app.routes.changelog import VERSIONS
+
+    return VERSIONS[0]["version"]
+
+
 @app.get("/health", tags=["health"])
 async def health_check(db: Session = Depends(get_db)):
     """
@@ -304,7 +310,7 @@ async def health_check(db: Session = Depends(get_db)):
             content={
                 "status": "healthy",
                 "service": "periodical",
-                "version": "0.12.0",
+                "version": _app_version(),
                 "database": "connected",
             },
         )

--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -15,6 +15,22 @@ router = APIRouter()
 
 VERSIONS = [
     {
+        "version": "0.18.0",
+        "date": "2026-04-26",
+        "entries": [
+            {
+                "type": "nyhet",
+                "sv": "Månadsvy: timlönsanvändare får nu en lönespecifikation med uppdelning per löneart – arbetade timmar, OB per kod, beredskap, övertid och sjuklön",
+                "en": "Month view: hourly wage users now see a payslip-style breakdown with rows per pay type – worked hours, OB by code, on-call, overtime and sick pay",
+            },
+            {
+                "type": "fix",
+                "sv": "Månadsvy: bruttolön i sammanfattningen stämmer nu med lönespecifikationens totalt för timlönsanvändare",
+                "en": "Month view: gross pay in the summary now matches the payslip spec total for hourly wage users",
+            },
+        ],
+    },
+    {
         "version": "0.17.0",
         "date": "2026-04-26",
         "entries": [

--- a/app/routes/schedule_personal.py
+++ b/app/routes/schedule_personal.py
@@ -681,6 +681,22 @@ async def show_week_for_person(
     )
 
 
+def _compute_sjuklon_base(
+    hourly_rate: float,
+    sick_hours: float,
+    absence_deduction: float,
+    sick_ob_hours_by_code: dict,
+) -> dict:
+    sjuklon_pay_total = max(0.0, hourly_rate * sick_hours - absence_deduction)
+    sjuklon_hours_total = (sjuklon_pay_total / (hourly_rate * 0.8)) if hourly_rate > 0 else 0.0
+    sick_ob_h_total = sum(sick_ob_hours_by_code.values())
+    sjuklon_base_hours = max(0.0, sjuklon_hours_total - sick_ob_h_total)
+    return {
+        "sjuklon_base_hours": sjuklon_base_hours,
+        "sjuklon_base_pay": sjuklon_base_hours * hourly_rate * 0.8,
+    }
+
+
 @router.get("/month/{person_id}", response_class=HTMLResponse, name="month_person")
 async def show_month_for_person(
     request: Request,
@@ -804,6 +820,92 @@ async def show_month_for_person(
         year, month, _cal_mod.monthrange(year, month)[1]
     )
 
+    # Aggregated payslip-style breakdown for hourly wage users
+    hourly_breakdown = None
+    if show_salary:
+        from app.database.database import WageType
+
+        wage_user = (
+            db.query(User).filter(User.id == user_id_for_wages).first()
+            if user_id_for_wages > 10
+            else db.query(User).filter(User.person_id == rotation_position).first()
+        )
+        if wage_user and getattr(wage_user, "wage_type", None) == WageType.HOURLY:
+            hourly_rate = float(
+                get_user_wage(db, user_id_for_wages, settings.monthly_salary, effective_date=date(year, month, 1))
+            )
+            _OC_TO_GROUP = {
+                "OC_WEEKDAY": "oc_vardag",
+                "OC_WEEKEND": "oc_helg",
+                "OC_WEEKEND_SAT": "oc_helg",
+                "OC_WEEKEND_SUN": "oc_helg",
+                "OC_WEEKEND_MON": "oc_helg",
+                "OC_HOLIDAY": "oc_helgdag",
+                "OC_HOLIDAY_EVE": "oc_helgdag",
+                "OC_NATIONALDAGEN": "oc_helgdag",
+                "OC_SPECIAL": "oc_storhelg",
+            }
+            agg = {
+                k: {"hours": 0.0, "pay": 0.0}
+                for k in [
+                    "norm",
+                    "OB1",
+                    "OB2",
+                    "OB3",
+                    "OB4",
+                    "OB5",
+                    "oc_vardag",
+                    "oc_helg",
+                    "oc_helgdag",
+                    "oc_storhelg",
+                    "ot",
+                ]
+            }
+            for d in days_in_month.get("days", []):
+                shift = d.get("shift")
+                hours = d.get("hours", 0.0) or 0.0
+                ob_h = d.get("ob_hours", {}) or {}
+                ob_p = d.get("ob_pay", {}) or {}
+                if shift and shift.code not in ("OFF", "OC", "OT") and hours:
+                    ob_sum = sum(ob_h.values())
+                    norm = max(hours - ob_sum, 0.0)
+                    agg["norm"]["hours"] += norm
+                    agg["norm"]["pay"] += norm * hourly_rate
+                    for code in ("OB1", "OB2", "OB3", "OB4", "OB5"):
+                        h = ob_h.get(code, 0.0) or 0.0
+                        agg[code]["hours"] += h
+                        agg[code]["pay"] += (ob_p.get(code, 0.0) or 0.0) + h * hourly_rate
+                oc_bd = (d.get("oncall_details") or {}).get("breakdown", {}) or {}
+                for oc_code, group in _OC_TO_GROUP.items():
+                    entry = oc_bd.get(oc_code) or {}
+                    agg[group]["hours"] += entry.get("hours", 0.0) or 0.0
+                    agg[group]["pay"] += entry.get("pay", 0.0) or 0.0
+                agg["ot"]["hours"] += d.get("ot_hours", 0.0) or 0.0
+                agg["ot"]["pay"] += d.get("ot_pay", 0.0) or 0.0
+            last_day = _cal_mod.monthrange(year, month)[1]
+            _sick_ob_py = days_in_month.get("sick_ob_pay_by_code", {}) or {}
+            _sick_ob_hs = days_in_month.get("sick_ob_hours_by_code", {}) or {}
+            _sjuklon_info = _compute_sjuklon_base(
+                hourly_rate,
+                days_in_month.get("sick_hours", 0.0) or 0.0,
+                days_in_month.get("absence_deduction", 0.0) or 0.0,
+                _sick_ob_hs,
+            )
+            _spec_total = sum(v["pay"] for v in agg.values()) + _sjuklon_info["sjuklon_base_pay"]
+            for _code, _ob_h in _sick_ob_hs.items():
+                if _ob_h > 0:
+                    _spec_total += _ob_h * hourly_rate * 0.8 + _sick_ob_py.get(_code, 0.0)
+            hourly_breakdown = {
+                "hourly_rate": hourly_rate,
+                "period": f"{year}{month:02d}01-{year}{month:02d}{last_day:02d}",
+                "rows": agg,
+                "sick_days": days_in_month.get("sick_days", 0) or 0,
+                "sick_ob_pay_by_code": _sick_ob_py,
+                "sick_ob_hours_by_code": _sick_ob_hs,
+                "spec_total": _spec_total,
+                **_sjuklon_info,
+            }
+
     return render_template(
         templates,
         "month.html",
@@ -820,6 +922,7 @@ async def show_month_for_person(
             "holiday_dates": holiday_dates,
             "vacation_month": vacation_month,
             "before_employment_month": before_employment_month,
+            "hourly_breakdown": hourly_breakdown,
         },
         user=current_user,
     )

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -102,7 +102,7 @@
         </main>
 
         <footer style="text-align: center; padding: 1.5rem 1rem 1rem; color: var(--muted); font-size: 0.78rem;">
-            <a href="/changelog" style="color: var(--muted); text-decoration: none;" title="Nyheter &amp; versioner">Periodical v0.17.0</a>
+            <a href="/changelog" style="color: var(--muted); text-decoration: none;" title="Nyheter &amp; versioner">Periodical v{{ app_version }}</a>
         </footer>
     </body>
 </html>

--- a/app/templates/month.html
+++ b/app/templates/month.html
@@ -76,7 +76,7 @@
             <tr>
                 {% if show_salary %}
                 <td data-label="{{ t.month_sum_net }}">{{ "%.0f"|format(days.netto_pay or 0) }}</td>
-                <td data-label="{{ t.month_sum_gross }}">{{ "%.0f"|format(days.brutto_pay or 0) }}</td>
+                <td data-label="{{ t.month_sum_gross }}">{{ "%.0f"|format(hourly_breakdown.spec_total if hourly_breakdown else (days.brutto_pay or 0)) }}</td>
                 <td data-label="{{ t.month_sum_shifts }}">{{ days.num_shifts }}</td>
                 <td data-label="{{ t.month_sum_hours }}">{{ "%.2f"|format(days.total_hours or 0) }}</td>
                 {% endif %}
@@ -405,6 +405,203 @@
             </table>
         </div>
     </div>
+
+    {% if hourly_breakdown %}
+    <div style="margin-top: 2rem;">
+        <h3 style="margin-bottom: 0.75rem;">Lönespecifikation</h3>
+        <div style="overflow-x: auto;">
+            <table class="breakdown-table">
+                <thead>
+                    <tr>
+                        <th class="th_left">Benämning</th>
+                        <th class="th_left">Period</th>
+                        <th class="th_right">Antal</th>
+                        <th class="th_right">A-pris</th>
+                        <th class="th_right">Belopp</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% set rows = hourly_breakdown.rows %}
+                    {% set period = hourly_breakdown.period %}
+                    {% set hr = hourly_breakdown.hourly_rate %}
+                    {% set ns2 = namespace(total=0.0) %}
+
+                    {% if rows.norm.hours > 0 %}
+                    <tr>
+                        <td class="td_left">Arbetade timmar</td>
+                        <td class="td_left num">{{ period }}</td>
+                        <td class="td_right num">{{ "%.1f"|format(rows.norm.hours) }} st</td>
+                        <td class="td_right num">{{ "%.2f"|format(hr) }}</td>
+                        <td class="td_right num">{{ "{:,.0f}".format(rows.norm.pay).replace(",", " ") }}</td>
+                    </tr>
+                    {% set ns2.total = ns2.total + rows.norm.pay %}
+                    {% endif %}
+
+                    {% if rows.OB1.hours > 0 %}
+                    {% set ob1_rate = rows.OB1.pay / rows.OB1.hours %}
+                    <tr>
+                        <td class="td_left">Arbetade timmar med OB vardag 18:00-24:00</td>
+                        <td class="td_left num">{{ period }}</td>
+                        <td class="td_right num">{{ "%.1f"|format(rows.OB1.hours) }} st</td>
+                        <td class="td_right num">{{ "%.2f"|format(ob1_rate) }}</td>
+                        <td class="td_right num">{{ "{:,.0f}".format(rows.OB1.pay).replace(",", " ") }}</td>
+                    </tr>
+                    {% set ns2.total = ns2.total + rows.OB1.pay %}
+                    {% endif %}
+
+                    {% if rows.OB2.hours > 0 %}
+                    {% set ob2_rate = rows.OB2.pay / rows.OB2.hours %}
+                    <tr>
+                        <td class="td_left">Arbetade timmar med OB vardag 00:00-07:00</td>
+                        <td class="td_left num">{{ period }}</td>
+                        <td class="td_right num">{{ "%.1f"|format(rows.OB2.hours) }} st</td>
+                        <td class="td_right num">{{ "%.2f"|format(ob2_rate) }}</td>
+                        <td class="td_right num">{{ "{:,.0f}".format(rows.OB2.pay).replace(",", " ") }}</td>
+                    </tr>
+                    {% set ns2.total = ns2.total + rows.OB2.pay %}
+                    {% endif %}
+
+                    {% if rows.OB3.hours > 0 %}
+                    {% set ob3_rate = rows.OB3.pay / rows.OB3.hours %}
+                    <tr>
+                        <td class="td_left">Arbetade timmar med OB helg</td>
+                        <td class="td_left num">{{ period }}</td>
+                        <td class="td_right num">{{ "%.1f"|format(rows.OB3.hours) }} st</td>
+                        <td class="td_right num">{{ "%.2f"|format(ob3_rate) }}</td>
+                        <td class="td_right num">{{ "{:,.0f}".format(rows.OB3.pay).replace(",", " ") }}</td>
+                    </tr>
+                    {% set ns2.total = ns2.total + rows.OB3.pay %}
+                    {% endif %}
+
+                    {% if rows.OB4.hours > 0 %}
+                    {% set ob4_rate = rows.OB4.pay / rows.OB4.hours %}
+                    <tr>
+                        <td class="td_left">Arbetade timmar med OB helgdag</td>
+                        <td class="td_left num">{{ period }}</td>
+                        <td class="td_right num">{{ "%.1f"|format(rows.OB4.hours) }} st</td>
+                        <td class="td_right num">{{ "%.2f"|format(ob4_rate) }}</td>
+                        <td class="td_right num">{{ "{:,.0f}".format(rows.OB4.pay).replace(",", " ") }}</td>
+                    </tr>
+                    {% set ns2.total = ns2.total + rows.OB4.pay %}
+                    {% endif %}
+
+                    {% if rows.OB5.hours > 0 %}
+                    {% set ob5_rate = rows.OB5.pay / rows.OB5.hours %}
+                    <tr>
+                        <td class="td_left">Arbetade timmar med OB storhelg</td>
+                        <td class="td_left num">{{ period }}</td>
+                        <td class="td_right num">{{ "%.1f"|format(rows.OB5.hours) }} st</td>
+                        <td class="td_right num">{{ "%.2f"|format(ob5_rate) }}</td>
+                        <td class="td_right num">{{ "{:,.0f}".format(rows.OB5.pay).replace(",", " ") }}</td>
+                    </tr>
+                    {% set ns2.total = ns2.total + rows.OB5.pay %}
+                    {% endif %}
+
+                    {% if rows.oc_vardag.hours > 0 %}
+                    {% set ocv_rate = rows.oc_vardag.pay / rows.oc_vardag.hours %}
+                    <tr>
+                        <td class="td_left">Beredskap vardag</td>
+                        <td class="td_left num">{{ period }}</td>
+                        <td class="td_right num">{{ "%.1f"|format(rows.oc_vardag.hours) }} st</td>
+                        <td class="td_right num">{{ "%.2f"|format(ocv_rate) }}</td>
+                        <td class="td_right num">{{ "{:,.0f}".format(rows.oc_vardag.pay).replace(",", " ") }}</td>
+                    </tr>
+                    {% set ns2.total = ns2.total + rows.oc_vardag.pay %}
+                    {% endif %}
+
+                    {% if rows.oc_helg.hours > 0 %}
+                    {% set och_rate = rows.oc_helg.pay / rows.oc_helg.hours %}
+                    <tr>
+                        <td class="td_left">Beredskap helg fre 17:00-mån 07:00</td>
+                        <td class="td_left num">{{ period }}</td>
+                        <td class="td_right num">{{ "%.1f"|format(rows.oc_helg.hours) }} st</td>
+                        <td class="td_right num">{{ "%.2f"|format(och_rate) }}</td>
+                        <td class="td_right num">{{ "{:,.0f}".format(rows.oc_helg.pay).replace(",", " ") }}</td>
+                    </tr>
+                    {% set ns2.total = ns2.total + rows.oc_helg.pay %}
+                    {% endif %}
+
+                    {% if rows.oc_helgdag.hours > 0 %}
+                    {% set ochd_rate = rows.oc_helgdag.pay / rows.oc_helgdag.hours %}
+                    <tr>
+                        <td class="td_left">Beredskap röd dag</td>
+                        <td class="td_left num">{{ period }}</td>
+                        <td class="td_right num">{{ "%.1f"|format(rows.oc_helgdag.hours) }} st</td>
+                        <td class="td_right num">{{ "%.2f"|format(ochd_rate) }}</td>
+                        <td class="td_right num">{{ "{:,.0f}".format(rows.oc_helgdag.pay).replace(",", " ") }}</td>
+                    </tr>
+                    {% set ns2.total = ns2.total + rows.oc_helgdag.pay %}
+                    {% endif %}
+
+                    {% if rows.oc_storhelg.hours > 0 %}
+                    {% set ocsh_rate = rows.oc_storhelg.pay / rows.oc_storhelg.hours %}
+                    <tr>
+                        <td class="td_left">Beredskap storhelg</td>
+                        <td class="td_left num">{{ period }}</td>
+                        <td class="td_right num">{{ "%.1f"|format(rows.oc_storhelg.hours) }} st</td>
+                        <td class="td_right num">{{ "%.2f"|format(ocsh_rate) }}</td>
+                        <td class="td_right num">{{ "{:,.0f}".format(rows.oc_storhelg.pay).replace(",", " ") }}</td>
+                    </tr>
+                    {% set ns2.total = ns2.total + rows.oc_storhelg.pay %}
+                    {% endif %}
+
+                    {% if rows.ot.hours > 0 %}
+                    {% set ot_rate = rows.ot.pay / rows.ot.hours %}
+                    <tr>
+                        <td class="td_left">Övertid</td>
+                        <td class="td_left num">{{ period }}</td>
+                        <td class="td_right num">{{ "%.1f"|format(rows.ot.hours) }} st</td>
+                        <td class="td_right num">{{ "%.2f"|format(ot_rate) }}</td>
+                        <td class="td_right num">{{ "{:,.0f}".format(rows.ot.pay).replace(",", " ") }}</td>
+                    </tr>
+                    {% set ns2.total = ns2.total + rows.ot.pay %}
+                    {% endif %}
+
+                    {% set ob_labels = {
+                        "OB1": "vardag 18:00-24:00",
+                        "OB2": "vardag 00:00-07:00",
+                        "OB3": "helg",
+                        "OB4": "helgdag",
+                        "OB5": "storhelg"
+                    } %}
+
+                    {% if hourly_breakdown.sjuklon_base_hours > 0 %}
+                    <tr>
+                        <td class="td_left">Sjuklön ({{ hourly_breakdown.sick_days }} dag{% if hourly_breakdown.sick_days != 1 %}ar{% endif %})</td>
+                        <td class="td_left num">{{ period }}</td>
+                        <td class="td_right num">{{ "%.1f"|format(hourly_breakdown.sjuklon_base_hours) }} st</td>
+                        <td class="td_right num">{{ "%.2f"|format(hr * 0.8) }}</td>
+                        <td class="td_right num">{{ "{:,.0f}".format(hourly_breakdown.sjuklon_base_pay).replace(",", " ") }}</td>
+                    </tr>
+                    {% set ns2.total = ns2.total + hourly_breakdown.sjuklon_base_pay %}
+                    {% endif %}
+
+                    {% for code, ob_h in hourly_breakdown.sick_ob_hours_by_code.items() %}
+                    {% if ob_h > 0 %}
+                    {% set ob_pay = hourly_breakdown.sick_ob_pay_by_code.get(code, 0) %}
+                    {% set sick_ob_rate = hr * 0.8 + ob_pay / ob_h %}
+                    {% set sick_ob_total = ob_h * sick_ob_rate %}
+                    <tr>
+                        <td class="td_left">Sjuklön timmar med OB {{ ob_labels.get(code, code) }}</td>
+                        <td class="td_left num">{{ period }}</td>
+                        <td class="td_right num">{{ "%.1f"|format(ob_h) }} st</td>
+                        <td class="td_right num">{{ "%.2f"|format(sick_ob_rate) }}</td>
+                        <td class="td_right num">{{ "{:,.0f}".format(sick_ob_total).replace(",", " ") }}</td>
+                    </tr>
+                    {% set ns2.total = ns2.total + sick_ob_total %}
+                    {% endif %}
+                    {% endfor %}
+                </tbody>
+                <tfoot>
+                    <tr>
+                        <td class="td_left" colspan="4"><strong>Totalt</strong></td>
+                        <td class="td_right num"><strong>{{ "{:,.0f}".format(ns2.total).replace(",", " ") }}</strong></td>
+                    </tr>
+                </tfoot>
+            </table>
+        </div>
+    </div>
+    {% endif %}
 
     <script>
     function toggleBreakdown() {


### PR DESCRIPTION
## Vad

Timlönsanvändare får nu en **Lönespecifikation** längst ner på månadsidan med en rad per löneart:

- Arbetade timmar (normaltid)
- OB per kod (vardag kväll/natt, helg, helgdag, storhelg) – inkluderar timlönen i A-priset
- Beredskap per kategori (vardag, helg, röd dag, storhelg)
- Övertid
- Sjuklön (uppdelat på bas + per OB-kod)

Bruttolönen i sammanfattningsraden stämmer nu överens med spec-tabellens totalt (faktiska jobbade timmar × timlön istället för det teoretiska 173,33-baserade månadsbeloppet).

App-versionen hämtas nu från ett enda ställe (`changelog.py`) och sprids automatiskt till footer, FastAPI-titel och `/health`-endpointen via en Jinja2-global.