### PR TITLE
Fix hourly wage calculations across all views and API

### DIFF
--- a/app/core/schedule/summary.py
+++ b/app/core/schedule/summary.py
@@ -242,7 +242,14 @@ def summarize_month_for_person(
                 get_user_wage(session, uid_for_wages, settings.monthly_salary, effective_date=month_start_date)
             )
             worked_hours = totals["total_hours"] - totals["ot_hours"]
-            totals["brutto_pay"] = totals["brutto_pay"] - base_salary + worked_hours * actual_hourly_rate
+            # absence_hours är frånvarotimmar som period.py sätter till 0 (ej inkl i total_hours).
+            # Absence_deduction är designad för månadslön och förutsätter att dessa timmar
+            # redan betalats – för timlön måste vi lägga till dem explicit så att
+            # (worked + absent) × hourly_rate - absence_deduction ger rätt sjuklöneunderlag.
+            absent_hours = totals.get("absence_hours", 0.0)
+            totals["brutto_pay"] = (
+                totals["brutto_pay"] - base_salary + (worked_hours + absent_hours) * actual_hourly_rate
+            )
 
     # Beräkna netto med användarens skattetabell (använd payment_year för rätt skattetabell)
     netto_pay = totals["brutto_pay"] - _calculate_tax(totals["brutto_pay"], tax_table, payment_year=payment_year)

--- a/app/core/schedule/summary.py
+++ b/app/core/schedule/summary.py
@@ -5,7 +5,7 @@ from app.core.storage import load_persons, load_tax_brackets
 from .core import get_settings
 from .ob import calculate_ob_hours, calculate_ob_pay, get_combined_rules_for_year
 from .period import generate_month_data, generate_period_data, generate_year_data
-from .wages import get_absence_deductions_for_month, get_all_user_wages, get_effective_monthly_wage
+from .wages import get_absence_deductions_for_month, get_all_user_wages, get_effective_monthly_wage, get_user_wage
 
 _tax_brackets = None
 _persons = None
