### PR TITLE
Add range view and fix vacation day display

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
           port: 2222
           script_stop: true
           script: |
-            bash ${{ secrets.PROD_APP_PATH }}/scripts/deploy.sh ${{ secrets.PROD_APP_PATH }} ${{ github.ref_name }}
+            GITEA_TOKEN=${{ secrets.GITEA_TOKEN }} bash ${{ secrets.PROD_APP_PATH }}/scripts/deploy.sh ${{ secrets.PROD_APP_PATH }} ${{ github.ref_name }}
 
       - name: Notify Success
         if: success()

--- a/app/core/translations.py
+++ b/app/core/translations.py
@@ -907,6 +907,14 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "admin_vac_user_weeks_selected_js": "veckor valda:",
         "admin_vac_user_day_count_js": "dag",
         "admin_vac_user_days_count_js": "dagar valda",
+        "day_sem_notice": "Du har semester denna dag.",
+        "day_absence_vacation": "Semester",
+        # ── Range view ─────────────────────────────────────────────
+        "range_title": "Valfritt intervall",
+        "range_from": "Från",
+        "range_to": "Till",
+        "range_apply": "Visa",
+        "range_btn": "Valfritt intervall",
         # ── Index ──────────────────────────────────────────────────
         "index_title": "Schemaöversikt",
         "index_desc1": "Denna applikation visar rotationsschemat och OB-ersättning för alla personer över år, månad, vecka och dag.",
@@ -1812,6 +1820,14 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "admin_vac_user_weeks_selected_js": "weeks selected:",
         "admin_vac_user_day_count_js": "day",
         "admin_vac_user_days_count_js": "days selected",
+        "day_sem_notice": "You have vacation on this day.",
+        "day_absence_vacation": "Vacation",
+        # ── Range view ─────────────────────────────────────────────
+        "range_title": "Custom range",
+        "range_from": "From",
+        "range_to": "To",
+        "range_apply": "Show",
+        "range_btn": "Custom range",
         # ── Index ──────────────────────────────────────────────────
         "index_title": "Schedule overview",
         "index_desc1": "This application shows the rotation schedule and OB pay for all persons over year, month, week and day.",

--- a/app/routes/api_v1.py
+++ b/app/routes/api_v1.py
@@ -348,7 +348,7 @@ async def get_user_schedule_range(
     current_user: User = Depends(get_api_user),
     db: Session = Depends(get_db),
 ):
-    """Schedule for a date range (?from_date=YYYY-MM-DD&to_date=YYYY-MM-DD, max 31 days)."""
+    """Schedule for a date range (?from_date=YYYY-MM-DD&to_date=YYYY-MM-DD, max 70 days)."""
     target = _get_user_or_404(user_id, db)
     try:
         start = datetime.date.fromisoformat(from_date)
