### PR TITLE
Add Docker support to dev server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,12 +26,12 @@ FROM base AS builder
 # Installera byggverktyg (om du har libs som kräver kompilering)
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential
 
-COPY requirements.txt .
+COPY pyproject.toml .
 # Vi installerar i en venv för att enkelt kunna kopiera hela miljön senare
 RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir -r requirements.txt
+    pip install --no-cache-dir ".[dev]"
 
 # -------------------------------------------------------------------
 # STAGE 3: Development
@@ -53,8 +53,8 @@ USER appuser
 # Kopiera koden (men docker-compose volumes kommer oftast överskugga detta i dev)
 COPY --chown=appuser:appgroup . .
 
-# Dev-kommando med reload
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+# Dev-kommando med reload (bara app/ och tests/ bevakas för att undvika file watch-problem)
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload", "--reload-dir", "app", "--reload-dir", "tests"]
 
 # -------------------------------------------------------------------
 # STAGE 4: Production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,15 @@ services:
     build:
       context: .
       target: dev
-    container_name: fastapi_dev
+    container_name: periodical_dev
     ports:
-      - "8001:8000"
+      - "${DEV_PORT:-8001}:8000"
     volumes:
-      # Persistens för data. Mappas till mappen ./data på din värdmaskin.
       - ./data:/app/data
-      # Hot reload. OBS: Dockerfile kopierar till /app/app, så vi måste mounta exakt dit.
-      # Om du mountar till /app skriver du över requirements.txt och venv, vilket kraschar allt.
       - ./app:/app/app
+      - ./tests:/app/tests
+    environment:
+      # Åsidosätt PRODUCTION från .env -- vi kör alltid i dev-läge här
+      - PRODUCTION=false
     env_file:
       - .env

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -2,21 +2,20 @@
 
 # ==============================================================================
 # Development Server Script for Periodical
-# Usage: ./scripts/dev.sh [--port PORT] [--host HOST]
+# Usage: ./scripts/dev.sh [--port PORT] [--host HOST] [--docker]
 # Example: ./scripts/dev.sh --port 8001 --host 127.0.0.1
+# Example: ./scripts/dev.sh --docker --port 8001
 # ==============================================================================
 
-# Konfigurera färger för output
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
-NC='\033[0m' # No Color
+NC='\033[0m'
 
-# Standard värden
 HOST="192.168.0.190"
 PORT="8001"
+USE_DOCKER=false
 
-# Parse arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
         --port)
@@ -27,6 +26,10 @@ while [[ $# -gt 0 ]]; do
             HOST="$2"
             shift 2
             ;;
+        --docker)
+            USE_DOCKER=true
+            shift
+            ;;
         *)
             echo -e "${YELLOW}Unknown option: $1${NC}"
             exit 1
@@ -34,42 +37,54 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Kontrollera att vi är i rätt katalog
 if [ ! -f "app/main.py" ]; then
     echo -e "${YELLOW}Error: app/main.py not found. Run this script from the project root.${NC}"
     exit 1
-fi
-
-# Kontrollera att venv är aktiverat
-if [ -z "$VIRTUAL_ENV" ]; then
-    echo -e "${YELLOW}Warning: Virtual environment not activated.${NC}"
-    echo -e "${BLUE}Attempting to activate venv...${NC}"
-    if [ -f "venv/bin/activate" ]; then
-        source venv/bin/activate
-    else
-        echo -e "${YELLOW}Error: venv not found. Please create and activate a virtual environment.${NC}"
-        exit 1
-    fi
 fi
 
 echo -e "${GREEN}╔════════════════════════════════════════════════════════════════╗${NC}"
 echo -e "${GREEN}║          Periodical Development Server Starting...          ║${NC}"
 echo -e "${GREEN}╚════════════════════════════════════════════════════════════════╝${NC}"
 echo ""
-echo -e "${BLUE}Host:${NC}     $HOST"
-echo -e "${BLUE}Port:${NC}     $PORT"
-echo -e "${BLUE}URL:${NC}      http://$HOST:$PORT"
-echo -e "${BLUE}Docs:${NC}     http://$HOST:$PORT/docs"
-echo -e "${BLUE}Watching:${NC} app/ and tests/ directories only"
-echo ""
-echo -e "${YELLOW}Note: Only app/ and tests/ are watched to avoid file watch limit issues${NC}"
-echo -e "${YELLOW}Press CTRL+C to quit${NC}"
-echo ""
 
-# Starta uvicorn med --reload-dir för att undvika file watch limit problem
-uvicorn app.main:app \
-    --reload \
-    --reload-dir app \
-    --reload-dir tests \
-    --host "$HOST" \
-    --port "$PORT"
+if [ "$USE_DOCKER" = true ]; then
+    echo -e "${BLUE}Mode:${NC}     Docker (hot reload, PRODUCTION=false)"
+    echo -e "${BLUE}Port:${NC}     $PORT"
+    echo -e "${BLUE}URL:${NC}      http://localhost:$PORT"
+    echo -e "${BLUE}Docs:${NC}     http://localhost:$PORT/docs"
+    echo ""
+    echo -e "${YELLOW}Press CTRL+C to quit${NC}"
+    echo ""
+
+    export DEV_PORT="$PORT"
+    docker compose up --build
+else
+    echo -e "${BLUE}Mode:${NC}     Local venv"
+    echo -e "${BLUE}Host:${NC}     $HOST"
+    echo -e "${BLUE}Port:${NC}     $PORT"
+    echo -e "${BLUE}URL:${NC}      http://$HOST:$PORT"
+    echo -e "${BLUE}Docs:${NC}     http://$HOST:$PORT/docs"
+    echo -e "${BLUE}Watching:${NC} app/ and tests/ directories only"
+    echo ""
+    echo -e "${YELLOW}Note: Only app/ and tests/ are watched to avoid file watch limit issues${NC}"
+    echo -e "${YELLOW}Press CTRL+C to quit${NC}"
+    echo ""
+
+    if [ -z "$VIRTUAL_ENV" ]; then
+        echo -e "${YELLOW}Warning: Virtual environment not activated.${NC}"
+        echo -e "${BLUE}Attempting to activate venv...${NC}"
+        if [ -f "venv/bin/activate" ]; then
+            source venv/bin/activate
+        else
+            echo -e "${YELLOW}Error: venv not found. Please create and activate a virtual environment.${NC}"
+            exit 1
+        fi
+    fi
+
+    uvicorn app.main:app \
+        --reload \
+        --reload-dir app \
+        --reload-dir tests \
+        --host "$HOST" \
+        --port "$PORT"
+fi


### PR DESCRIPTION
## Summary
- `scripts/dev.sh`: nytt `--docker`-flagga som kör servern via `docker compose`; lokalt venv är fortfarande default
- `Dockerfile`: installerar beroenden från `pyproject.toml` istället för `requirements.txt`, lägger till `--reload-dir`-flaggor i dev-CMD
- `docker-compose.yml`: monterar `tests/`, sätter `PRODUCTION=false` (åsidosätter `.env`), dynamisk port via `DEV_PORT`

## Test plan
- [x] `./scripts/dev.sh` startar som vanligt med lokal venv
- [x] `./scripts/dev.sh --docker` bygger och startar containern på port 8001
- [x] Hot reload fungerar vid ändringar i `app/` och `tests/`
- [x] `PRODUCTION=false` syns i loggar vid Docker-start
- [x] `docker compose down` stoppar och tar bort containern