### PR TITLE
Fix week view not showing week-based vacation

### DIFF
--- a/app/core/schedule/period.py
+++ b/app/core/schedule/period.py
@@ -70,6 +70,7 @@ def build_week_data(
     oncall_override_map = _batch_fetch_oncall_overrides(session, person_ids, monday, sunday, rotation_to_user_id)
     swap_map = _batch_fetch_swap_map(session, person_ids, monday, sunday, rotation_to_user_id)
     shift_override_map = _batch_fetch_shift_overrides(session, person_ids, monday, sunday, rotation_to_user_id)
+    vacation_dates = _load_vacation_dates(_get_years_in_range(monday, sunday))
 
     days_in_week = []
 
@@ -89,7 +90,7 @@ def build_week_data(
                     persons,
                     shift_types,
                     session,
-                    None,
+                    vacation_dates,
                     ot_shift_map,
                     absence_map,
                     oncall_override_map,
@@ -106,7 +107,7 @@ def build_week_data(
                     persons,
                     shift_types,
                     session,
-                    None,
+                    vacation_dates,
                     ot_shift_map,
                     absence_map,
                     oncall_override_map,

--- a/app/core/schedule/vacation.py
+++ b/app/core/schedule/vacation.py
@@ -4,7 +4,6 @@ import datetime
 import math
 
 from app.core.constants import PERSON_IDS
-from app.core.storage import load_persons
 
 
 def get_vacation_dates_for_year(year: int) -> dict[int, set[datetime.date]]:
@@ -15,16 +14,25 @@ def get_vacation_dates_for_year(year: int) -> dict[int, set[datetime.date]]:
     day-level vacation (Absence records with type VACATION).
 
     Returns:
-        Dict med person_id -> set av semesterdatum
+        Dict med person_id (rotationsposition) -> set av semesterdatum
     """
     from app.database.database import Absence, AbsenceType, SessionLocal, User
 
-    persons = load_persons()
-    per_person: dict[int, set[datetime.date]] = {p.id: set() for p in persons}
+    per_person: dict[int, set[datetime.date]] = {pid: set() for pid in PERSON_IDS}
 
     db = SessionLocal()
     try:
-        users = db.query(User).filter(User.id.in_(PERSON_IDS)).all()
+        # Query active users by rotation position, not by user.id
+        users = (
+            db.query(User)
+            .filter(
+                User.person_id.in_(PERSON_IDS),
+                User.is_active,
+            )
+            .all()
+        )
+
+        user_id_to_person_id = {u.id: u.person_id for u in users}
 
         for user in users:
             vac_by_year = user.vacation or {}
@@ -34,7 +42,7 @@ def get_vacation_dates_for_year(year: int) -> dict[int, set[datetime.date]]:
                 for day in range(1, 8):
                     try:
                         d = datetime.date.fromisocalendar(year, week, day)
-                        per_person[user.id].add(d)
+                        per_person[user.person_id].add(d)
                     except ValueError:
                         continue
 
@@ -42,7 +50,7 @@ def get_vacation_dates_for_year(year: int) -> dict[int, set[datetime.date]]:
         day_absences = (
             db.query(Absence)
             .filter(
-                Absence.user_id.in_(PERSON_IDS),
+                Absence.user_id.in_(user_id_to_person_id.keys()),
                 Absence.absence_type == AbsenceType.VACATION,
                 Absence.date >= datetime.date(year, 1, 1),
                 Absence.date <= datetime.date(year, 12, 31),
@@ -50,8 +58,9 @@ def get_vacation_dates_for_year(year: int) -> dict[int, set[datetime.date]]:
             .all()
         )
         for absence in day_absences:
-            if absence.user_id in per_person:
-                per_person[absence.user_id].add(absence.date)
+            person_id = user_id_to_person_id.get(absence.user_id)
+            if person_id is not None:
+                per_person[person_id].add(absence.date)
     finally:
         db.close()
 

--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -15,6 +15,22 @@ router = APIRouter()
 
 VERSIONS = [
     {
+        "version": "0.18.2",
+        "date": "2026-04-30",
+        "entries": [
+            {
+                "type": "fix",
+                "sv": "Veckovy: veckobaserad semester visades inte, pass visades som vanligt arbetspass trots inlagd semester",
+                "en": "Week view: week-based vacation was not shown, shifts appeared as normal working shifts despite scheduled vacation",
+            },
+            {
+                "type": "fix",
+                "sv": "Semester: veckobaserad semester var osynlig för användare vars user-ID inte matchar rotationsposition",
+                "en": "Vacation: week-based vacation was invisible for users whose user ID does not match their rotation position",
+            },
+        ],
+    },
+    {
         "version": "0.18.1",
         "date": "2026-04-26",
         "entries": [


### PR DESCRIPTION
## Summary

- `build_week_data` passed `None` for `vacation_dates` to `_build_person_day_basic`, so week-based vacations were never shown in `/week`
- `get_vacation_dates_for_year` queried users by `user.id` instead of `person_id`, excluding users whose IDs fall outside `PERSON_IDS` (1-10)
- Results were stored keyed by `user.id` but looked up by rotation position (`person_id`), causing a silent key mismatch for affected users