### PR TITLE
Add late arrival support for partial-day absence (v0.23.0)

### DIFF
--- a/add_arrived_at_column.py
+++ b/add_arrived_at_column.py
@@ -1,0 +1,21 @@
+"""Migration: add arrived_at column to absences table."""
+
+import sqlite3
+import sys
+
+DB_PATH = sys.argv[1] if len(sys.argv) > 1 else "app/database/schedule.db"
+
+conn = sqlite3.connect(DB_PATH)
+cur = conn.cursor()
+
+cur.execute("PRAGMA table_info(absences)")
+columns = [row[1] for row in cur.fetchall()]
+
+if "arrived_at" not in columns:
+    cur.execute("ALTER TABLE absences ADD COLUMN arrived_at VARCHAR(5)")
+    conn.commit()
+    print("Added arrived_at column.")
+else:
+    print("Column already exists, skipping.")
+
+conn.close()

--- a/app/core/schedule/period.py
+++ b/app/core/schedule/period.py
@@ -674,17 +674,25 @@ def _build_person_day_basic(
     if absence:
         from app.database.database import AbsenceType
 
-        # Partiell frånvaro: visa originalskiftet men med trunkerad sluttid
-        if absence.left_at is not None and absence.absence_type != AbsenceType.VACATION:
+        # Partial absence: show original shift with truncated start/end
+        if (
+            absence.left_at is not None or absence.arrived_at is not None
+        ) and absence.absence_type != AbsenceType.VACATION:
             result = determine_shift_for_date(date, person_id)
             if result and result[0]:
                 original_shift, rotation_week = result
                 hours, start, end = calculate_shift_hours(date, original_shift.code)
-                if start is not None and absence.left_at:
-                    left_time = datetime.datetime.strptime(absence.left_at, "%H:%M").time()
-                    end = datetime.datetime.combine(date, left_time)
-                    if end <= start:
-                        end = start  # säkerhetsventil
+                if start is not None:
+                    if absence.left_at:
+                        left_time = datetime.datetime.strptime(absence.left_at, "%H:%M").time()
+                        end = datetime.datetime.combine(date, left_time)
+                        if end <= start:
+                            end = start
+                    if absence.arrived_at:
+                        arrived_time = datetime.datetime.strptime(absence.arrived_at, "%H:%M").time()
+                        start = datetime.datetime.combine(date, arrived_time)
+                        if start >= end:
+                            start = end
                     hours = (end - start).total_seconds() / 3600.0
                 return {
                     "person_id": person_id,
@@ -984,17 +992,25 @@ def _populate_single_person_day(
     if absence:
         from app.database.database import AbsenceType
 
-        # Partiell frånvaro: beräkna OB och timmar för jobbad del av passet
-        if absence.left_at is not None and absence.absence_type != AbsenceType.VACATION:
+        # Partial absence: calculate OB and hours for the worked portion of the shift
+        if (
+            absence.left_at is not None or absence.arrived_at is not None
+        ) and absence.absence_type != AbsenceType.VACATION:
             result = determine_shift_for_date(current_day, person_id)
             if result and result[0]:
                 original_shift, rotation_week = result
                 hours, start, end = calculate_shift_hours(current_day, original_shift.code)
-                if start is not None and absence.left_at:
-                    left_time = datetime.datetime.strptime(absence.left_at, "%H:%M").time()
-                    end = datetime.datetime.combine(current_day, left_time)
-                    if end <= start:
-                        end = start
+                if start is not None:
+                    if absence.left_at:
+                        left_time = datetime.datetime.strptime(absence.left_at, "%H:%M").time()
+                        end = datetime.datetime.combine(current_day, left_time)
+                        if end <= start:
+                            end = start
+                    if absence.arrived_at:
+                        arrived_time = datetime.datetime.strptime(absence.arrived_at, "%H:%M").time()
+                        start = datetime.datetime.combine(current_day, arrived_time)
+                        if start >= end:
+                            start = end
                     hours = (end - start).total_seconds() / 3600.0
                     ob = calculate_ob_hours(start, end, combined_ob_rules) if original_shift.code != "OC" else {}
                 else:

--- a/app/core/schedule/summary.py
+++ b/app/core/schedule/summary.py
@@ -573,6 +573,7 @@ def _process_day_for_summary(
         "ot_details": day.get("ot_details", {}),
         "start": start,
         "end": end,
+        "partial_absence": day.get("partial_absence"),
     }
 
 

--- a/app/core/schedule/wages.py
+++ b/app/core/schedule/wages.py
@@ -280,9 +280,8 @@ def get_karens_consumed_before_date(session, user_id: int, sick_date: "date") ->
         if consumed >= KARENS_HOURS:
             break
         # Hämta frånvarotimmar för denna dag
-        _, _, shift_end_dt = get_shift_times_for_date(session, user_id, absence.date)
-        shift_h = get_shift_hours_for_date(session, user_id, absence.date)
-        absent_h = get_absent_hours_from_left_at(absence.left_at, shift_end_dt, shift_h)
+        shift_h, shift_start_dt, shift_end_dt = get_shift_times_for_date(session, user_id, absence.date)
+        absent_h = get_absent_hours_for_absence(absence, shift_start_dt, shift_end_dt, shift_h)
         karens_this_day = min(absent_h, KARENS_HOURS - consumed)
         consumed += karens_this_day
 
@@ -346,6 +345,47 @@ def get_absent_hours_from_left_at(left_at: str, shift_end_dt: datetime.datetime 
         return max(0.0, absent)
     except ValueError:
         return shift_hours
+
+
+def get_absent_hours_for_absence(
+    absence,
+    shift_start_dt: datetime.datetime | None,
+    shift_end_dt: datetime.datetime | None,
+    shift_hours: float,
+) -> float:
+    """
+    Calculates total absent hours for an absence record, handling left_at, arrived_at, or both.
+    Falls back to shift_hours for full-day absence or when shift times are unavailable.
+    """
+    left_at = getattr(absence, "left_at", None)
+    arrived_at = getattr(absence, "arrived_at", None)
+
+    if not left_at and not arrived_at:
+        return shift_hours
+
+    total = 0.0
+
+    # Hours missed at end of shift (left early)
+    if left_at and shift_end_dt is not None:
+        try:
+            left_time = datetime.datetime.strptime(left_at, "%H:%M").time()
+            left_dt = datetime.datetime.combine(shift_end_dt.date(), left_time)
+            if left_dt < shift_end_dt:
+                total += (shift_end_dt - left_dt).total_seconds() / 3600.0
+        except ValueError:
+            total += shift_hours
+
+    # Hours missed at start of shift (arrived late)
+    if arrived_at and shift_start_dt is not None:
+        try:
+            arrived_time = datetime.datetime.strptime(arrived_at, "%H:%M").time()
+            arrived_dt = datetime.datetime.combine(shift_start_dt.date(), arrived_time)
+            if arrived_dt > shift_start_dt:
+                total += (arrived_dt - shift_start_dt).total_seconds() / 3600.0
+        except ValueError:
+            total += shift_hours
+
+    return max(0.0, min(total, shift_hours))
 
 
 def get_absence_deductions_for_month(
@@ -434,8 +474,8 @@ def get_absence_deductions_for_month(
 
     for absence in absences:
         # Hämta antal timmar för det skift som skulle ha jobbats
-        shift_hours, start_dt, shift_end_dt = get_shift_times_for_date(session, user_id, absence.date)
-        absent_hours = get_absent_hours_from_left_at(absence.left_at, shift_end_dt, shift_hours)
+        shift_hours, shift_start_dt, shift_end_dt = get_shift_times_for_date(session, user_id, absence.date)
+        absent_hours = get_absent_hours_for_absence(absence, shift_start_dt, shift_end_dt, shift_hours)
         total_hours += absent_hours
 
         if absence.absence_type == AbsenceType.SICK:
@@ -462,7 +502,7 @@ def get_absence_deductions_for_month(
 
             # OB på frånvarodagen: beräkna alltid för att kunna visa totalt tapp
             sjuklon_hours = absent_hours - karens_today
-            if ob_rules and start_dt is not None and shift_end_dt is not None and shift_hours > 0:
+            if ob_rules and shift_start_dt is not None and shift_end_dt is not None and shift_hours > 0:
                 from app.core.schedule.ob import calculate_ob_pay
 
                 _ob_overrides = ob_rate_overrides
@@ -478,9 +518,9 @@ def get_absence_deductions_for_month(
                 from app.core.schedule.ob import calculate_ob_hours as _calc_ob_hours
 
                 full_ob_by_code = calculate_ob_pay(
-                    start_dt, shift_end_dt, ob_rules, monthly_wage, rate_overrides=_ob_overrides
+                    shift_start_dt, shift_end_dt, ob_rules, monthly_wage, rate_overrides=_ob_overrides
                 )
-                full_ob_hours_by_code = _calc_ob_hours(start_dt, shift_end_dt, ob_rules)
+                full_ob_hours_by_code = _calc_ob_hours(shift_start_dt, shift_end_dt, ob_rules)
                 full_ob_total = sum(full_ob_by_code.values())
                 sick_total_ob += full_ob_total * (absent_hours / shift_hours)
 

--- a/app/database/database.py
+++ b/app/database/database.py
@@ -177,7 +177,8 @@ class Absence(Base):
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     date = Column(Date, nullable=False)
     absence_type = Column(SQLEnum(AbsenceType), nullable=False)
-    left_at = Column(String(5), nullable=True)  # "HH:MM" - klockslag när de slutade jobba (None = heldag)
+    left_at = Column(String(5), nullable=True)  # "HH:MM" - time they left early (None = full day or on time)
+    arrived_at = Column(String(5), nullable=True)  # "HH:MM" - time they arrived late (None = full day or on time)
     created_at = Column(DateTime, default=datetime.utcnow)
 
     # Relationships
@@ -185,12 +186,12 @@ class Absence(Base):
 
     @property
     def is_partial_day(self) -> bool:
-        return self.left_at is not None
+        return self.left_at is not None or self.arrived_at is not None
 
     def __repr__(self):
         return (
             f"<Absence(id={self.id}, user_id={self.user_id}, date={self.date}, "
-            f"type={self.absence_type}, left_at={self.left_at})>"
+            f"type={self.absence_type}, left_at={self.left_at}, arrived_at={self.arrived_at})>"
         )
 
 

--- a/app/routes/api_v1.py
+++ b/app/routes/api_v1.py
@@ -159,6 +159,7 @@ def _build_day_status(
             "rotation_week": rotation_week,
             "overtime": None,
             "partial_day": absence.left_at,
+            "arrived_late": absence.arrived_at,
         }
         if include_salary:
             result["ob_pay"] = None
@@ -583,6 +584,7 @@ async def get_user_absences(
             "date": a.date.isoformat(),
             "type": a.absence_type.value,
             "partial_day": a.left_at,
+            "arrived_late": a.arrived_at,
         }
         for a in rows
     ]

--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -15,6 +15,22 @@ router = APIRouter()
 
 VERSIONS = [
     {
+        "version": "0.23.0",
+        "date": "2026-05-28",
+        "entries": [
+            {
+                "type": "ny funktion",
+                "sv": "Frånvaro: stöd för sen ankomst – man kan nu registrera klockslag för när man kom till jobbet ('Kom HH:MM') på samma sätt som man redan kunde registrera tidig avgång; frånvarotimmar, OB och löneunderlag räknas om korrekt för den jobbade delen av passet",
+                "en": "Absence: support for late arrival – it is now possible to register the time of arrival ('Kom HH:MM') the same way early departure was already supported; absent hours, OB and salary base are recalculated correctly for the worked portion of the shift",
+            },
+            {
+                "type": "förbättring",
+                "sv": "Excel-export (min månad): ny kolumn 'Kommentar' som visar 'Sen ankomst HH:MM' och/eller 'Slutade tidigt HH:MM' för dagar med partiell frånvaro; kolumnen utelämnas automatiskt om inga sådana dagar finns i månaden",
+                "en": "Excel export (my month): new 'Kommentar' column showing 'Sen ankomst HH:MM' and/or 'Slutade tidigt HH:MM' for days with partial absence; the column is omitted automatically if no such days exist in the month",
+            },
+        ],
+    },
+    {
         "version": "0.22.0",
         "date": "2026-05-27",
         "entries": [

--- a/app/routes/dashboard.py
+++ b/app/routes/dashboard.py
@@ -33,7 +33,7 @@ from app.core.schedule import (
 from app.core.schedule.wages import (
     KARENS_HOURS,
     calculate_absence_deduction,
-    get_absent_hours_from_left_at,
+    get_absent_hours_for_absence,
     get_karens_consumed_before_date,
     get_shift_times_for_date,
 )
@@ -56,8 +56,8 @@ def _query_absence_and_deduction(
     absence = db.query(Absence).filter(Absence.user_id == user_id, Absence.date == check_date).first()
     deduction = 0.0
     if absence and show_salary:
-        shift_hours, _, shift_end_dt = get_shift_times_for_date(db, user_id, check_date)
-        absent_hours = get_absent_hours_from_left_at(absence.left_at, shift_end_dt, shift_hours)
+        shift_hours, shift_start_dt, shift_end_dt = get_shift_times_for_date(db, user_id, check_date)
+        absent_hours = get_absent_hours_for_absence(absence, shift_start_dt, shift_end_dt, shift_hours)
         if absence.absence_type.value == "SICK":
             karens_consumed = get_karens_consumed_before_date(db, user_id, check_date)
             karens_remaining = max(0.0, KARENS_HOURS - karens_consumed)

--- a/app/routes/profile.py
+++ b/app/routes/profile.py
@@ -639,10 +639,12 @@ async def add_absence(
     date_str: str = Form(..., alias="date"),
     absence_type: str = Form(...),
     left_at: str = Form(default=""),
+    arrived_at: str = Form(default=""),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
     """Add absence for the current user."""
+    import re
     from datetime import datetime
 
     if current_user.role != UserRole.ADMIN and user_id != current_user.id:
@@ -658,15 +660,16 @@ async def add_absence(
     except ValueError:
         raise HTTPException(status_code=400, detail=f"Ogiltig frånvarotyp: {absence_type}") from None
 
-    # Validera left_at-format HH:MM (valfritt, tomt = heldag)
-    parsed_left_at: str | None = None
-    stripped = left_at.strip()
-    if stripped:
-        import re
-
+    def _parse_time(value: str, field: str) -> str | None:
+        stripped = value.strip()
+        if not stripped:
+            return None
         if not re.match(r"^\d{2}:\d{2}$", stripped):
-            raise HTTPException(status_code=400, detail="Ogiltigt klockslags-format, använd HH:MM") from None
-        parsed_left_at = stripped
+            raise HTTPException(status_code=400, detail=f"Ogiltigt klockslags-format för {field}, använd HH:MM")
+        return stripped
+
+    parsed_left_at = _parse_time(left_at, "left_at")
+    parsed_arrived_at = _parse_time(arrived_at, "arrived_at")
 
     if current_user.role == UserRole.ADMIN:
         target_user_id = user_id
@@ -678,6 +681,7 @@ async def add_absence(
     if existing:
         existing.absence_type = absence_type_enum
         existing.left_at = parsed_left_at
+        existing.arrived_at = parsed_arrived_at
         db.commit()
     else:
         new_absence = Absence(
@@ -685,6 +689,7 @@ async def add_absence(
             date=absence_date,
             absence_type=absence_type_enum,
             left_at=parsed_left_at,
+            arrived_at=parsed_arrived_at,
         )
         db.add(new_absence)
         db.commit()

--- a/app/routes/schedule_personal.py
+++ b/app/routes/schedule_personal.py
@@ -243,8 +243,8 @@ async def show_day_for_person(
     # Absences are stored per user_id
     absence = db.query(Absence).filter(Absence.user_id == user_id_for_wages, Absence.date == date_obj).first()
 
-    # Partiell frånvaro: trunkera end_dt till left_at och räkna om OB
-    original_end_dt = end_dt  # Spara originalslut innan ev. trunkering
+    # Partial absence: truncate shift end/start and recalculate OB
+    original_end_dt = end_dt
     if absence and absence.left_at and start_dt is not None and end_dt is not None:
         left_time = datetime.strptime(absence.left_at, "%H:%M").time()
         truncated_end = datetime.combine(date_obj, left_time)
@@ -257,11 +257,24 @@ async def show_day_for_person(
                     start_dt, end_dt, combined_rules, monthly_salary, rate_overrides=_user_rates["ob"]
                 )
 
-    # Heldags-sjukfrånvaro: nollställ OB (ingen ordinarie OB utgår vid sjukdom)
+    if absence and absence.arrived_at and start_dt is not None and end_dt is not None:
+        arrived_time = datetime.strptime(absence.arrived_at, "%H:%M").time()
+        truncated_start = datetime.combine(date_obj, arrived_time)
+        if truncated_start < end_dt:
+            start_dt = truncated_start
+            hours = (end_dt - start_dt).total_seconds() / 3600.0
+            if not is_full_ot and not is_effective_oc:
+                ob_hours = calculate_ob_hours(start_dt, end_dt, combined_rules)
+                ob_pay = calculate_ob_pay(
+                    start_dt, end_dt, combined_rules, monthly_salary, rate_overrides=_user_rates["ob"]
+                )
+
+    # Full-day sick absence: zero out OB
     if (
         absence
         and absence.absence_type.value == "SICK"
         and absence.left_at is None
+        and absence.arrived_at is None
         and not is_full_ot
         and not is_effective_oc
     ):
@@ -328,14 +341,14 @@ async def show_day_for_person(
         from app.core.schedule.wages import (
             KARENS_HOURS,
             calculate_absence_deduction,
-            get_absent_hours_from_left_at,
+            get_absent_hours_for_absence,
             get_karens_consumed_before_date,
             get_shift_times_for_date,
         )
 
         # Get shift hours and times for the day
-        full_shift_hours, _, shift_end_dt = get_shift_times_for_date(db, rotation_position, date_obj)
-        absent_hours = get_absent_hours_from_left_at(absence.left_at, shift_end_dt, full_shift_hours)
+        full_shift_hours, shift_start_dt, shift_end_dt = get_shift_times_for_date(db, rotation_position, date_obj)
+        absent_hours = get_absent_hours_for_absence(absence, shift_start_dt, shift_end_dt, full_shift_hours)
         # absence_shift_hours visas i templaten
         absence_shift_hours = absent_hours
 
@@ -1003,6 +1016,7 @@ async def export_month_excel(
         "Beredskap Helgdag(112)",
         "Beredskap Storhelg(192)",
         "Övertid(x2)",
+        "Kommentar",
     ]
     # Indices for numeric columns (0-based, from COL_HEADERS)
     NUM_START = 5  # "Vanliga timmar" is col index 5
@@ -1036,6 +1050,16 @@ async def export_month_excel(
             shift_label = "Ledig"
         else:
             shift_label = shift.label if hasattr(shift, "label") and shift.label else shift.code
+
+        # Build comment from partial absence (arrived late / left early)
+        partial_absence = d.get("partial_absence") if d else None
+        comment_parts = []
+        if partial_absence:
+            if partial_absence.arrived_at:
+                comment_parts.append(f"Sen ankomst {partial_absence.arrived_at}")
+            if partial_absence.left_at:
+                comment_parts.append(f"Slutade tidigt {partial_absence.left_at}")
+        comment = ", ".join(comment_parts)
 
         if d and shift and shift.code not in ("OFF",):
             # Times
@@ -1076,13 +1100,13 @@ async def export_month_excel(
             oc_storhelg = oc_bd.get("OC_SPECIAL", {}).get("hours", 0) or 0
             ot = d.get("ot_hours", 0) or 0
 
-            num_vals = [norm, ob1, ob2, ob3, ob5, oc_vardag, oc_helg, oc_helgdag, oc_storhelg, ot]
+            num_vals = [norm, ob1, ob2, ob3, ob5, oc_vardag, oc_helg, oc_helgdag, oc_storhelg, ot, comment]
 
             oc_total = oc_vardag + oc_helg + oc_helgdag + oc_storhelg
             if oc_total > 0 and ot > 0:
                 # Dela upp i en beredskapsrad och en övertidsrad
-                oc_vals = [0, 0, 0, 0, 0, oc_vardag, oc_helg, oc_helgdag, oc_storhelg, 0]
-                ot_vals = [norm, ob1, ob2, ob3, ob5, 0, 0, 0, 0, ot]
+                oc_vals = [0, 0, 0, 0, 0, oc_vardag, oc_helg, oc_helgdag, oc_storhelg, 0, ""]
+                ot_vals = [norm, ob1, ob2, ob3, ob5, 0, 0, 0, 0, ot, comment]
                 rows.append([str(day_date), _SV_DAYS[day_date.weekday()], "Beredskap", "", ""] + oc_vals)
                 rows.append([str(day_date), _SV_DAYS[day_date.weekday()], shift_label, start_str, end_t_str] + ot_vals)
             else:
@@ -1090,10 +1114,10 @@ async def export_month_excel(
         else:
             start_str = ""
             end_t_str = ""
-            num_vals = [0.0] * 10
+            num_vals = [0.0] * 10 + [comment]
             rows.append([str(day_date), _SV_DAYS[day_date.weekday()], shift_label, start_str, end_t_str] + num_vals)
 
-        for i, v in enumerate(num_vals):
+        for i, v in enumerate(num_vals[:-1]):  # exclude comment column
             totals[NUM_START + i] = totals[NUM_START + i] + v
 
     # ── Determine which numeric columns have any data ───────────────────
@@ -1161,6 +1185,7 @@ async def export_month_excel(
         "Skifttyp": 14,
         "Start": 7,
         "Slut": 7,
+        "Kommentar": 28,
     }
     default_num_width = 22
     for i, h in enumerate(final_headers, start=1):

--- a/app/templates/day.html
+++ b/app/templates/day.html
@@ -303,6 +303,9 @@
                                     {% else %}
                                         {{ absence.absence_type.value }}
                                     {% endif %}
+                                    {% if absence.arrived_at is not none %}
+                                        <span style="color: var(--text-muted); font-size: 0.9em;">(kom {{ absence.arrived_at }})</span>
+                                    {% endif %}
                                     {% if absence.left_at is not none %}
                                         <span style="color: var(--text-muted); font-size: 0.9em;">(slutade {{ absence.left_at }})</span>
                                     {% endif %}
@@ -321,7 +324,7 @@
                                     {% elif absence.absence_type.value == 'PARENTAL' %}
                                         <span class="badge" style="background: #3b82f6; color: white;">{{ t.day_absence_parental }}</span>
                                     {% endif %}
-                                    {% if absence.left_at is not none %}
+                                    {% if absence.left_at is not none or absence.arrived_at is not none %}
                                         <span class="badge" style="background: #0ea5e9; color: white;">Deldag</span>
                                     {% endif %}
                                 </td>
@@ -347,24 +350,25 @@
                         <tbody>
                             <tr>
                                 <td>
+                                    {% set is_partial = absence.left_at is not none or absence.arrived_at is not none %}
                                     {% if absence.absence_type.value == 'SICK' %}
                                         {% if karens_hours_today > 0 and sjuklon_hours_today > 0 %}
                                             {{ "%.1f"|format(karens_hours_today) }} h karens + {{ "%.1f"|format(sjuklon_hours_today) }} h sjuklön
                                         {% elif karens_hours_today > 0 %}
-                                            {% if absence.left_at is not none %}
-                                                {{ "%.1f"|format(karens_hours_today) }} h (karens, slutade {{ absence.left_at }})
+                                            {% if is_partial %}
+                                                {{ "%.1f"|format(karens_hours_today) }} h (karens, deldag)
                                             {% else %}
                                                 8,0 h (karens)
                                             {% endif %}
                                         {% else %}
-                                            {% if absence.left_at is not none %}
-                                                {{ "%.1f"|format(sjuklon_hours_today) }} h (slutade {{ absence.left_at }})
+                                            {% if is_partial %}
+                                                {{ "%.1f"|format(sjuklon_hours_today) }} h (deldag)
                                             {% else %}
                                                 {{ "%.2f"|format(absence_shift_hours) }} h
                                             {% endif %}
                                         {% endif %}
-                                    {% elif absence.left_at is not none %}
-                                        {{ "%.1f"|format(absence_shift_hours) }} h (slutade {{ absence.left_at }})
+                                    {% elif is_partial %}
+                                        {{ "%.1f"|format(absence_shift_hours) }} h (deldag)
                                     {% else %}
                                         {{ "%.2f"|format(absence_shift_hours) }} h
                                     {% endif %}
@@ -422,6 +426,11 @@
                                 <option value="LEAVE">{{ t.day_absence_leave }}</option>
                                 <option value="OFF">{{ t.day_absence_off }}</option>
                             </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="arrived_at">Kom (lämna tomt = i tid)</label>
+                            <input type="time" id="arrived_at" name="arrived_at"
+                                   placeholder="HH:MM">
                         </div>
                         <div class="form-group">
                             <label for="left_at">Slutade (lämna tomt = heldag)</label>


### PR DESCRIPTION
## Summary

- Add `arrived_at` field (HH:MM) to `Absence` model for registering when someone arrived late, mirroring the existing `left_at` (early departure) field
- Absent hours, OB and salary deductions are correctly recalculated for the worked portion of the shift
- Excel monthly export gets a new `Kommentar` column showing `Sen ankomst HH:MM` / `Slutade tidigt HH:MM`; column is omitted automatically if no partial-day rows exist in the month

## Changes

- `database.py`: add `arrived_at` column, update `is_partial_day` property
- `add_arrived_at_column.py`: migration script (already run on prod)
- `wages.py`: new `get_absent_hours_for_absence()` handling all combinations of `arrived_at`, `left_at`, and full-day absence; replace all callers of the old `get_absent_hours_from_left_at()`
- `period.py`: truncate shift start time when `arrived_at` is set (both day view and month view)
- `schedule_personal.py`: recalculate OB when `arrived_at` truncates shift start; fix full-day sick OB zeroing to require both fields being `None`
- `summary.py`: propagate `partial_absence` through `_process_day_for_summary` so Excel export can read the field
- `profile.py`: accept and validate `arrived_at` form field
- `day.html`: add `Kom HH:MM` time input, display arrival time and Deldag badge in absence view
- `api_v1.py`: include `arrived_late` in absence API responses
- `changelog.py`: v0.23.0 entry