### PR TITLE
Centralize auth checks and inject DB session in vacation helpers

### DIFF
--- a/app/core/helpers.py
+++ b/app/core/helpers.py
@@ -5,13 +5,19 @@ Shared helper functions for templates and route handlers.
 
 from datetime import date
 
-from fastapi import Request
+from fastapi import HTTPException, Request
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
 
 from app.core.translations import TRANSLATIONS
 from app.core.utils import get_today
 from app.database.database import User, UserRole
+
+
+def require_own_or_admin(current_user: User, target_user_id: int, detail: str = "Not authorized") -> None:
+    """Raise HTTP 403 if current_user is neither admin nor the target user."""
+    if current_user.role != UserRole.ADMIN and target_user_id != current_user.id:
+        raise HTTPException(status_code=403, detail=detail)
 
 
 def contrast_color(hex_color: str) -> str:

--- a/app/core/schedule/period.py
+++ b/app/core/schedule/period.py
@@ -207,8 +207,8 @@ def generate_period_data(
         combined_ob_rules.extend(get_combined_rules_for_year(yr))
 
     # Ladda semester- och föräldraledighetsdatum
-    vacation_dates = _load_vacation_dates(years_in_range)
-    parental_dates = _load_parental_dates(years_in_range)
+    vacation_dates = _load_vacation_dates(years_in_range, session=session)
+    parental_dates = _load_parental_dates(years_in_range, session=session)
 
     # Ladda löner om inte redan gjort
     if user_wages is None:
@@ -334,11 +334,11 @@ def _get_years_in_range(start: datetime.date, end: datetime.date) -> set[int]:
     return years
 
 
-def _load_vacation_dates(years: set[int]) -> dict[int, set[datetime.date]]:
+def _load_vacation_dates(years: set[int], session=None) -> dict[int, set[datetime.date]]:
     """Laddar semesterdatum för flera år."""
     vacation_dates: dict[int, set[datetime.date]] = {}
     for yr in years:
-        year_vacations = get_vacation_dates_for_year(yr)
+        year_vacations = get_vacation_dates_for_year(yr, session=session)
         for pid, dates in year_vacations.items():
             if pid not in vacation_dates:
                 vacation_dates[pid] = set()
@@ -346,11 +346,11 @@ def _load_vacation_dates(years: set[int]) -> dict[int, set[datetime.date]]:
     return vacation_dates
 
 
-def _load_parental_dates(years: set[int]) -> dict[int, set[datetime.date]]:
+def _load_parental_dates(years: set[int], session=None) -> dict[int, set[datetime.date]]:
     """Laddar föräldraledighetsdatum för flera år."""
     parental_dates: dict[int, set[datetime.date]] = {}
     for yr in years:
-        year_parentals = get_parental_dates_for_year(yr)
+        year_parentals = get_parental_dates_for_year(yr, session=session)
         for pid, dates in year_parentals.items():
             if pid not in parental_dates:
                 parental_dates[pid] = set()

--- a/app/core/schedule/vacation.py
+++ b/app/core/schedule/vacation.py
@@ -6,7 +6,7 @@ import math
 from app.core.constants import PERSON_IDS
 
 
-def get_vacation_dates_for_year(year: int) -> dict[int, set[datetime.date]]:
+def get_vacation_dates_for_year(year: int, session=None) -> dict[int, set[datetime.date]]:
     """
     Hämtar semesterdatum för alla personer för ett år.
 
@@ -20,7 +20,8 @@ def get_vacation_dates_for_year(year: int) -> dict[int, set[datetime.date]]:
 
     per_person: dict[int, set[datetime.date]] = {pid: set() for pid in PERSON_IDS}
 
-    db = SessionLocal()
+    _owned = session is None
+    db = SessionLocal() if _owned else session
     try:
         # Query active users by rotation position, not by user.id
         users = (
@@ -62,12 +63,13 @@ def get_vacation_dates_for_year(year: int) -> dict[int, set[datetime.date]]:
             if person_id is not None:
                 per_person[person_id].add(absence.date)
     finally:
-        db.close()
+        if _owned:
+            db.close()
 
     return per_person
 
 
-def get_parental_dates_for_year(year: int) -> dict[int, set[datetime.date]]:
+def get_parental_dates_for_year(year: int, session=None) -> dict[int, set[datetime.date]]:
     """
     Hämtar föräldraledighetsdatum för alla personer för ett år.
 
@@ -81,7 +83,8 @@ def get_parental_dates_for_year(year: int) -> dict[int, set[datetime.date]]:
 
     per_person: dict[int, set[datetime.date]] = {pid: set() for pid in PERSON_IDS}
 
-    db = SessionLocal()
+    _owned = session is None
+    db = SessionLocal() if _owned else session
     try:
         users = (
             db.query(User)
@@ -122,7 +125,8 @@ def get_parental_dates_for_year(year: int) -> dict[int, set[datetime.date]]:
             if person_id is not None:
                 per_person[person_id].add(absence.date)
     finally:
-        db.close()
+        if _owned:
+            db.close()
 
     return per_person
 

--- a/app/routes/oncall.py
+++ b/app/routes/oncall.py
@@ -10,8 +10,9 @@ from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 
 from app.auth.auth import get_current_user
+from app.core.helpers import require_own_or_admin
 from app.core.schedule import clear_schedule_cache
-from app.database.database import OnCallOverride, OnCallOverrideType, User, UserRole, get_db
+from app.database.database import OnCallOverride, OnCallOverrideType, User, get_db
 
 router = APIRouter(prefix="/oncall", tags=["oncall"])
 
@@ -31,9 +32,7 @@ async def add_oncall_override(
     - Admin: can add for any user
     - User: can only add for themselves
     """
-    # Permission check
-    if current_user.role != UserRole.ADMIN and user_id != current_user.id:
-        raise HTTPException(status_code=403, detail="Not authorized to add on-call for other users")
+    require_own_or_admin(current_user, user_id, "Not authorized to add on-call for other users")
 
     # Parse date
     oc_date = datetime.strptime(date, "%Y-%m-%d").date()
@@ -83,8 +82,7 @@ async def remove_oncall_override(
     - User: can only remove for themselves
     """
     # Permission check
-    if current_user.role != UserRole.ADMIN and user_id != current_user.id:
-        raise HTTPException(status_code=403, detail="Not authorized to remove on-call for other users")
+    require_own_or_admin(current_user, user_id, "Not authorized to remove on-call for other users")
 
     # Parse date
     oc_date = datetime.strptime(date, "%Y-%m-%d").date()
@@ -137,8 +135,7 @@ async def delete_oncall_override(
         raise HTTPException(status_code=404, detail="On-call override not found")
 
     # Permission check
-    if current_user.role != UserRole.ADMIN and override.user_id != current_user.id:
-        raise HTTPException(status_code=403, detail="Not authorized to delete this on-call override")
+    require_own_or_admin(current_user, override.user_id, "Not authorized to delete this on-call override")
 
     # Save info for redirect
     user_id = override.user_id

--- a/app/routes/overtime.py
+++ b/app/routes/overtime.py
@@ -10,13 +10,14 @@ from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 
 from app.auth.auth import get_current_user
+from app.core.helpers import require_own_or_admin
 from app.core.schedule import (
     calculate_overtime_pay,
     clear_schedule_cache,
     get_ot_hourly_rate_from_stored_wage,
     get_user_wage,
 )
-from app.database.database import OvertimeShift, User, UserRole, get_db
+from app.database.database import OvertimeShift, User, get_db
 
 router = APIRouter(prefix="/overtime", tags=["overtime"])
 
@@ -39,9 +40,7 @@ async def add_overtime_shift(
     - Admin: can add for any user
     - User: can only add for themselves
     """
-    # Permission check
-    if current_user.role != UserRole.ADMIN and user_id != current_user.id:
-        raise HTTPException(status_code=403, detail="Not authorized to add overtime for other users")
+    require_own_or_admin(current_user, user_id, "Not authorized to add overtime for other users")
 
     # Parse date first (needed for wage lookup)
     ot_date = datetime.strptime(date, "%Y-%m-%d").date()
@@ -103,9 +102,7 @@ async def delete_overtime_shift(
     if not ot_shift:
         raise HTTPException(status_code=404, detail="Overtime shift not found")
 
-    # Permission check
-    if current_user.role != UserRole.ADMIN and ot_shift.user_id != current_user.id:
-        raise HTTPException(status_code=403, detail="Not authorized to delete this overtime shift")
+    require_own_or_admin(current_user, ot_shift.user_id, "Not authorized to delete this overtime shift")
 
     # Save info for redirect
     user_id = ot_shift.user_id

--- a/app/routes/shift_override.py
+++ b/app/routes/shift_override.py
@@ -8,8 +8,9 @@ from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 
 from app.auth.auth import get_current_user
+from app.core.helpers import require_own_or_admin
 from app.core.schedule import clear_schedule_cache
-from app.database.database import ShiftOverride, User, UserRole, get_db
+from app.database.database import ShiftOverride, User, get_db
 
 router = APIRouter(prefix="/shift-override", tags=["shift_override"])
 
@@ -24,8 +25,7 @@ async def add_shift_override(
     session: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    if current_user.role != UserRole.ADMIN and current_user.id != user_id:
-        raise HTTPException(status_code=403, detail="Du kan bara lägga till manuella pass för dig själv")
+    require_own_or_admin(current_user, user_id, "Du kan bara lägga till manuella pass för dig själv")
 
     if shift_code not in _ALLOWED_CODES:
         raise HTTPException(status_code=400, detail="Ogiltigt skiftkod, använd N1/N2/N3")
@@ -69,8 +69,7 @@ async def delete_shift_override(
     if not override:
         raise HTTPException(status_code=404, detail="Override hittades inte")
 
-    if current_user.role != UserRole.ADMIN and current_user.id != override.user_id:
-        raise HTTPException(status_code=403, detail="Du kan bara ta bort dina egna manuella pass")
+    require_own_or_admin(current_user, override.user_id, "Du kan bara ta bort dina egna manuella pass")
 
     redirect_date = override.date
     redirect_user = override.user_id


### PR DESCRIPTION
## Summary

- Extract repeated HTTP-403 permission check into `require_own_or_admin()` in `helpers.py`, replacing 7 inline blocks across `overtime.py`, `oncall.py`, and `shift_override.py`
- Remove now-unused `UserRole` imports from those three route files
- Add optional `session` parameter to `get_vacation_dates_for_year` and `get_parental_dates_for_year` so callers can reuse an existing DB connection instead of opening a new one
- Pass session through `_load_vacation_dates` / `_load_parental_dates` in `period.py`; `generate_period_data` now reuses its own session for the entire request