### PR TITLE
Fix cowork detail view counting vacation days as shared shifts (v0.21.2)

### DIFF
--- a/app/core/schedule/cowork.py
+++ b/app/core/schedule/cowork.py
@@ -194,10 +194,10 @@ def build_cowork_details(
         target_shift = target.get("shift")
         other_shift = other.get("shift")
 
-        # Båda måste jobba
-        if not target_shift or target_shift.code == "OFF":
+        # Båda måste jobba ett riktigt arbetspass (N1/N2/N3)
+        if not target_shift or target_shift.code not in ("N1", "N2", "N3"):
             continue
-        if not other_shift or other_shift.code == "OFF":
+        if not other_shift or other_shift.code not in ("N1", "N2", "N3"):
             continue
 
         # Samma skifttyp

--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -15,6 +15,17 @@ router = APIRouter()
 
 VERSIONS = [
     {
+        "version": "0.21.2",
+        "date": "2026-05-14",
+        "entries": [
+            {
+                "type": "fix",
+                "sv": "Cowork: semesterdagar (SEM) räknades som gemensamma pass i detaljvyn om båda personerna hade semester samma dag – enbart N1/N2/N3 räknas nu som arbetspass",
+                "en": "Cowork: vacation days (SEM) were counted as shared shifts in the detail view when both persons had vacation on the same day – only N1/N2/N3 now count as work shifts",
+            },
+        ],
+    },
+    {
         "version": "0.21.1",
         "date": "2026-05-14",
         "entries": [


### PR DESCRIPTION
## Summary
- `build_cowork_details` only filtered out `OFF`, letting `SEM` (and other non-work codes like `SICK`, `VAB`) pass through
- Days where both persons were on vacation appeared as shared shifts in the detail table
- Filter now requires `N1/N2/N3`, matching the existing logic in `build_cowork_stats`

## Test plan
- [x] Open cowork detail view for two persons who share vacation days -- verify SEM rows no longer appear
- [x] Verify N1/N2/N3 shared shifts still show correctly