### PR TITLE
Add per-calendar-day OB/OT breakdown toggle on month view (v0.22.0)

### DIFF
--- a/app/core/schedule/__init__.py
+++ b/app/core/schedule/__init__.py
@@ -23,6 +23,7 @@ from .cowork import build_cowork_details, build_cowork_stats, build_handover_det
 from .holidays_ob import build_special_ob_rules_for_year
 from .ob import (
     calculate_ob_hours,
+    calculate_ob_hours_by_day,
     calculate_ob_pay,
     get_combined_rules_for_year,
     get_ob_rules,
@@ -85,6 +86,7 @@ __all__ = [
     "clear_schedule_cache",
     # ob
     "calculate_ob_hours",
+    "calculate_ob_hours_by_day",
     "calculate_ob_pay",
     "get_ob_rules",
     "get_special_rules_for_year",

--- a/app/core/schedule/ob.py
+++ b/app/core/schedule/ob.py
@@ -89,6 +89,65 @@ def calculate_ob_hours(
     return ob_totals
 
 
+def calculate_ob_hours_by_day(
+    start_dt: datetime.datetime,
+    end_dt: datetime.datetime,
+    rules: list[ObRule],
+) -> dict[datetime.date, dict[str, float]]:
+    """
+    Calculate OB hours per code per calendar day.
+
+    Unlike calculate_ob_hours which returns a flat total per code, this
+    function returns a dict keyed by calendar date. Used for the per-day
+    breakdown toggle, where a night shift crossing midnight should show
+    OB on the day the hours actually fall on.
+
+    Args:
+        start_dt: Shift start time
+        end_dt: Shift end time
+        rules: List of OB rules to apply
+
+    Returns:
+        Dict mapping date -> {OB code -> hours}
+    """
+    if not start_dt or not end_dt or end_dt <= start_dt:
+        return {}
+
+    result: dict[datetime.date, dict[str, float]] = {}
+    current = start_dt
+
+    while current < end_dt:
+        day_end = datetime.datetime.combine(
+            current.date() + datetime.timedelta(days=1),
+            datetime.time(0, 0),
+        )
+        segment_end = min(end_dt, day_end)
+
+        ob_totals = {rule.code: 0.0 for rule in rules}
+        todays_rules = select_ob_rules_for_date(current, rules)
+        sorted_rules = sorted(todays_rules, key=_rule_priority, reverse=True)
+        covered: list[tuple[datetime.datetime, datetime.datetime]] = []
+
+        for rule in sorted_rules:
+            ob_start, ob_end = _rule_interval_for_day(rule, current)
+            overlap_start = max(current, ob_start)
+            overlap_end = min(segment_end, ob_end)
+
+            if overlap_end <= overlap_start:
+                continue
+
+            uncovered = _subtract_covered(overlap_start, overlap_end, covered)
+            for ustart, uend in uncovered:
+                hours = (uend - ustart).total_seconds() / 3600.0
+                ob_totals[rule.code] += hours
+                covered.append((ustart, uend))
+
+        result[current.date()] = ob_totals
+        current = segment_end
+
+    return result
+
+
 def calculate_ob_pay(
     start_dt: datetime.datetime,
     end_dt: datetime.datetime,

--- a/app/core/schedule/summary.py
+++ b/app/core/schedule/summary.py
@@ -2,8 +2,8 @@
 
 from app.core.storage import load_persons, load_tax_brackets
 
-from .core import get_settings
-from .ob import calculate_ob_hours, calculate_ob_pay, get_combined_rules_for_year
+from .core import get_settings, weekday_names
+from .ob import calculate_ob_hours, calculate_ob_hours_by_day, calculate_ob_pay, get_combined_rules_for_year
 from .period import generate_month_data, generate_period_data, generate_year_data
 from .wages import get_absence_deductions_for_month, get_all_user_wages, get_effective_monthly_wage, get_user_wage
 
@@ -203,6 +203,27 @@ def summarize_month_for_person(
             ob_rate_overrides=user_rates.get("ob") if user_rates else None,
         )
         days_out.append(day_data)
+
+    # Aggregate OB and OT hours per calendar day (used by the per-day breakdown toggle).
+    # A night shift crossing midnight contributes to both calendar days:
+    # e.g. Sat 22:00-Sun 06:30 gives 2h OB on Saturday and 6.5h OB on Sunday.
+    # If the person also works Sun-Mon, Sunday's totals are merged: 6.5 + 2 = 8.5h.
+    calendar_day_ob: dict = {}
+    for day_data in days_out:
+        for cal_date, ob_dict in day_data.get("ob_hours_by_day", {}).items():
+            bucket = calendar_day_ob.setdefault(cal_date, {})
+            for code, hrs in ob_dict.items():
+                bucket[code] = bucket.get(code, 0.0) + hrs
+
+    calendar_day_ot: dict = {}
+    for day_data in days_out:
+        for cal_date, ot_hrs in day_data.get("ot_hours_by_day", {}).items():
+            if ot_hrs > 0:
+                calendar_day_ot[cal_date] = calendar_day_ot.get(cal_date, 0.0) + ot_hrs
+
+    for day_data in days_out:
+        day_data["ob_hours_calendar_day"] = calendar_day_ob.get(day_data["date"], {})
+        day_data["ot_hours_calendar_day"] = calendar_day_ot.get(day_data["date"], 0.0)
 
     # Hämta frånvaroavdrag för månaden
     absence_details = []
@@ -449,15 +470,33 @@ def _process_day_for_summary(
     start = day.get("start")
     end = day.get("end")
 
-    # Beräkna OB om tillämpligt
+    # Calculate OB if applicable
     if shift and shift.code not in ("OFF", "OC", "OT") and start and end:
         ob_hours = calculate_ob_hours(start, end, combined_rules)
         ob_pay = calculate_ob_pay(start, end, combined_rules, base_salary, rate_overrides=ob_rate_overrides)
+        ob_hours_by_day = calculate_ob_hours_by_day(start, end, combined_rules)
     else:
         ob_hours = {r.code: 0.0 for r in combined_rules}
         ob_pay = {r.code: 0.0 for r in combined_rules}
+        ob_hours_by_day = {}
 
-    # Uppdatera totaler (exkludera OC från shifts och hours)
+    # Compute midnight-crossing metadata (used for per-calendar-day OB aggregation)
+    from datetime import datetime as _dt
+    from datetime import time as _time
+    from datetime import timedelta as _td
+
+    date_next_day = None
+    weekday_name_next_day = None
+    hours_this_day = hours
+    hours_next_day = 0.0
+    if start and end and end.date() > start.date():
+        midnight = _dt.combine(end.date(), _time(0, 0))
+        hours_this_day = max((midnight - start).total_seconds() / 3600.0, 0.0)
+        hours_next_day = max((end - midnight).total_seconds() / 3600.0, 0.0)
+        date_next_day = end.date()
+        weekday_name_next_day = weekday_names[date_next_day.weekday()]
+
+    # Update totals (exclude OC from shifts and hours)
     if shift and shift.code != "OC":
         totals["total_hours"] += hours
 
@@ -471,12 +510,39 @@ def _process_day_for_summary(
         totals["ob_pay"][code] = totals["ob_pay"].get(code, 0.0) + p
         totals["brutto_pay"] += p
 
-    # Lägg till beredskap och övertid
+    # Add on-call and overtime
     oncall_pay = day.get("oncall_pay", 0.0)
     oncall_details = day.get("oncall_details", {})
     oncall_hours = oncall_details.get("total_hours", 0.0) if oncall_details else 0.0
     ot_pay = day.get("ot_pay", 0.0)
     ot_hours = day.get("ot_hours", 0.0)
+
+    # Compute per-calendar-day OT hours for midnight-crossing overtime shifts
+    ot_details_data = day.get("ot_details", {})
+    ot_hours_by_day: dict = {}
+    if ot_hours > 0 and ot_details_data:
+        _start_str = str(ot_details_data.get("start_time", ""))
+        _end_str = str(ot_details_data.get("end_time", ""))
+        if _start_str and _end_str:
+            try:
+                _day_date = day["date"]
+                _sh, _sm = int(_start_str[:2]), int(_start_str[3:5])
+                _eh, _em = int(_end_str[:2]), int(_end_str[3:5])
+                _ot_start = _dt(_day_date.year, _day_date.month, _day_date.day, _sh, _sm)
+                _ot_end = _dt(_day_date.year, _day_date.month, _day_date.day, _eh, _em)
+                if _ot_end <= _ot_start:
+                    _ot_end += _td(days=1)
+                if _ot_end.date() > _ot_start.date():
+                    _midnight = _dt.combine(_ot_end.date(), _time(0, 0))
+                    _ot_this = max((_midnight - _ot_start).total_seconds() / 3600.0, 0.0)
+                    _ot_next = max((_ot_end - _midnight).total_seconds() / 3600.0, 0.0)
+                    ot_hours_by_day = {_ot_start.date(): _ot_this, _ot_end.date(): _ot_next}
+                else:
+                    ot_hours_by_day = {_day_date: ot_hours}
+            except (ValueError, IndexError, KeyError):
+                ot_hours_by_day = {day["date"]: ot_hours}
+    elif ot_hours > 0:
+        ot_hours_by_day = {day["date"]: ot_hours}
 
     totals["brutto_pay"] += oncall_pay + ot_pay
     totals["oncall_pay"] += oncall_pay
@@ -494,10 +560,16 @@ def _process_day_for_summary(
         "hours": hours,
         "ob_hours": ob_hours,
         "ob_pay": ob_pay,
+        "ob_hours_by_day": ob_hours_by_day,
+        "hours_this_day": hours_this_day,
+        "hours_next_day": hours_next_day,
+        "date_next_day": date_next_day,
+        "weekday_name_next_day": weekday_name_next_day,
         "oncall_pay": oncall_pay,
         "oncall_details": day.get("oncall_details", {}),
         "ot_pay": ot_pay,
         "ot_hours": day.get("ot_hours", 0.0),
+        "ot_hours_by_day": ot_hours_by_day,
         "ot_details": day.get("ot_details", {}),
         "start": start,
         "end": end,

--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -15,6 +15,17 @@ router = APIRouter()
 
 VERSIONS = [
     {
+        "version": "0.22.0",
+        "date": "2026-05-27",
+        "entries": [
+            {
+                "type": "ny funktion",
+                "sv": "Månadsvy: ny toggle i detaljerad breakdown – 'Visa OB per kalenderdag' fördelar OB och ÖT på de kalenderdagar timmarna faktiskt faller på istället för att lägga allt på startdagen; nattpass som sträcker sig över midnatt visas uppdelade",
+                "en": "Month view: new toggle in the detailed breakdown – 'Show OB per calendar day' distributes OB and OT hours across the calendar days they actually fall on instead of attributing everything to the shift start day; night shifts crossing midnight are shown split accordingly",
+            },
+        ],
+    },
+    {
         "version": "0.21.3",
         "date": "2026-05-14",
         "entries": [

--- a/app/templates/month.html
+++ b/app/templates/month.html
@@ -219,8 +219,13 @@
         {% endif %}
     </div>
 
-    <div id="breakdown-section" style="display: none; margin-top: 1rem;">
-        <h3 style="margin-bottom: 0.5rem;">{{ t.month_breakdown_title }}</h3>
+    <div id="breakdown-section" style="display: none; margin-top: 1rem;" class="ob-by-shift">
+        <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.75rem; flex-wrap: wrap; gap: 0.5rem;">
+            <h3 style="margin: 0;">{{ t.month_breakdown_title }}</h3>
+            <button class="btn secondary" id="ob-day-toggle" onclick="toggleObDayMode()" style="font-size: 0.85rem;">
+                Visa OB per kalenderdag
+            </button>
+        </div>
         <div style="overflow-x: auto;">
             <table class="breakdown-table">
                 <thead>
@@ -278,97 +283,139 @@
 
                         {% set row_total = norm + ob_sum + oc_vardag + oc_helg + oc_helgdag + oc_storhelg + ot %}
 
-                        {% if row_total > 0 %}
-                            {% set ns.has_rows = true %}
-                            {% set ns.tot_norm = ns.tot_norm + norm %}
-                            {% set ns.tot_ob1 = ns.tot_ob1 + ob1 %}
-                            {% set ns.tot_ob2 = ns.tot_ob2 + ob2 %}
-                            {% set ns.tot_ob3 = ns.tot_ob3 + ob3 %}
-                            {% set ns.tot_ob4 = ns.tot_ob4 + ob4 %}
-                            {% set ns.tot_ob5 = ns.tot_ob5 + ob5 %}
-                            {% set ns.tot_vardag = ns.tot_vardag + oc_vardag %}
-                            {% set ns.tot_helg = ns.tot_helg + oc_helg %}
-                            {% set ns.tot_helgdag = ns.tot_helgdag + oc_helgdag %}
-                            {% set ns.tot_storhelg = ns.tot_storhelg + oc_storhelg %}
-                            {% set ns.tot_ot = ns.tot_ot + ot %}
+                        {# Per-calendar-day OB and OT: aggregated across all shifts touching this day #}
+                        {% set cd_ob = d.ob_hours_calendar_day if d.ob_hours_calendar_day is defined else {} %}
+                        {% set cd_ob1 = cd_ob.get('OB1', 0) or 0 %}
+                        {% set cd_ob2 = cd_ob.get('OB2', 0) or 0 %}
+                        {% set cd_ob3 = cd_ob.get('OB3', 0) or 0 %}
+                        {% set cd_ob4 = cd_ob.get('OB4', 0) or 0 %}
+                        {% set cd_ob5 = cd_ob.get('OB5', 0) or 0 %}
+                        {% set cd_ob_sum = cd_ob1 + cd_ob2 + cd_ob3 + cd_ob4 + cd_ob5 %}
+                        {% set cd_ot = d.ot_hours_calendar_day if d.ot_hours_calendar_day is defined else 0 %}
+                        {% set cd_row_total = cd_ob_sum + oc_vardag + oc_helg + oc_helgdag + oc_storhelg + cd_ot %}
 
-                            {# Shift type label and times #}
-                            {% set shift_label = d.shift.label if d.shift and d.shift.label else (d.shift.code if d.shift else '') %}
-                            {% if d.start and d.end %}
-                                {% set t_start = d.start | time_format %}
-                                {% set t_end = d.end | time_format %}
-                            {% elif d.shift and d.shift.start_time %}
-                                {% set t_start = d.shift.start_time %}
-                                {% set t_end = d.shift.end_time %}
-                            {% else %}
-                                {% set t_start = '' %}
-                                {% set t_end = '' %}
+                        {# Shift label (needed in both modes) #}
+                        {% set shift_label = d.shift.label if d.shift and d.shift.label else (d.shift.code if d.shift and d.shift.code != 'OFF' else '') %}
+
+                        {% if row_total > 0 or cd_row_total > 0 %}
+                            {% if row_total > 0 or cd_row_total > 0 %}{% set ns.has_rows = true %}{% endif %}
+
+                            {% if row_total > 0 %}
+                                {% set ns.tot_norm = ns.tot_norm + norm %}
+                                {% set ns.tot_ob1 = ns.tot_ob1 + ob1 %}
+                                {% set ns.tot_ob2 = ns.tot_ob2 + ob2 %}
+                                {% set ns.tot_ob3 = ns.tot_ob3 + ob3 %}
+                                {% set ns.tot_ob4 = ns.tot_ob4 + ob4 %}
+                                {% set ns.tot_ob5 = ns.tot_ob5 + ob5 %}
+                                {% set ns.tot_vardag = ns.tot_vardag + oc_vardag %}
+                                {% set ns.tot_helg = ns.tot_helg + oc_helg %}
+                                {% set ns.tot_helgdag = ns.tot_helgdag + oc_helgdag %}
+                                {% set ns.tot_storhelg = ns.tot_storhelg + oc_storhelg %}
+                                {% set ns.tot_ot = ns.tot_ot + ot %}
+
+                                {# Shift start/end times #}
+                                {% if d.start and d.end %}
+                                    {% set t_start = d.start | time_format %}
+                                    {% set t_end = d.end | time_format %}
+                                {% elif d.shift and d.shift.start_time %}
+                                    {% set t_start = d.shift.start_time %}
+                                    {% set t_end = d.shift.end_time %}
+                                {% else %}
+                                    {% set t_start = '' %}
+                                    {% set t_end = '' %}
+                                {% endif %}
+                                {# For extensions: show actual end time from OT data #}
+                                {% if d.ot_details and d.ot_details.get('is_extension') %}
+                                    {% set t_end = d.ot_details.end_time[:5] %}
+                                {% endif %}
+
+                                {% set has_oncall = (oc_vardag + oc_helg + oc_helgdag + oc_storhelg) > 0 %}
+                                {% set has_ot = ot > 0 %}
+
+                                {# ── Per-shift mode (default) ── #}
+                                {% if has_oncall and has_ot %}
+                                    {# Split into two rows: on-call and overtime separately #}
+                                    <tr class="ob-row-shift">
+                                        <td class="td_left num">{{ d.date }}</td>
+                                        <td class="td_left">{{ d.weekday_name }}</td>
+                                        <td class="td_left">Beredskap</td>
+                                        <td class="td_right num"></td>
+                                        <td class="td_right num"></td>
+                                        <td class="td_right num"></td>
+                                        <td class="td_right num"></td>
+                                        <td class="td_right num"></td>
+                                        <td class="td_right num"></td>
+                                        <td class="td_right num"></td>
+                                        <td class="td_right num"></td>
+                                        <td class="td_right num">{% if oc_vardag %}{{ "%.1f"|format(oc_vardag) }}{% endif %}</td>
+                                        <td class="td_right num">{% if oc_helg %}{{ "%.1f"|format(oc_helg) }}{% endif %}</td>
+                                        <td class="td_right num">{% if oc_helgdag %}{{ "%.1f"|format(oc_helgdag) }}{% endif %}</td>
+                                        <td class="td_right num">{% if oc_storhelg %}{{ "%.1f"|format(oc_storhelg) }}{% endif %}</td>
+                                        <td class="td_right num"></td>
+                                    </tr>
+                                    <tr class="ob-row-shift">
+                                        <td class="td_left num">{{ d.date }}</td>
+                                        <td class="td_left">{{ d.weekday_name }}</td>
+                                        <td class="td_left">{{ shift_label }}</td>
+                                        <td class="td_right num">{{ t_start }}</td>
+                                        <td class="td_right num">{{ t_end }}</td>
+                                        <td class="td_right num">{% if norm %}{{ "%.1f"|format(norm) }}{% endif %}</td>
+                                        <td class="td_right num">{% if ob1 %}{{ "%.1f"|format(ob1) }}{% endif %}</td>
+                                        <td class="td_right num">{% if ob2 %}{{ "%.1f"|format(ob2) }}{% endif %}</td>
+                                        <td class="td_right num">{% if ob3 %}{{ "%.1f"|format(ob3) }}{% endif %}</td>
+                                        <td class="td_right num">{% if ob4 %}{{ "%.1f"|format(ob4) }}{% endif %}</td>
+                                        <td class="td_right num">{% if ob5 %}{{ "%.1f"|format(ob5) }}{% endif %}</td>
+                                        <td class="td_right num"></td>
+                                        <td class="td_right num"></td>
+                                        <td class="td_right num"></td>
+                                        <td class="td_right num"></td>
+                                        <td class="td_right num">{{ "%.1f"|format(ot) }}</td>
+                                    </tr>
+                                {% else %}
+                                    <tr class="ob-row-shift">
+                                        <td class="td_left num">{{ d.date }}</td>
+                                        <td class="td_left">{{ d.weekday_name }}</td>
+                                        <td class="td_left">{{ shift_label }}</td>
+                                        <td class="td_right num">{{ t_start }}</td>
+                                        <td class="td_right num">{{ t_end }}</td>
+                                        <td class="td_right num">{% if norm %}{{ "%.1f"|format(norm) }}{% endif %}</td>
+                                        <td class="td_right num">{% if ob1 %}{{ "%.1f"|format(ob1) }}{% endif %}</td>
+                                        <td class="td_right num">{% if ob2 %}{{ "%.1f"|format(ob2) }}{% endif %}</td>
+                                        <td class="td_right num">{% if ob3 %}{{ "%.1f"|format(ob3) }}{% endif %}</td>
+                                        <td class="td_right num">{% if ob4 %}{{ "%.1f"|format(ob4) }}{% endif %}</td>
+                                        <td class="td_right num">{% if ob5 %}{{ "%.1f"|format(ob5) }}{% endif %}</td>
+                                        <td class="td_right num">{% if oc_vardag %}{{ "%.1f"|format(oc_vardag) }}{% endif %}</td>
+                                        <td class="td_right num">{% if oc_helg %}{{ "%.1f"|format(oc_helg) }}{% endif %}</td>
+                                        <td class="td_right num">{% if oc_helgdag %}{{ "%.1f"|format(oc_helgdag) }}{% endif %}</td>
+                                        <td class="td_right num">{% if oc_storhelg %}{{ "%.1f"|format(oc_storhelg) }}{% endif %}</td>
+                                        <td class="td_right num">{% if ot %}{{ "%.1f"|format(ot) }}{% endif %}</td>
+                                    </tr>
+                                {% endif %}
                             {% endif %}
-                            {# För förlängningar: visa faktisk sluttid från OT-data #}
-                            {% if d.ot_details and d.ot_details.get('is_extension') %}
-                                {% set t_end = d.ot_details.end_time[:5] %}
-                            {% endif %}
 
-                            {% set has_oncall = (oc_vardag + oc_helg + oc_helgdag + oc_storhelg) > 0 %}
-                            {% set has_ot = ot > 0 %}
-
-                            {% if has_oncall and has_ot %}
-                                {# Dela upp i två rader: beredskap och övertid var för sig #}
-                                <tr>
-                                    <td class="td_left num">{{ d.date }}</td>
-                                    <td class="td_left">{{ d.weekday_name }}</td>
-                                    <td class="td_left">Beredskap</td>
-                                    <td class="td_right num"></td>
-                                    <td class="td_right num"></td>
-                                    <td class="td_right num"></td>
-                                    <td class="td_right num"></td>
-                                    <td class="td_right num"></td>
-                                    <td class="td_right num"></td>
-                                    <td class="td_right num"></td>
-                                    <td class="td_right num"></td>
-                                    <td class="td_right num">{% if oc_vardag %}{{ "%.1f"|format(oc_vardag) }}{% endif %}</td>
-                                    <td class="td_right num">{% if oc_helg %}{{ "%.1f"|format(oc_helg) }}{% endif %}</td>
-                                    <td class="td_right num">{% if oc_helgdag %}{{ "%.1f"|format(oc_helgdag) }}{% endif %}</td>
-                                    <td class="td_right num">{% if oc_storhelg %}{{ "%.1f"|format(oc_storhelg) }}{% endif %}</td>
-                                    <td class="td_right num"></td>
-                                </tr>
-                                <tr>
-                                    <td class="td_left num">{{ d.date }}</td>
-                                    <td class="td_left">{{ d.weekday_name }}</td>
-                                    <td class="td_left">{{ shift_label }}</td>
-                                    <td class="td_right num">{{ t_start }}</td>
-                                    <td class="td_right num">{{ t_end }}</td>
-                                    <td class="td_right num">{% if norm %}{{ "%.1f"|format(norm) }}{% endif %}</td>
-                                    <td class="td_right num">{% if ob1 %}{{ "%.1f"|format(ob1) }}{% endif %}</td>
-                                    <td class="td_right num">{% if ob2 %}{{ "%.1f"|format(ob2) }}{% endif %}</td>
-                                    <td class="td_right num">{% if ob3 %}{{ "%.1f"|format(ob3) }}{% endif %}</td>
-                                    <td class="td_right num">{% if ob4 %}{{ "%.1f"|format(ob4) }}{% endif %}</td>
-                                    <td class="td_right num">{% if ob5 %}{{ "%.1f"|format(ob5) }}{% endif %}</td>
-                                    <td class="td_right num"></td>
-                                    <td class="td_right num"></td>
-                                    <td class="td_right num"></td>
-                                    <td class="td_right num"></td>
-                                    <td class="td_right num">{{ "%.1f"|format(ot) }}</td>
-                                </tr>
-                            {% else %}
-                                <tr>
-                                    <td class="td_left num">{{ d.date }}</td>
-                                    <td class="td_left">{{ d.weekday_name }}</td>
-                                    <td class="td_left">{{ shift_label }}</td>
-                                    <td class="td_right num">{{ t_start }}</td>
-                                    <td class="td_right num">{{ t_end }}</td>
-                                    <td class="td_right num">{% if norm %}{{ "%.1f"|format(norm) }}{% endif %}</td>
-                                    <td class="td_right num">{% if ob1 %}{{ "%.1f"|format(ob1) }}{% endif %}</td>
-                                    <td class="td_right num">{% if ob2 %}{{ "%.1f"|format(ob2) }}{% endif %}</td>
-                                    <td class="td_right num">{% if ob3 %}{{ "%.1f"|format(ob3) }}{% endif %}</td>
-                                    <td class="td_right num">{% if ob4 %}{{ "%.1f"|format(ob4) }}{% endif %}</td>
-                                    <td class="td_right num">{% if ob5 %}{{ "%.1f"|format(ob5) }}{% endif %}</td>
-                                    <td class="td_right num">{% if oc_vardag %}{{ "%.1f"|format(oc_vardag) }}{% endif %}</td>
-                                    <td class="td_right num">{% if oc_helg %}{{ "%.1f"|format(oc_helg) }}{% endif %}</td>
-                                    <td class="td_right num">{% if oc_helgdag %}{{ "%.1f"|format(oc_helgdag) }}{% endif %}</td>
-                                    <td class="td_right num">{% if oc_storhelg %}{{ "%.1f"|format(oc_storhelg) }}{% endif %}</td>
-                                    <td class="td_right num">{% if ot %}{{ "%.1f"|format(ot) }}{% endif %}</td>
-                                </tr>
+                            {# ── Per-calendar-day mode ── #}
+                            {# One row per calendar day with OB and OT aggregated from all
+                               shifts touching that day. Night shifts and overtime crossing
+                               midnight contribute to both their start day and the next. #}
+                            {% if cd_row_total > 0 %}
+                            <tr class="ob-row-day">
+                                <td class="td_left num">{{ d.date }}</td>
+                                <td class="td_left">{{ d.weekday_name }}</td>
+                                <td class="td_left">{{ shift_label }}</td>
+                                <td class="td_right num"></td>
+                                <td class="td_right num"></td>
+                                <td class="td_right num"></td>
+                                <td class="td_right num">{% if cd_ob1 %}{{ "%.1f"|format(cd_ob1) }}{% endif %}</td>
+                                <td class="td_right num">{% if cd_ob2 %}{{ "%.1f"|format(cd_ob2) }}{% endif %}</td>
+                                <td class="td_right num">{% if cd_ob3 %}{{ "%.1f"|format(cd_ob3) }}{% endif %}</td>
+                                <td class="td_right num">{% if cd_ob4 %}{{ "%.1f"|format(cd_ob4) }}{% endif %}</td>
+                                <td class="td_right num">{% if cd_ob5 %}{{ "%.1f"|format(cd_ob5) }}{% endif %}</td>
+                                <td class="td_right num">{% if oc_vardag %}{{ "%.1f"|format(oc_vardag) }}{% endif %}</td>
+                                <td class="td_right num">{% if oc_helg %}{{ "%.1f"|format(oc_helg) }}{% endif %}</td>
+                                <td class="td_right num">{% if oc_helgdag %}{{ "%.1f"|format(oc_helgdag) }}{% endif %}</td>
+                                <td class="td_right num">{% if oc_storhelg %}{{ "%.1f"|format(oc_storhelg) }}{% endif %}</td>
+                                <td class="td_right num">{% if cd_ot %}{{ "%.1f"|format(cd_ot) }}{% endif %}</td>
+                            </tr>
                             {% endif %}
                         {% endif %}
                     {% endfor %}
@@ -604,6 +651,13 @@
     </div>
     {% endif %}
 
+    <style>
+    /* Per-shift mode (default): show shift rows, hide day rows */
+    #breakdown-section.ob-by-shift .ob-row-day  { display: none; }
+    /* Per-calendar-day mode: show day rows, hide shift rows */
+    #breakdown-section.ob-by-day   .ob-row-shift { display: none; }
+    </style>
+
     <script>
     function toggleBreakdown() {
         var section = document.getElementById('breakdown-section');
@@ -617,6 +671,20 @@
             section.style.display = 'none';
             btn.textContent = '{{ t.month_show_breakdown }}';
             history.replaceState(null, '', window.location.pathname + window.location.search);
+        }
+    }
+
+    function toggleObDayMode() {
+        var section = document.getElementById('breakdown-section');
+        var btn = document.getElementById('ob-day-toggle');
+        if (section.classList.contains('ob-by-shift')) {
+            section.classList.remove('ob-by-shift');
+            section.classList.add('ob-by-day');
+            btn.textContent = 'Visa OB per pass';
+        } else {
+            section.classList.remove('ob-by-day');
+            section.classList.add('ob-by-shift');
+            btn.textContent = 'Visa OB per kalenderdag';
         }
     }
 


### PR DESCRIPTION
## Summary

Adds a toggle button in the detailed breakdown on the My Month page that switches between two display modes for OB and OT hours:

- **Per shift (default):** all OB/OT for a shift is shown on the shift start day (existing behavior)
- **Per calendar day:** OB and OT hours are distributed across the actual calendar days they fall on

### Example

A night shift Sat 23/5 22:00 -- Sun 24/5 06:30 (8.5h OB5):

| Mode | Sat 23/5 | Sun 24/5 |
|------|----------|----------|
| Per shift | 8.5h | -- |
| Per calendar day | 2.0h | 6.5h |

Consecutive night shifts are handled correctly: if the person also works Sun 24/5 22:00 -- Mon 25/5 06:30, Sunday shows 6.5h + 2.0h = 8.5h on a single row.

## Changes

### `app/core/schedule/ob.py`
- New `calculate_ob_hours_by_day()`: same logic as `calculate_ob_hours` but returns `dict[date, dict[str, float]]` instead of a flat total per code.

### `app/core/schedule/summary.py`
- `_process_day_for_summary`: compute `ob_hours_by_day` and `ot_hours_by_day`, splitting at midnight for shifts crossing calendar day boundaries.
- Post-processing step after the day loop: aggregate `ob_hours_by_day` and `ot_hours_by_day` across all days into `calendar_day_ob` / `calendar_day_ot`, then attach `ob_hours_calendar_day` and `ot_hours_calendar_day` to each day.

### `app/templates/month.html`
- Toggle button "Visa OB per kalenderdag" / "Visa OB per pass" inside the breakdown section header.
- Each day renders two sets of rows: `ob-row-shift` (existing) and `ob-row-day` (new).
- CSS classes `ob-by-shift` / `ob-by-day` on the section parent control visibility -- no server round-trip.

### `app/routes/changelog.py`
- Version 0.22.0.

## Notes
- Display only. Wage calculations, totals and tfoot are completely unchanged.
- OT midnight-crossing uses the same end<=start logic as `parse_ot_times()` in time_utils.py.
- 77/77 tests pass.