### PR TITLE
v0.20.0: Multi-view improvements

### DIFF
--- a/app/core/schedule/period.py
+++ b/app/core/schedule/period.py
@@ -273,6 +273,7 @@ def generate_period_data(
                 swap_map,
                 user_rates_map=user_rates_map,
                 employment_start=employment_start,
+                shift_override_map=shift_override_map,
             )
 
         days_out.append(day_info)
@@ -875,6 +876,7 @@ def _populate_single_person_day(
     swap_map: dict[tuple[int, datetime.date], str] | None = None,
     user_rates_map: dict[int, dict] | None = None,
     employment_start: datetime.date | None = None,
+    shift_override_map: dict[tuple[int, datetime.date], str] | None = None,
 ) -> None:
     """Fyller i detaljerad daginfo för en person."""
     vacation_shift = get_vacation_shift()
@@ -1027,6 +1029,22 @@ def _populate_single_person_day(
         rotation_week = None
         hours, start, end = 0.0, None, None
         ob = {}
+    elif shift_override_map is not None and shift_override_map.get((person_id, current_day)):
+        override_code = shift_override_map[(person_id, current_day)]
+        result = determine_shift_for_date(current_day, person_id)
+        rotation_week = result[1] if result else None
+        override_shift = next((s for s in shift_types if s.code == override_code), None)
+        if override_shift:
+            shift = override_shift
+            hours, start, end = calculate_shift_hours(current_day, override_shift.code)
+            if start is not None and override_shift.code != "OC":
+                ob = calculate_ob_hours(start, end, combined_ob_rules)
+            else:
+                ob = {}
+        else:
+            shift, rotation_week = None, None
+            hours, start, end = 0.0, None, None
+            ob = {}
     elif swap_map is not None and (person_id, current_day) in swap_map:
         # Skiftbyte: ersätt med det nya skiftet
         new_code = swap_map[(person_id, current_day)]

--- a/app/core/schedule/person_history.py
+++ b/app/core/schedule/person_history.py
@@ -95,10 +95,9 @@ def get_employment_period(session: Session, user_id: int, person_id: int) -> tup
         return (record.effective_from, record.effective_to)
 
     # Fallback: assume employed from rotation start
-    from app.core.schedule.core import get_settings
+    from app.core.schedule.core import get_rotation_start_date
 
-    settings = get_settings()
-    return (settings.rotation_start_date, None)
+    return (get_rotation_start_date(), None)
 
 
 def add_person_change(

--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -15,6 +15,47 @@ router = APIRouter()
 
 VERSIONS = [
     {
+        "version": "0.20.0",
+        "date": "2026-05-08",
+        "entries": [
+            {
+                "type": "fix",
+                "sv": "Månadsvy: manuellt tilldelade pass (t.ex. N2) visades inte i kalenderrutnätet trots att de syntes i veckovy",
+                "en": "Month view: manually assigned shifts (e.g. N2) were not shown in the calendar grid even though they appeared in week view",
+            },
+            {
+                "type": "fix",
+                "sv": "Månadsvy: dagens datum markerades inte med blå ram",
+                "en": "Month view: today's date was not highlighted with a blue border",
+            },
+            {
+                "type": "fix",
+                "sv": "Intervalvy: rotationsvecka visades inte på söndagar",
+                "en": "Range view: rotation week was not shown on Sundays",
+            },
+            {
+                "type": "nyhet",
+                "sv": "ISO-veckonummer (v17) i månadsvy och intervalvy är nu klickbara länkar till veckovy för den veckan",
+                "en": "ISO week numbers (v17) in month and range views are now clickable links to the week view for that week",
+            },
+            {
+                "type": "nyhet",
+                "sv": "Alla-vyer (månad/år): ISO-veckonummer visas i datumkolumnen på måndagar och länkar till veckovyn för alla",
+                "en": "All-person views (month/year): ISO week numbers appear in the date column on Mondays and link to the all-persons week view",
+            },
+            {
+                "type": "nyhet",
+                "sv": "Alla-vyer (månad/år): personfilterfält med kryssboxar per person samt markera/avmarkera alla",
+                "en": "All-person views (month/year): person filter panel with per-person checkboxes and select/deselect all",
+            },
+            {
+                "type": "nyhet",
+                "sv": "Alla-vyer (månad/år): tydligare hover-markering vid musöverfart på dagrader",
+                "en": "All-person views (month/year): more visible hover highlight on day rows",
+            },
+        ],
+    },
+    {
         "version": "0.19.1",
         "date": "2026-05-02",
         "entries": [

--- a/app/routes/schedule_all.py
+++ b/app/routes/schedule_all.py
@@ -144,6 +144,7 @@ async def show_month_all(
             "show_salary": show_salary,
             "storhelg_dates": storhelg_dates,
             "holiday_dates": holiday_dates,
+            "today": get_today(),
         },
         user=current_user,
     )

--- a/app/routes/schedule_personal.py
+++ b/app/routes/schedule_personal.py
@@ -1073,6 +1073,7 @@ async def show_month_for_person(
             "vacation_month": vacation_month,
             "before_employment_month": before_employment_month,
             "hourly_breakdown": hourly_breakdown,
+            "today": get_today(),
         },
         user=current_user,
     )

--- a/app/static/css/calendar.css
+++ b/app/static/css/calendar.css
@@ -49,6 +49,8 @@
 .day-number { font-size: 1.2rem; font-weight: 700; color: var(--text); text-decoration: none; line-height: 1; }
 .day-number:hover { color: var(--accent); }
 .rotation-week-small { font-size: 0.7rem; color: var(--muted); font-weight: 500; }
+a.rotation-week-small { text-decoration: none; }
+a.rotation-week-small:hover { color: var(--text); }
 
 .calendar-day-body { flex: 1; display: flex; flex-direction: column; gap: 4px; }
 .calendar-badge { font-size: 0.75rem; padding: 3px 7px; align-self: flex-start; }

--- a/app/static/css/tables.css
+++ b/app/static/css/tables.css
@@ -29,6 +29,8 @@ tbody td {
   color: var(--text);
 }
 
+tr.shift-row:hover { background: rgba(255,255,255,0.12); }
+tr.shift-row:hover td { background: transparent; }
 tr:hover td { background: rgba(255,255,255,0.01); }
 td.num, th.num { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
 

--- a/app/templates/month.html
+++ b/app/templates/month.html
@@ -159,7 +159,7 @@
                                         <span class="badge badge-ob4" style="font-size:0.6rem;padding:1px 4px;">H</span>
                                     {% endif %}
                                     {% if day_data.date.weekday() == 0 %}
-                                        <span class="rotation-week-small">v{{ day_data.date.isocalendar()[1] }}</span>
+                                        <a href="/week/{{ person_id }}?year={{ day_data.date.isocalendar()[0] }}&week={{ day_data.date.isocalendar()[1] }}" class="rotation-week-small">v{{ day_data.date.isocalendar()[1] }}</a>
                                     {% elif day_data.date.weekday() == 6 and day_data.rotation_week %}
                                         {% if day_data.rotation_length %}
                                             <span class="rotation-week-small">r-v{{ day_data.rotation_week }}/{{ day_data.rotation_length }}</span>

--- a/app/templates/month_all.html
+++ b/app/templates/month_all.html
@@ -46,6 +46,17 @@
 
 <h2 class="page-title">{{ t.month_all_title.replace('{year}', year|string).replace('{month}', "%02d"|format(month)) }}</h2>
 
+    <div style="display:flex;flex-wrap:wrap;gap:0.5rem;margin-bottom:0.75rem;padding:0.5rem 0.75rem;background:var(--panel);border-radius:var(--radius);border:1px solid var(--border);align-items:center;">
+        <button onclick="setAllPersonCols(true)" class="btn secondary" style="font-size:0.8rem;padding:2px 8px;">Markera alla</button>
+        <button onclick="setAllPersonCols(false)" class="btn secondary" style="font-size:0.8rem;padding:2px 8px;">Avmarkera alla</button>
+        <span style="color:var(--border);margin:0 0.25rem;">|</span>
+        {% for p in persons %}
+        <label style="display:flex;align-items:center;gap:0.3rem;cursor:pointer;font-size:0.85rem;user-select:none;">
+            <input type="checkbox" checked onchange="togglePersonCol({{ p.person_id }}, this.checked)" style="cursor:pointer;">
+            {{ p.person_name }}
+        </label>
+        {% endfor %}
+    </div>
 
     {% set header_days = persons[0].days if persons and persons|length > 0 else [] %}
 
@@ -61,7 +72,7 @@
                         {% set total_ob = (p.ob_pay.get('OB1',0) or 0) + (p.ob_pay.get('OB2',0) or 0)
                                           + (p.ob_pay.get('OB3',0) or 0) + (p.ob_pay.get('OB4',0) or 0)
                                           + (p.ob_pay.get('OB5',0) or 0) %}
-                        <th>{{ "%.2f"|format(total_ob) }}</th>
+                        <th data-person="{{ p.person_id }}">{{ "%.2f"|format(total_ob) }}</th>
                     {% endfor %}
                 </tr>
                 {% endif %}
@@ -69,7 +80,7 @@
                     <th class="w-sm">{{ t.month_all_day_col }}</th>
                     <th class="w-md">{{ t.month_all_date_col }}</th>
                     {% for p in persons %}
-                        <th class="person-header">
+                        <th class="person-header" data-person="{{ p.person_id }}">
                             <a href="/month/{{ p.person_id }}?year={{ year }}&month={{ month }}">
                                 {{ p.person_name }}<br>
                                 <small>(#{{ p.person_id }})</small>
@@ -87,6 +98,9 @@
                         <td class="day-cell">{{ weekday_names_full[day.date.weekday()] }}</td>
                         <td class="date-cell">
                             {{ day.date }}
+                            {% if day.date.weekday() == 0 %}
+                                <a href="/week?year={{ day.date.isocalendar()[0] }}&week={{ day.date.isocalendar()[1] }}" class="rotation-week-small">v{{ day.date.isocalendar()[1] }}</a>
+                            {% endif %}
                             {% if storhelg_dates is defined and day.date in storhelg_dates %}
                                 <span class="badge badge-ob5" style="font-size:0.55rem;padding:1px 3px;">S</span>
                             {% elif holiday_dates is defined and day.date in holiday_dates %}
@@ -95,7 +109,7 @@
                         </td>
                         {% for p in persons %}
                             {% set d = p.days[i] %}
-                            <td class="day-cell"
+                            <td class="day-cell" data-person="{{ p.person_id }}"
                                 title="{{ d.date.isoformat() }}"
                                 style="border-left:6px solid {% if d.shift %}{{ d.shift.color }}{% else %}transparent{% endif %}; padding-left:8px;">
                                 {% if d.shift %}
@@ -136,5 +150,19 @@
             </tbody>
         </table>
     </div>
+
+<script>
+function togglePersonCol(pid, show) {
+    document.querySelectorAll('[data-person="' + pid + '"]').forEach(function(c) {
+        c.style.display = show ? '' : 'none';
+    });
+}
+function setAllPersonCols(show) {
+    document.querySelectorAll('input[onchange^="togglePersonCol"]').forEach(function(cb) {
+        cb.checked = show;
+        cb.dispatchEvent(new Event('change'));
+    });
+}
+</script>
 
 {% endblock %}

--- a/app/templates/range.html
+++ b/app/templates/range.html
@@ -111,7 +111,13 @@
                         <span class="badge badge-ob4" style="font-size:0.6rem;padding:1px 4px;">H</span>
                     {% endif %}
                     {% if day.date.weekday() == 0 %}
-                        <span class="rotation-week-small">v{{ day.date.isocalendar()[1] }}</span>
+                        <a href="/week/{{ person_id }}?year={{ day.date.isocalendar()[0] }}&week={{ day.date.isocalendar()[1] }}" class="rotation-week-small">v{{ day.date.isocalendar()[1] }}</a>
+                    {% elif day.date.weekday() == 6 and day.rotation_week %}
+                        {% if day.rotation_length %}
+                            <span class="rotation-week-small">r-v{{ day.rotation_week }}/{{ day.rotation_length }}</span>
+                        {% else %}
+                            <span class="rotation-week-small">r-v{{ day.rotation_week }}</span>
+                        {% endif %}
                     {% endif %}
                 </div>
                 <div class="calendar-day-body">

--- a/app/templates/year_all.html
+++ b/app/templates/year_all.html
@@ -31,6 +31,18 @@
 
 <h2 class="page-title">{{ t.year_all_title.replace('{year}', year|string) }}</h2>
 
+    <div style="display:flex;flex-wrap:wrap;gap:0.5rem;margin-bottom:0.75rem;padding:0.5rem 0.75rem;background:var(--panel);border-radius:var(--radius);border:1px solid var(--border);align-items:center;">
+        <button onclick="setAllPersonCols(true)" class="btn secondary" style="font-size:0.8rem;padding:2px 8px;">Markera alla</button>
+        <button onclick="setAllPersonCols(false)" class="btn secondary" style="font-size:0.8rem;padding:2px 8px;">Avmarkera alla</button>
+        <span style="color:var(--border);margin:0 0.25rem;">|</span>
+        {% for p in person_headers %}
+        <label style="display:flex;align-items:center;gap:0.3rem;cursor:pointer;font-size:0.85rem;user-select:none;">
+            <input type="checkbox" checked onchange="togglePersonCol({{ p.person_id }}, this.checked)" style="cursor:pointer;">
+            {{ p.person_name }}
+        </label>
+        {% endfor %}
+    </div>
+
     <div class="month-grid">
         <table class="month-schedule table-sticky">
             <thead>
@@ -40,7 +52,7 @@
                         <th></th>
                         <th></th>
                         {% for p in person_headers %}
-                            <th class="num" id="total-{{ p.person_id }}">
+                            <th class="num" id="total-{{ p.person_id }}" data-person="{{ p.person_id }}">
                                 <span class="loading-spinner" style="color: #999; font-size: 0.9em;">...</span>
                             </th>
                         {% endfor %}
@@ -50,10 +62,9 @@
                     <th class="w-md">{{ t.month_all_day_col }}</th>
                     <th class="w-lg">{{ t.month_all_date_col }}</th>
                     {% for p in person_headers %}
-                        <th class="person-header">
-                            {% if user and (user.role.value == 'admin' or user.rotation_person_id == p.person_id) %}
-                                {% set link_id = user.id if user.rotation_person_id == p.person_id else p.person_id %}
-                                <a href="/year/{{ link_id }}?year={{ year }}">
+                        <th class="person-header" data-person="{{ p.person_id }}">
+                            {% if user and user.rotation_person_id == p.person_id %}
+                                <a href="/year/{{ user.id }}?year={{ year }}">
                                     {{ p.person_name }}<br>
                                     <small>(#{{ p.person_id }})</small>
                                 </a>
@@ -72,6 +83,9 @@
                         <td class="day-cell">{{ weekday_names_full[day.date.weekday()] }}</td>
                         <td class="date-cell">
                             {{ day.date }}
+                            {% if day.date.weekday() == 0 %}
+                                <a href="/week?year={{ day.date.isocalendar()[0] }}&week={{ day.date.isocalendar()[1] }}" class="rotation-week-small">v{{ day.date.isocalendar()[1] }}</a>
+                            {% endif %}
                             {% if storhelg_dates is defined and day.date in storhelg_dates %}
                                 <span class="badge badge-ob5" style="font-size:0.55rem;padding:1px 3px;">S</span>
                             {% elif holiday_dates is defined and day.date in holiday_dates %}
@@ -79,7 +93,7 @@
                             {% endif %}
                         </td>
                         {% for person in day.persons %}
-                            <td style="border-left:6px solid {% if person.shift %}{{ person.shift.color }}{% else %}transparent{% endif %}; padding-left:8px;">
+                            <td data-person="{{ person.person_id }}" style="border-left:6px solid {% if person.shift %}{{ person.shift.color }}{% else %}transparent{% endif %}; padding-left:8px;">
                                 {% if person.shift %}
                                     {# Länka till day-sida bara om admin eller egen #}
                                     {% if user and (user.role.value == 'admin' or user.rotation_person_id == person.person_id) %}
@@ -120,6 +134,18 @@
     </div>
 
 <script>
+function togglePersonCol(pid, show) {
+    document.querySelectorAll('[data-person="' + pid + '"]').forEach(function(c) {
+        c.style.display = show ? '' : 'none';
+    });
+}
+function setAllPersonCols(show) {
+    document.querySelectorAll('input[onchange^="togglePersonCol"]').forEach(function(cb) {
+        cb.checked = show;
+        cb.dispatchEvent(new Event('change'));
+    });
+}
+
 // Hide/show past days toggle
 var pastRowsVisible = false;
 


### PR DESCRIPTION
## Summary

- Fix shift overrides (t.ex. N2) not appearing in month view calendar grid -- `_populate_single_person_day` was missing `shift_override_map` parameter
- Fix today highlight missing in month view and month_all view
- Fix rotation week not shown on Sundays in range view
- Fix 500 error on year view for non-admin users -- `get_employment_period` fallback returned raw config string instead of `datetime.date`
- ISO week numbers (v17) in month, range, month_all and year_all are now clickable links to the corresponding week view
- Person filter panel with checkboxes (+ select/deselect all) in month_all and year_all for easier comparison between people
- Clearer row hover highlight in month_all and year_all

## Test plan

- [x] Add a shift override (N1/N2/N3) for a date and verify it shows in both week view and month view
- [x] Verify today's date is highlighted in month view and month_all
- [x] Open range view on a Sunday and verify rotation week appears
- [x] Click a week number link (v17) in month view -- should navigate to week view for that week
- [x] In month_all/year_all, uncheck a person, verify their column disappears cleanly with no misalignment
- [x] Use "Avmarkera alla" then "Markera alla" to verify all columns hide and reappear