### PR TITLE
Refactor: DRY/KISS cleanup -- OB-duplikat, tyst exception, månadsdata

### DIFF
--- a/app/core/schedule/ob.py
+++ b/app/core/schedule/ob.py
@@ -63,8 +63,7 @@ def calculate_ob_hours(
         )
         segment_end = min(end_dt, day_end)
 
-        # Hämta och prioritera dagens regler
-        todays_rules = _select_rules_for_date(current, rules)
+        todays_rules = select_ob_rules_for_date(current, rules)
         sorted_rules = sorted(todays_rules, key=_rule_priority, reverse=True)
 
         covered: list[tuple[datetime.datetime, datetime.datetime]] = []
@@ -78,7 +77,6 @@ def calculate_ob_hours(
             if overlap_end <= overlap_start:
                 continue
 
-            # Subtrahera redan täckta intervall
             uncovered = _subtract_covered(overlap_start, overlap_end, covered)
 
             for ustart, uend in uncovered:
@@ -120,10 +118,8 @@ def calculate_ob_pay(
         if h > 0:
             fixed_rate = overrides.get(rule.code)
             if fixed_rate is not None:
-                # Per-user override: fixed kr/tim
                 pays[rule.code] = h * float(fixed_rate)
             else:
-                # Default: salary / divisor
                 divisor = getattr(rule, "rate", None)
                 pays[rule.code] = h * (monthly_salary / float(divisor)) if divisor else 0.0
         else:
@@ -132,60 +128,11 @@ def calculate_ob_pay(
     return pays
 
 
-# === Privata hjälpfunktioner ===
-
-
-def _rule_priority(rule: ObRule) -> int:
-    """Returnerar prioritet för en OB-regel."""
-    return OB_PRIORITY_BY_CODE.get(rule.code, OB_PRIORITY_DEFAULT)
-
-
-def _select_rules_for_date(
-    dt: datetime.datetime,
-    rules: list[ObRule],
-) -> list[ObRule]:
-    """Väljer regler som gäller för ett specifikt datum."""
-    weekday = dt.weekday()
-    date_iso = dt.date().isoformat()
-
-    matching = []
-    for rule in rules:
-        match = False
-
-        # Matcha på veckodag
-        if getattr(rule, "days", None) and weekday in rule.days:
-            match = True
-
-        # Matcha på specifikt datum
-        if not match and getattr(rule, "specific_date", None) == date_iso:
-            match = True
-
-        # Matcha på lista av datum
-        if not match:
-            specific_dates = getattr(rule, "specific_dates", None)
-            if specific_dates and date_iso in specific_dates:
-                match = True
-
-        if match:
-            matching.append(rule)
-
-    return matching
-
-
-"""OB-tilläggsberäkningar."""
-
-# === Publika hjälpfunktioner ===
-
-
 def select_ob_rules_for_date(
     dt: datetime.datetime,
     rules: list[ObRule],
 ) -> list[ObRule]:
-    """
-    Väljer regler som gäller för ett specifikt datum.
-
-    Publik funktion för användning i routes.
-    """
+    """Väljer regler som gäller för ett specifikt datum."""
     weekday = dt.weekday()
     date_iso = dt.date().isoformat()
 
@@ -216,38 +163,6 @@ def select_ob_rules_for_date(
 def _rule_priority(rule: ObRule) -> int:
     """Returnerar prioritet för en OB-regel."""
     return OB_PRIORITY_BY_CODE.get(rule.code, OB_PRIORITY_DEFAULT)
-
-
-def _select_rules_for_date(
-    dt: datetime.datetime,
-    rules: list[ObRule],
-) -> list[ObRule]:
-    """Väljer regler som gäller för ett specifikt datum."""
-    weekday = dt.weekday()
-    date_iso = dt.date().isoformat()
-
-    matching = []
-    for rule in rules:
-        match = False
-
-        # Matcha på veckodag
-        if getattr(rule, "days", None) and weekday in rule.days:
-            match = True
-
-        # Matcha på specifikt datum
-        if not match and getattr(rule, "specific_date", None) == date_iso:
-            match = True
-
-        # Matcha på lista av datum
-        if not match:
-            specific_dates = getattr(rule, "specific_dates", None)
-            if specific_dates and date_iso in specific_dates:
-                match = True
-
-        if match:
-            matching.append(rule)
-
-    return matching
 
 
 def _rule_interval_for_day(

--- a/app/core/schedule/summary.py
+++ b/app/core/schedule/summary.py
@@ -156,7 +156,9 @@ def summarize_month_for_person(
 
     # Använd förgenererad data eller generera ny
     if year_days is None:
-        days = generate_year_data(year, person_id, session=session, user_wages=user_wages, user_rates_map=_rates_map)
+        days = generate_month_data(
+            year, month, person_id, session=session, user_wages=user_wages, user_rates_map=_rates_map
+        )
     else:
         days = year_days
 

--- a/app/routes/dashboard.py
+++ b/app/routes/dashboard.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 
 from app.auth.auth import get_current_user_optional
 from app.core.helpers import can_see_salary, render_template
+from app.core.logging_config import get_logger
 from app.core.oncall import _cached_oncall_rules, calculate_oncall_pay
 from app.core.rates import get_user_rates
 from app.core.schedule import (
@@ -42,6 +43,7 @@ from app.database.database import Absence, OnCallOverride, OnCallOverrideType, S
 from app.routes.shared import templates
 
 router = APIRouter(tags=["dashboard"])
+logger = get_logger(__name__)
 
 
 def _query_absence_and_deduction(
@@ -191,7 +193,7 @@ def _compute_month_summary(
             payment_year = year + 1 if month == 12 else year
             taxes = calculate_tax_from_table(gross_pay, tax_table, year=payment_year)
         except Exception:
-            pass
+            logger.warning("Skatteberäkning misslyckades för tabell %s", tax_table, exc_info=True)
 
     net_pay = gross_pay - taxes
     ob_pct = (ob_hours / total_hours * 100) if total_hours > 0 else 0.0

--- a/app/routes/schedule_personal.py
+++ b/app/routes/schedule_personal.py
@@ -965,7 +965,9 @@ async def show_month_for_person(
                         "supplement_month": round(pay.get("supplement_per_day", 0) * sem_count, 0),
                     }
                 except Exception:
-                    pass
+                    logger.warning(
+                        "Semestertillägg kunde inte beräknas för user_id=%s", user_id_for_wages, exc_info=True
+                    )
 
     # Hide summary stats if the entire month is before the viewer's employment start
     import calendar as _cal_mod


### PR DESCRIPTION
## Summary

- `ob.py`: Raderar två identiska kopior av `_select_rules_for_date` samt en extra `_rule_priority` och en lös modul-docstring -- troligen ett gammalt sammanslagningsmisstag. `select_ob_rules_for_date` är nu den enda definitionen.
- `summary.py`: `summarize_month_for_person` anropade `generate_year_data` (365 dagar) och filtrerade sedan bort allt utom en månad -- bytt till `generate_month_data` (~30 dagar).
- `dashboard.py`: Lägger till logger och byter tyst `except: pass` mot `logger.warning` så att skatteberäkningsfel syns i loggar.
- `schedule_personal.py`: Samma `logger.warning` för semestertillägg.

Netto: -90 rader.