@@ -357,8 +357,8 @@ async def get_user_schedule_range(
         raise HTTPException(status_code=400, detail="Ogiltigt datumformat, använd YYYY-MM-DD") from None
     if end < start:
         raise HTTPException(status_code=400, detail="to_date måste vara efter from_date")
-    if (end - start).days > 31:
-        raise HTTPException(status_code=400, detail="Max 31 dagar per anrop")
+    if (end - start).days >= 70:
+        raise HTTPException(status_code=400, detail="Max 70 dagar per anrop")
     include_salary = _can_see_salary(current_user, target)
     days, _ = _build_period(target, start, end, db, include_salary)
     return {"days": days}

--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -15,6 +15,22 @@ router = APIRouter()
 
 VERSIONS = [
     {
+        "version": "0.19.0",
+        "date": "2026-05-01",
+        "entries": [
+            {
+                "type": "nyhet",
+                "sv": "Intervalvy: visa 1-10 veckor av ditt personliga schema i ett rutnät, nåbar via vecko- och månadsvy",
+                "en": "Range view: display 1-10 weeks of your personal schedule in a grid, reachable from the week and month views",
+            },
+            {
+                "type": "fix",
+                "sv": "Dagvy: semesterdagar visades som vanligt arbetspass – SEM-badge och gul notis visas nu korrekt bredvid rotationspasset",
+                "en": "Day view: vacation days were shown as regular working shifts – SEM badge and yellow notice now appear correctly alongside the rotation shift",
+            },
+        ],
+    },
+    {
         "version": "0.18.2",
         "date": "2026-04-30",
         "entries": [

--- a/app/routes/schedule_personal.py
+++ b/app/routes/schedule_personal.py
@@ -50,7 +50,16 @@ from app.core.schedule import (
 from app.core.schedule.vacation import calculate_vacation_balance
 from app.core.utils import get_navigation_dates, get_ot_shift_display_code, get_safe_today, get_today
 from app.core.validators import validate_date_params, validate_person_id
-from app.database.database import Absence, OnCallOverride, OnCallOverrideType, ShiftOverride, User, UserRole, get_db
+from app.database.database import (
+    Absence,
+    AbsenceType,
+    OnCallOverride,
+    OnCallOverrideType,
+    ShiftOverride,
+    User,
+    UserRole,
+    get_db,
+)
 from app.routes.shared import redirect_if_not_own_data, templates
 
 logger = get_logger(__name__)
@@ -550,6 +559,30 @@ async def show_day_for_person(
     # Use rotation_position for coworker matching (schedule-based)
     coworkers = get_coworkers_for_day(rotation_position, shift_code_for_matching, persons_today, start_dt, end_dt)
 
+    # Check if this day is a vacation day for the user
+    _vac_user = (
+        db.query(User).filter(User.id == user_id_for_wages).first()
+        if user_id_for_wages != current_user.id
+        else current_user
+    )
+    is_vacation_day = False
+    if _vac_user:
+        _iso_year, _iso_week, _ = date_obj.isocalendar()
+        _vac_json = _vac_user.vacation or {}
+        if str(_iso_year) in _vac_json and _iso_week in _vac_json[str(_iso_year)]:
+            is_vacation_day = True
+        if not is_vacation_day:
+            is_vacation_day = (
+                db.query(Absence)
+                .filter(
+                    Absence.user_id == user_id_for_wages,
+                    Absence.date == date_obj,
+                    Absence.absence_type == AbsenceType.VACATION,
+                )
+                .first()
+                is not None
+            )
+
     return render_template(
         templates,
         "day.html",
@@ -595,6 +628,7 @@ async def show_day_for_person(
             "has_rotation_oc": has_rotation_oc,
             "is_effective_oc": is_effective_oc,
             "shift_override": shift_override,
+            "is_vacation_day": is_vacation_day,
             **nav,
         },
         user=current_user,
@@ -676,6 +710,127 @@ async def show_week_for_person(
             "storhelg_dates": storhelg_dates,
             "holiday_dates": holiday_dates,
             **nav,
+        },
+        user=current_user,
+    )
+
+
+@router.get("/range/{person_id}", response_class=HTMLResponse, name="range_person")
+async def show_range_for_person(
+    request: Request,
+    person_id: int,
+    from_date: str | None = Query(None, alias="from"),
+    to_date: str | None = Query(None, alias="to"),
+    weeks_param: int | None = Query(None, alias="weeks", ge=1, le=10),
+    current_user: User | None = Depends(get_current_user_optional),
+    db: Session = Depends(get_db),
+):
+    """Range view for a specific person -- arbitrary date interval (max 70 days)."""
+    if current_user is None:
+        return RedirectResponse(url=f"/login?next={request.url.path}", status_code=302)
+
+    if person_id > 10:
+        target_user = db.query(User).filter(User.id == person_id).first()
+        if not target_user:
+            raise HTTPException(status_code=404, detail="User not found")
+        user_id_for_wages = person_id
+        rotation_position = target_user.rotation_person_id
+        person_name = target_user.name
+    else:
+        person_id = validate_person_id(person_id)
+        user_id_for_wages = person_id
+        rotation_position = person_id
+        person_name = None
+
+    if redirect := redirect_if_not_own_data(current_user, user_id_for_wages, f"/range/{current_user.id}"):
+        return redirect
+
+    real_today = get_today()
+
+    # Weeks-based mode: snap to Monday, compute end from weeks count
+    if weeks_param is not None or (from_date is None and to_date is None):
+        active_weeks = weeks_param if weeks_param is not None else 2
+        try:
+            anchor = date.fromisoformat(from_date) if from_date else real_today
+        except ValueError:
+            anchor = real_today
+        start = anchor - timedelta(days=anchor.weekday())  # snap to Monday
+        end = start + timedelta(weeks=active_weeks) - timedelta(days=1)
+    else:
+        # Free-form mode: both from/to provided explicitly
+        active_weeks = None
+        try:
+            start = date.fromisoformat(from_date) if from_date else real_today
+            end = date.fromisoformat(to_date) if to_date else real_today + timedelta(days=13)
+        except ValueError:
+            start = real_today
+            end = real_today + timedelta(days=13)
+        if end < start:
+            end = start
+        if (end - start).days >= 70:
+            end = start + timedelta(days=69)
+
+    if person_name is None:
+        if current_user is not None and current_user.rotation_person_id == rotation_position:
+            person_name = current_user.name
+        else:
+            holder = db.query(User).filter(User.person_id == rotation_position).first()
+            person_name = holder.name if holder else person_list[rotation_position - 1].name
+
+    range_employment_start = None
+    if person_id > 10:
+        from app.core.schedule.person_history import get_employment_period
+
+        emp_start, _ = get_employment_period(db, target_user.id, rotation_position)
+        range_employment_start = emp_start
+
+    # Build days week-by-week then filter to exact range (reuses build_week_data incl. coworkers)
+    days_in_range = []
+    current_monday = start - timedelta(days=start.weekday())
+    seen_weeks: set[tuple[int, int]] = set()
+    while current_monday <= end:
+        iso_year, iso_week, _ = current_monday.isocalendar()
+        if (iso_year, iso_week) not in seen_weeks:
+            seen_weeks.add((iso_year, iso_week))
+            week_days = build_week_data(
+                iso_year,
+                iso_week,
+                person_id=rotation_position,
+                session=db,
+                include_coworkers=True,
+                employment_start=range_employment_start,
+            )
+            for d in week_days:
+                if start <= d["date"] <= end:
+                    days_in_range.append(d)
+        current_monday += timedelta(days=7)
+
+    years_in_range = {d["date"].year for d in days_in_range}
+    storhelg_dates: set = set()
+    holiday_dates: set = set()
+    for yr in years_in_range:
+        storhelg_dates |= _get_storhelg_dates_for_year(yr)
+        holiday_dates |= get_holiday_dates_for_year(yr)
+
+    return render_template(
+        templates,
+        "range.html",
+        request,
+        {
+            "person_id": person_id,
+            "person_name": person_name,
+            "start_date": start,
+            "end_date": end,
+            "days": days_in_range,
+            "num_weeks": len(seen_weeks),
+            "active_weeks": active_weeks,
+            "prev_from": (start - timedelta(weeks=active_weeks)).isoformat() if active_weeks else None,
+            "next_from": (start + timedelta(weeks=active_weeks)).isoformat() if active_weeks else None,
+            "prev_week_from": (start - timedelta(weeks=1)).isoformat() if active_weeks else None,
+            "next_week_from": (start + timedelta(weeks=1)).isoformat() if active_weeks else None,
+            "today": real_today,
+            "storhelg_dates": storhelg_dates,
+            "holiday_dates": holiday_dates,
         },
         user=current_user,
     )

--- a/app/templates/day.html
+++ b/app/templates/day.html
@@ -49,6 +49,12 @@
         </h2>
     </div>
 
+    {% if is_vacation_day %}
+    <div style="background:rgba(199,199,0,0.12);border-left:4px solid #c7c700;border-radius:6px;padding:0.6rem 1rem;margin-bottom:1rem;color:#c7c700;font-weight:500;">
+        {{ t.day_sem_notice }}
+    </div>
+    {% endif %}
+
     <!-- Shift -->
     <div class="day-layout">
         <section class="day-section">
@@ -68,7 +74,11 @@
                         style="border-left:6px solid {% if shift %}{{ shift.color }}{% else %}transparent{% endif %};">
                         <td>{% if rotation_week and rotation_length %}{{ rotation_week }}/{{ rotation_length }}{% else %}-{% endif %}</td>
                         <td>
-                            {% if shift %}
+                            {% if is_vacation_day %}
+                                <span style="white-space:nowrap;">
+                                    <span class="badge" style="background:#c7c700;color:#000;">SEM</span>{% if shift %}&nbsp;<span class="badge" style="background:{{ shift.color }};color:{{ shift.color | contrast }};">{{ shift.code }}</span>{% endif %}
+                                </span>
+                            {% elif shift %}
                                 <span class="badge"
                                       style="background: {{ shift.color }}; color: {{ shift.color | contrast }};">
                                     {{ shift.code }}
@@ -78,7 +88,9 @@
                             {% endif %}
                         </td>
                         <td>
-                            {% if shift %}
+                            {% if is_vacation_day %}
+                                {{ t.day_absence_vacation }}{% if shift %} ({{ shift.label }}){% endif %}
+                            {% elif shift %}
                                 {{ shift.label }}
                             {% else %}
                                 {{ t.day_no_shift }}
@@ -284,6 +296,8 @@
                                         {{ t.day_absence_leave }}
                                     {% elif absence.absence_type.value == 'OFF' %}
                                         {{ t.day_absence_off }}
+                                    {% elif absence.absence_type.value == 'VACATION' %}
+                                        {{ t.day_absence_vacation }}
                                     {% else %}
                                         {{ absence.absence_type.value }}
                                     {% endif %}
@@ -300,6 +314,8 @@
                                         <span class="badge" style="background: #a855f7; color: white;">{{ t.day_absence_leave }}</span>
                                     {% elif absence.absence_type.value == 'OFF' %}
                                         <span class="badge" style="background: #888888; color: white;">{{ t.day_absence_off }}</span>
+                                    {% elif absence.absence_type.value == 'VACATION' %}
+                                        <span class="badge" style="background: #c7c700; color: #000;">{{ t.day_absence_vacation }}</span>
                                     {% endif %}
                                     {% if absence.left_at is not none %}
                                         <span class="badge" style="background: #0ea5e9; color: white;">Deldag</span>

--- a/app/templates/month.html
+++ b/app/templates/month.html
@@ -34,6 +34,7 @@
         </div>
 
         <div class="page-header-right">
+            <a href="/range/{{ person_id }}?from={{ year }}-{{ '%02d'|format(month) }}-01&to={{ days.days[-1].date }}" class="btn secondary">{{ t.range_btn }}</a>
             {# Navigering mellan personer - endast för admin #}
             {% if user and user.role.value == 'admin' %}
                 <a href="/month/{{ person_id - 1 if person_id != 1 else max_persons }}?year={{ year }}&month={{ month }}" class="btn secondary">&lt-</a>

--- a/app/templates/range.html
+++ b/app/templates/range.html
@@ -1,1 +1,152 @@
-{# Todo: #}
+{# app/templates/range.html #}
+{% extends "base.html" %}
+
+{% block title %}Periodical – {{ t.range_title }}{% if person_name %} – {{ person_name }}{% endif %}{% endblock %}
+
+{% block page_content %}
+
+{# ── Scaling styles based on number of weeks ───────────────────── #}
+{% if num_weeks >= 9 %}
+{% set cell_h = "48px" %}{% set cell_p = "0.15rem" %}{% set th_p = "0.25rem 0.2rem" %}{% set th_f = "0.68rem" %}{% set badge_f = "0.58rem" %}{% set small_f = "0.54rem" %}{% set dn_f = "0.66rem" %}
+{% elif num_weeks >= 7 %}
+{% set cell_h = "75px" %}{% set cell_p = "0.22rem" %}{% set th_p = "0.38rem 0.28rem" %}{% set th_f = "0.74rem" %}{% set badge_f = "0.63rem" %}{% set small_f = "0.59rem" %}{% set dn_f = "0.71rem" %}
+{% elif num_weeks >= 5 %}
+{% set cell_h = "90px" %}{% set cell_p = "0.28rem" %}{% set th_p = "0.5rem 0.35rem" %}{% set th_f = "0.79rem" %}{% set badge_f = "0.67rem" %}{% set small_f = "0.62rem" %}{% set dn_f = "0.74rem" %}
+{% elif num_weeks >= 3 %}
+{% set cell_h = "112px" %}{% set cell_p = "0.36rem" %}{% set th_p = "0.6rem 0.4rem" %}{% set th_f = "0.83rem" %}{% set badge_f = "0.72rem" %}{% set small_f = "0.67rem" %}{% set dn_f = "0.78rem" %}
+{% else %}
+{% set cell_h = "140px" %}{% set cell_p = "0.5rem" %}{% set th_p = "0.75rem 0.5rem" %}{% set th_f = "0.85rem" %}{% set badge_f = "0.75rem" %}{% set small_f = "0.7rem" %}{% set dn_f = null %}
+{% endif %}
+
+{% if num_weeks >= 3 %}
+<style>
+.range-grid .calendar-day { height: {{ cell_h }} !important; overflow: hidden; }
+.range-grid .calendar-day-content { padding: {{ cell_p }}; height: {{ cell_h }}; overflow: hidden; }
+.range-grid thead th { padding: {{ th_p }}; font-size: {{ th_f }}; }
+.range-grid .calendar-badge { font-size: {{ badge_f }}; padding: 2px 4px; }
+.range-grid .calendar-time, .range-grid .coworkers-list, .range-grid .rotation-week-small { font-size: {{ small_f }}; }
+{% if dn_f %}.range-grid .day-number { font-size: {{ dn_f }}; }{% endif %}
+{% if num_weeks >= 9 %}
+.range-grid .calendar-day-body { flex-direction: row; align-items: flex-start; gap: 10px; flex-wrap: nowrap; overflow: hidden; }
+.range-grid .calendar-badge { flex-shrink: 0; }
+.range-grid .range-text-stack { display: flex; flex-direction: column; min-width: 0; overflow: hidden; gap: 1px; }
+.range-grid .calendar-time, .range-grid .coworkers-list { margin-top: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+{% endif %}
+</style>
+{% endif %}
+
+<div class="page-header">
+    <div class="page-header-left">
+        {% if active_weeks is not none %}
+            <a href="/range/{{ person_id }}?weeks={{ active_weeks }}&from={{ prev_from }}" class="btn btn-primary">&laquo; {{ active_weeks }}v</a>
+            <a href="/range/{{ person_id }}?weeks={{ active_weeks }}&from={{ prev_week_from }}" class="btn btn-primary">&lsaquo; 1v</a>
+            <a href="/range/{{ person_id }}?weeks={{ active_weeks }}" class="btn btn-primary">{{ t.week_today }}</a>
+            <a href="/range/{{ person_id }}?weeks={{ active_weeks }}&from={{ next_week_from }}" class="btn btn-primary">1v &rsaquo;</a>
+            <a href="/range/{{ person_id }}?weeks={{ active_weeks }}&from={{ next_from }}" class="btn btn-primary">{{ active_weeks }}v &raquo;</a>
+        {% else %}
+            <a href="/range/{{ person_id }}" class="btn btn-primary">{{ t.week_today }}</a>
+        {% endif %}
+    </div>
+    <div class="page-header-right" style="position:relative;">
+        <select onchange="window.location='/range/{{ person_id }}?weeks='+this.value+'&from={{ start_date.isoformat() }}'"
+                style="background:#0f1720;color:#e6eef6;border:1px solid rgba(255,255,255,0.15);border-radius:4px;padding:4px 8px;font-size:0.9rem;cursor:pointer;color-scheme:dark;">
+            {% for w in range(1, 11) %}
+                <option value="{{ w }}" {% if active_weeks == w %}selected{% endif %} style="background:#0f1720;color:#e6eef6;">{{ w }}v</option>
+            {% endfor %}
+        </select>
+        <button class="btn secondary" onclick="var f=this.nextElementSibling;f.style.display=f.style.display==='flex'?'none':'flex';">{{ t.range_from }}/{{ t.range_to }} ▾</button>
+        <form method="get" action="/range/{{ person_id }}"
+              style="display:none;gap:0.5rem;align-items:center;flex-wrap:wrap;position:absolute;right:0;top:100%;background:var(--card-bg);border:1px solid var(--border);border-radius:6px;padding:0.5rem;z-index:10;margin-top:4px;">
+            <label style="color:var(--muted);font-size:0.85rem;">{{ t.range_from }}</label>
+            <input type="date" name="from" value="{{ start_date.isoformat() }}"
+                   style="background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:4px 8px;font-size:0.9rem;">
+            <label style="color:var(--muted);font-size:0.85rem;">{{ t.range_to }}</label>
+            <input type="date" name="to" value="{{ end_date.isoformat() }}"
+                   style="background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:4px 8px;font-size:0.9rem;">
+            <button type="submit" class="btn btn-primary">{{ t.range_apply }}</button>
+        </form>
+    </div>
+</div>
+
+<h2 class="page-title">{{ person_name if person_name else '' }}</h2>
+
+{# ── Calendar grid ─────────────────────────────────────────────── #}
+{% set weekday_names_short = t.week_day_names | from_json %}
+
+{% if days %}
+<table class="calendar-grid week-grid-single range-grid">
+    <thead><tr>
+        {% for dn in weekday_names_short %}<th>{{ dn }}</th>{% endfor %}
+    </tr></thead>
+    <tbody>
+    {% set ns = namespace(current_week=none) %}
+    {% for day in days %}
+        {% set week_key = day.date.isocalendar()[0] ~ '-' ~ day.date.isocalendar()[1] %}
+
+        {% if week_key != ns.current_week %}
+            {% if ns.current_week is not none %}
+                {% set prev_day = days[loop.index0 - 1] %}
+                {% for pad in range(6 - prev_day.date.weekday()) %}
+                    <td class="calendar-day" style="background:transparent;border:none;"></td>
+                {% endfor %}
+                </tr>
+            {% endif %}
+            {% set ns.current_week = week_key %}
+            <tr>
+            {% for pad in range(day.date.weekday()) %}
+                <td class="calendar-day" style="background:transparent;border:none;"></td>
+            {% endfor %}
+        {% endif %}
+
+        {% set is_today = today is defined and day.date == today %}
+        <td class="calendar-day {% if is_today %}today-cell{% endif %}"
+            style="border-top: 4px solid {% if day.shift %}{{ day.shift.color }}{% else %}#333{% endif %};">
+            <div class="calendar-day-content">
+                <div class="calendar-day-header">
+                    <a href="/day/{{ person_id }}/{{ day.date.year }}/{{ day.date.month }}/{{ day.date.day }}"
+                       class="day-number">{{ day.date.day }}/{{ day.date.month }}</a>
+                    {% if storhelg_dates is defined and day.date in storhelg_dates %}
+                        <span class="badge badge-ob5" style="font-size:0.6rem;padding:1px 4px;">S</span>
+                    {% elif holiday_dates is defined and day.date in holiday_dates %}
+                        <span class="badge badge-ob4" style="font-size:0.6rem;padding:1px 4px;">H</span>
+                    {% endif %}
+                    {% if day.date.weekday() == 0 %}
+                        <span class="rotation-week-small">v{{ day.date.isocalendar()[1] }}</span>
+                    {% endif %}
+                </div>
+                <div class="calendar-day-body">
+                    {% if day.shift %}
+                        <span class="badge calendar-badge"
+                              style="background:{{ day.shift.color }};color:{{ day.shift.color | contrast }};">
+                            {{ day.shift.code }}
+                        </span>
+                    {% else %}
+                        <span class="badge badge-off calendar-badge">OFF</span>
+                    {% endif %}
+                    {% if num_weeks >= 9 %}<div class="range-text-stack">{% endif %}
+                    {% if day.shift and day.shift.code != 'OC' %}
+                        {% if day.shift.code == 'OT' and day.start and day.end %}
+                            <div class="calendar-time">{{ day.start | time_format }} - {{ day.end | time_format }}</div>
+                        {% elif day.shift.start_time is not none %}
+                            <div class="calendar-time">{{ day.shift.start_time }} - {{ day.shift.end_time }}</div>
+                        {% endif %}
+                    {% endif %}
+                    {% if day.coworkers %}
+                        <div class="coworkers-list">{{ t.week_with }} {{ day.coworkers | join(', ') }}</div>
+                    {% endif %}
+                    {% if num_weeks >= 9 %}</div>{% endif %}
+                </div>
+            </div>
+        </td>
+    {% endfor %}
+
+    {% set last_day = days[-1] %}
+    {% for pad in range(6 - last_day.date.weekday()) %}
+        <td class="calendar-day" style="background:transparent;border:none;"></td>
+    {% endfor %}
+    </tr>
+    </tbody>
+</table>
+{% endif %}
+
+{% endblock %}

--- a/app/templates/week.html
+++ b/app/templates/week.html
@@ -15,6 +15,7 @@
     </div>
 
     <div class="page-header-right">
+        <a href="/range/{{ person_id }}?from={{ days[0].date }}&to={{ days[6].date }}" class="btn secondary">{{ t.range_btn }}</a>
         <a href="/week?year={{ year }}&week={{ week }}" class="btn secondary">{{ t.week_all }}</a>
         {# Navigering mellan personer - endast för admin #}
         {% if user and user.role.value == 'admin' %}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -17,10 +17,22 @@ APP_PATH="${1:-.}"
 TAG="${2:-}"
 SERVICE_NAME="ica-schedule"
 HEALTH_URL="http://127.0.0.1:8000/health"
+GITEA_TOKEN="${GITEA_TOKEN:-}"
+GITEA_MIRROR_URL="https://gitea.kakanweb.com/api/v1/repos/kalle/periodical/mirror-sync"
 
 # Funktion för loggning med timestamp
 log() {
     echo -e "${GREEN}[$(date +'%Y-%m-%d %H:%M:%S')]${NC} $1"
+}
+
+gitea_sync() {
+    if [ -n "$GITEA_TOKEN" ]; then
+        log "🔄 Triggar Gitea mirror-sync..."
+        curl -s -o /dev/null -X POST "$GITEA_MIRROR_URL" \
+            -H "Authorization: token $GITEA_TOKEN" && \
+            log "✅ Gitea mirror-sync triggad." || \
+            warn "Gitea mirror-sync misslyckades (icke-kritiskt)."
+    fi
 }
 
 warn() {
@@ -141,6 +153,7 @@ HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$HEALTH_URL")
 
 if [ "$HTTP_STATUS" -eq 200 ]; then
     log "✅ Deployment slutförd! Health check svarade 200 OK."
+    gitea_sync
     exit 0
 else
     log "⏳ Väntar 30 sekunder på att tjänsten ska starta..."
@@ -148,6 +161,7 @@ else
     HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$HEALTH_URL")
     if [ "$HTTP_STATUS" -eq 200 ]; then
         log "✅ Deployment slutförd efter väntan! Health check svarade 200 OK."
+        gitea_sync
         exit 0
     fi
     # Hämta loggar för att se vad som gick fel

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -13,7 +13,7 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # Standard värden
-HOST="127.0.0.1"
+HOST="192.168.0.190"
 PORT="8001"
 
 # Parse arguments

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+TAG=$1
+if [ -z "$TAG" ]; then
+    echo "Usage: ./release.sh <tag>  (e.g. ./release.sh v0.12.1)"
+    exit 1
+fi
+
+git checkout main
+git pull
+git tag "$TAG"
+git push origin "$TAG"
+
+echo "Released $TAG"


### PR DESCRIPTION
## Summary

- Add `/range/{person_id}` route for 1-10 week personal schedule view, linked from week and month page headers
- Dynamic cell scaling based on number of weeks (3/5/7/9+ breakpoints), with shift text moving to the right of the badge at 9+ weeks
- Navigation with prev/next week and N-week jumps, week count dropdown (1-10), and collapsible date picker
- Increase single-user API schedule limit from 31 to 70 days
- Fix day view not indicating vacation when rotation shows a working shift -- SEM + rotation badges now shown side by side with a yellow banner