@@ -170,6 +170,7 @@ def summarize_month_for_person(
         "oncall_pay": 0.0,
         "oncall_hours": 0.0,
         "ot_pay": 0.0,
+        "ot_hours": 0.0,
         "absence_deduction": 0.0,
         "absence_hours": 0.0,
         "sick_days": 0,
@@ -231,6 +232,17 @@ def summarize_month_for_person(
         # Dra av frånvaroavdrag och lägg till OB-sjuklön
         totals["brutto_pay"] -= totals["absence_deduction"]
         totals["brutto_pay"] += totals["sick_ob_pay"]
+
+        # För timlönsanvändare: ersätt det teoretiska månadslöneunderlaget (hourly_rate×173.33)
+        # med faktiska schemalagda timmar × timlön så att brutto stämmer med spec-tabellen
+        from app.database.database import WageType
+
+        if user and user.wage_type == WageType.HOURLY:
+            actual_hourly_rate = float(
+                get_user_wage(session, uid_for_wages, settings.monthly_salary, effective_date=month_start_date)
+            )
+            worked_hours = totals["total_hours"] - totals["ot_hours"]
+            totals["brutto_pay"] = totals["brutto_pay"] - base_salary + worked_hours * actual_hourly_rate
 
     # Beräkna netto med användarens skattetabell (använd payment_year för rätt skattetabell)
     netto_pay = totals["brutto_pay"] - _calculate_tax(totals["brutto_pay"], tax_table, payment_year=payment_year)
@@ -455,6 +467,7 @@ def _process_day_for_summary(
     totals["oncall_pay"] += oncall_pay
     totals["oncall_hours"] += oncall_hours
     totals["ot_pay"] += ot_pay
+    totals["ot_hours"] = totals.get("ot_hours", 0.0) + ot_hours
     totals["total_hours"] += ot_hours
 
     return {

--- a/app/routes/api_v1.py
+++ b/app/routes/api_v1.py
@@ -147,7 +147,10 @@ def _build_day_status(
             if start_dt and end_dt:
                 rules = get_combined_rules_for_year(date.year)
                 rate_overrides = (user.custom_rates or {}).get("ob")
-                ob_pay_raw = calculate_ob_pay(start_dt, end_dt, rules, user.wage, rate_overrides)
+                from app.core.schedule.wages import get_effective_monthly_wage
+
+                monthly_wage = get_effective_monthly_wage(db, user.id, user.wage, effective_date=date)
+                ob_pay_raw = calculate_ob_pay(start_dt, end_dt, rules, monthly_wage, rate_overrides)
                 ob_total = round(sum(ob_pay_raw.values()), 2)
                 ob_pay_data = {k: round(v, 2) for k, v in ob_pay_raw.items() if v > 0}
 

--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -15,6 +15,17 @@ router = APIRouter()
 
 VERSIONS = [
     {
+        "version": "0.18.1",
+        "date": "2026-04-26",
+        "entries": [
+            {
+                "type": "fix",
+                "sv": "Månadsvy: nettolön i sammanfattningen beräknas nu på rätt underlag för timlönsanvändare",
+                "en": "Month view: net pay in the summary is now calculated on the correct base for hourly wage users",
+            },
+        ],
+    },
+    {
         "version": "0.18.0",
         "date": "2026-04-26",
         "entries": [

--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -20,8 +20,13 @@ VERSIONS = [
         "entries": [
             {
                 "type": "fix",
-                "sv": "Månadsvy: nettolön i sammanfattningen beräknas nu på rätt underlag för timlönsanvändare",
-                "en": "Month view: net pay in the summary is now calculated on the correct base for hourly wage users",
+                "sv": "Timlön: brutto- och nettolön visas nu korrekt i alla vyer baserat på faktiska jobbade timmar istället för teoretiskt månadsunderlag",
+                "en": "Hourly wage: gross and net pay now display correctly in all views based on actual worked hours instead of the theoretical monthly equivalent",
+            },
+            {
+                "type": "fix",
+                "sv": "API: OB-tillägg beräknades på fel underlag för timlönsanvändare i schema-endpointsen",
+                "en": "API: OB supplements were calculated on the wrong base for hourly wage users in schedule endpoints",
             },
         ],
     },

--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -25,6 +25,11 @@ VERSIONS = [
             },
             {
                 "type": "fix",
+                "sv": "Timlön: sjuklön beräknades fel när timlönsanvändare hade sjukfrånvaro – brutto stämmer nu med lönespecifikationens totalt",
+                "en": "Hourly wage: sick pay was calculated incorrectly for hourly wage users – gross pay now matches the payslip spec total",
+            },
+            {
+                "type": "fix",
                 "sv": "API: OB-tillägg beräknades på fel underlag för timlönsanvändare i schema-endpointsen",
                 "en": "API: OB supplements were calculated on the wrong base for hourly wage users in schedule endpoints",
             },

--- a/app/routes/schedule_personal.py
+++ b/app/routes/schedule_personal.py
@@ -895,6 +895,9 @@ async def show_month_for_person(
             for _code, _ob_h in _sick_ob_hs.items():
                 if _ob_h > 0:
                     _spec_total += _ob_h * hourly_rate * 0.8 + _sick_ob_py.get(_code, 0.0)
+            from app.core.schedule.summary import _calculate_tax
+
+            _spec_tax = _calculate_tax(_spec_total, getattr(wage_user, "tax_table", None), payment_year=year)
             hourly_breakdown = {
                 "hourly_rate": hourly_rate,
                 "period": f"{year}{month:02d}01-{year}{month:02d}{last_day:02d}",
@@ -903,6 +906,7 @@ async def show_month_for_person(
                 "sick_ob_pay_by_code": _sick_ob_py,
                 "sick_ob_hours_by_code": _sick_ob_hs,
                 "spec_total": _spec_total,
+                "spec_netto": _spec_total - _spec_tax,
                 **_sjuklon_info,
             }
 

--- a/app/routes/schedule_personal.py
+++ b/app/routes/schedule_personal.py
@@ -891,13 +891,6 @@ async def show_month_for_person(
                 days_in_month.get("absence_deduction", 0.0) or 0.0,
                 _sick_ob_hs,
             )
-            _spec_total = sum(v["pay"] for v in agg.values()) + _sjuklon_info["sjuklon_base_pay"]
-            for _code, _ob_h in _sick_ob_hs.items():
-                if _ob_h > 0:
-                    _spec_total += _ob_h * hourly_rate * 0.8 + _sick_ob_py.get(_code, 0.0)
-            from app.core.schedule.summary import _calculate_tax
-
-            _spec_tax = _calculate_tax(_spec_total, getattr(wage_user, "tax_table", None), payment_year=year)
             hourly_breakdown = {
                 "hourly_rate": hourly_rate,
                 "period": f"{year}{month:02d}01-{year}{month:02d}{last_day:02d}",
@@ -905,8 +898,6 @@ async def show_month_for_person(
                 "sick_days": days_in_month.get("sick_days", 0) or 0,
                 "sick_ob_pay_by_code": _sick_ob_py,
                 "sick_ob_hours_by_code": _sick_ob_hs,
-                "spec_total": _spec_total,
-                "spec_netto": _spec_total - _spec_tax,
                 **_sjuklon_info,
             }
 

--- a/app/templates/month.html
+++ b/app/templates/month.html
@@ -75,7 +75,7 @@
                               + (days.ob_pay.get('OB5',0) or 0) %}
             <tr>
                 {% if show_salary %}
-                <td data-label="{{ t.month_sum_net }}">{{ "%.0f"|format(days.netto_pay or 0) }}</td>
+                <td data-label="{{ t.month_sum_net }}">{{ "%.0f"|format(hourly_breakdown.spec_netto if hourly_breakdown else (days.netto_pay or 0)) }}</td>
                 <td data-label="{{ t.month_sum_gross }}">{{ "%.0f"|format(hourly_breakdown.spec_total if hourly_breakdown else (days.brutto_pay or 0)) }}</td>
                 <td data-label="{{ t.month_sum_shifts }}">{{ days.num_shifts }}</td>
                 <td data-label="{{ t.month_sum_hours }}">{{ "%.2f"|format(days.total_hours or 0) }}</td>

--- a/app/templates/month.html
+++ b/app/templates/month.html
@@ -75,8 +75,8 @@
                               + (days.ob_pay.get('OB5',0) or 0) %}
             <tr>
                 {% if show_salary %}
-                <td data-label="{{ t.month_sum_net }}">{{ "%.0f"|format(hourly_breakdown.spec_netto if hourly_breakdown else (days.netto_pay or 0)) }}</td>
-                <td data-label="{{ t.month_sum_gross }}">{{ "%.0f"|format(hourly_breakdown.spec_total if hourly_breakdown else (days.brutto_pay or 0)) }}</td>
+                <td data-label="{{ t.month_sum_net }}">{{ "%.0f"|format(days.netto_pay or 0) }}</td>
+                <td data-label="{{ t.month_sum_gross }}">{{ "%.0f"|format(days.brutto_pay or 0) }}</td>
                 <td data-label="{{ t.month_sum_shifts }}">{{ days.num_shifts }}</td>
                 <td data-label="{{ t.month_sum_hours }}">{{ "%.2f"|format(days.total_hours or 0) }}</td>
                 {% endif %}


### PR DESCRIPTION
## Vad

Uppföljningsfixar efter v0.18.0 som rättar löneberäkningar för timlönsanvändare.

- Brutto och netto i `/month` och `/year` baseras nu på faktiska jobbade timmar × timlön istället för teoretiskt månadsunderlag
- Sjuklön hanteras korrekt: brutto stämmer nu med lönespecifikationens totalt även vid sjukfrånvaro
- OB-tillägg i API-endpointsen använder nu rätt månadsmotsvarighet för timlönsanvändare