### PR TITLE
Fix API overnight shift data and add date/time simulation to /status

### DIFF
--- a/app/routes/api_v1.py
+++ b/app/routes/api_v1.py
@@ -56,6 +56,24 @@ def _overtime_by_date(
     return result
 
 
+def _is_overnight(shift) -> bool:
+    """Returns True when the shift ends on the next calendar day (end_time <= start_time)."""
+    if not shift or not shift.start_time or not shift.end_time:
+        return False
+    return shift.end_time <= shift.start_time
+
+
+def _shift_to_dict(shift) -> dict:
+    return {
+        "code": shift.code,
+        "label": shift.label,
+        "start_time": shift.start_time,
+        "end_time": shift.end_time,
+        "color": shift.color,
+        "overnight": _is_overnight(shift),
+    }
+
+
 def _find_shift_for_overtime(ot_end: datetime.time) -> tuple[str, str]:
     """Match overtime end time to a named shift; falls back to 'OT'/'Övertid'."""
     ot_end_str = ot_end.strftime("%H:%M")
@@ -121,11 +139,13 @@ def _build_day_status(
             }
         coworkers = _build_coworkers(user.id, date, all_users, effective_absent, effective_overtime)
 
+    shift_data = _shift_to_dict(shift) if shift else None
+
     if absence:
         result = {
             "date": date.isoformat(),
             "status": absence.absence_type.value.lower(),
-            "shift": None,
+            "shift": shift_data,
             "rotation_week": rotation_week,
             "overtime": None,
             "partial_day": absence.left_at,
@@ -153,16 +173,6 @@ def _build_day_status(
                 ob_pay_raw = calculate_ob_pay(start_dt, end_dt, rules, monthly_wage, rate_overrides)
                 ob_total = round(sum(ob_pay_raw.values()), 2)
                 ob_pay_data = {k: round(v, 2) for k, v in ob_pay_raw.items() if v > 0}
-
-    shift_data = None
-    if shift:
-        shift_data = {
-            "code": shift.code,
-            "label": shift.label,
-            "start_time": shift.start_time,
-            "end_time": shift.end_time,
-            "color": shift.color,
-        }
 
     overtime_data = None
     if overtime:
@@ -533,6 +543,21 @@ async def get_user_next_shift(
         today = now.date()
         current_time = now.time()
 
+    # Check if there is an ongoing overnight shift from yesterday still running.
+    currently_active: dict | None = None
+    yesterday = today - datetime.timedelta(days=1)
+    yesterday_absence = db.query(Absence).filter(Absence.user_id == target.id, Absence.date == yesterday).first()
+    if not yesterday_absence:
+        prev_shift, prev_rw = determine_shift_for_date(yesterday, target.rotation_person_id)
+        if prev_shift and prev_shift.code not in ("OFF", "OC") and _is_overnight(prev_shift):
+            prev_end = datetime.time.fromisoformat(prev_shift.end_time)
+            if current_time < prev_end:
+                currently_active = {
+                    "date": yesterday.isoformat(),
+                    "shift": _shift_to_dict(prev_shift),
+                    "rotation_week": prev_rw,
+                }
+
     for offset in range(60):
         candidate = today + datetime.timedelta(days=offset)
         absence = db.query(Absence).filter(Absence.user_id == target.id, Absence.date == candidate).first()
@@ -545,18 +570,15 @@ async def get_user_next_shift(
             shift_start = datetime.time.fromisoformat(shift.start_time)
             if current_time >= shift_start:
                 continue
-        return {
+        result = {
             "date": candidate.isoformat(),
             "days_from_today": offset,
-            "shift": {
-                "code": shift.code,
-                "label": shift.label,
-                "start_time": shift.start_time,
-                "end_time": shift.end_time,
-                "color": shift.color,
-            },
+            "shift": _shift_to_dict(shift),
             "rotation_week": rotation_week,
         }
+        if currently_active is not None:
+            result["currently_active_shift"] = currently_active
+        return result
 
     raise HTTPException(status_code=404, detail="Inget kommande pass hittades inom 60 dagar")
 

--- a/app/routes/api_v1.py
+++ b/app/routes/api_v1.py
@@ -254,18 +254,46 @@ async def get_me(current_user: User = Depends(get_api_user)):
 @router.get("/users/{user_id}/status")
 async def get_user_status(
     user_id: int,
+    at_date: str | None = Query(None, alias="date", description="Simulate date (YYYY-MM-DD)"),
+    at_time: str | None = Query(None, alias="time", description="Simulate time (HH:MM)"),
     current_user: User = Depends(get_api_user),
     db: Session = Depends(get_db),
 ):
-    """Status for today for a given user. Includes co-workers and OB if own user or admin."""
+    """Status for a given user. Defaults to now; pass ?date=YYYY-MM-DD&time=HH:MM to simulate."""
     target = _get_user_or_404(user_id, db)
     include_salary = _can_see_salary(current_user, target)
+    if at_date:
+        try:
+            today = datetime.date.fromisoformat(at_date)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Ogiltigt datumformat, använd YYYY-MM-DD") from None
+        try:
+            current_time = datetime.time.fromisoformat(at_time) if at_time else datetime.time(0, 0)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Ogiltigt tidsformat, använd HH:MM") from None
+    else:
+        now = datetime.datetime.now(APP_TIMEZONE)
+        today = now.date()
+        current_time = now.time()
     all_users = db.query(User).filter(User.is_active == 1).all()
-    today = get_today()
     absent_ids = {row[0] for row in db.query(Absence.user_id).filter(Absence.date == today).all()}
-    return _build_day_status(
+    result = _build_day_status(
         target, today, db, include_salary=include_salary, all_users=all_users, absent_ids=absent_ids
     )
+    # Check for an ongoing overnight shift from the previous day.
+    yesterday = today - datetime.timedelta(days=1)
+    yesterday_absence = db.query(Absence).filter(Absence.user_id == target.id, Absence.date == yesterday).first()
+    if not yesterday_absence:
+        prev_shift, prev_rw = determine_shift_for_date(yesterday, target.rotation_person_id)
+        if prev_shift and prev_shift.code not in ("OFF", "OC") and _is_overnight(prev_shift):
+            prev_end = datetime.time.fromisoformat(prev_shift.end_time)
+            if current_time < prev_end:
+                result["currently_active_shift"] = {
+                    "date": yesterday.isoformat(),
+                    "shift": _shift_to_dict(prev_shift),
+                    "rotation_week": prev_rw,
+                }
+    return result
 
 
 @router.get("/users/{user_id}/schedule/today")

--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -15,6 +15,32 @@ router = APIRouter()
 
 VERSIONS = [
     {
+        "version": "0.19.1",
+        "date": "2026-05-02",
+        "entries": [
+            {
+                "type": "fix",
+                "sv": "API: nattpass returnerade ingen skiftdata vid frånvaro – rotationspasset visas nu även när dagen är ledig",
+                "en": "API: night shifts returned no shift data on absence days – rotation shift is now included even when the day is leave",
+            },
+            {
+                "type": "nyhet",
+                "sv": "API: overnight-fält på alla pass så integrationer vet när sluttiden är nästa kalenderdag",
+                "en": "API: overnight field on all shifts so integrations know when end_time falls on the next calendar day",
+            },
+            {
+                "type": "nyhet",
+                "sv": "API: currently_active_shift på /status och /next-shift visar pågående nattpass från föregående dag baserat på klockan",
+                "en": "API: currently_active_shift on /status and /next-shift shows an ongoing overnight shift from the previous day based on current time",
+            },
+            {
+                "type": "nyhet",
+                "sv": "API: /status accepterar ?date och ?time för att simulera status för valfri tidpunkt",
+                "en": "API: /status accepts ?date and ?time to simulate status for any point in time",
+            },
+        ],
+    },
+    {
         "version": "0.19.0",
         "date": "2026-05-01",
         "entries": [


### PR DESCRIPTION
## Summary

- Add `overnight` boolean to all `shift_data` responses so integrations know when `end_time` falls on the next calendar day
- Include rotation `shift_data` in absence responses (was `null` before), so the scheduled shift is visible even when the day is leave
- Add `currently_active_shift` to `/next-shift` and `/status` responses when an overnight shift from the previous day is still running (clock check against shift end time)
- Add `?date=YYYY-MM-DD&time=HH:MM` simulation params to `/status` endpoint, matching the existing pattern in `/next-shift`