### PR TITLE
Enforce mandatory password change on every protected page

### DIFF
--- a/app/auth/auth.py
+++ b/app/auth/auth.py
@@ -33,6 +33,22 @@ if SECRET_KEY == "your-secret-key-change-this-in-production":
             stacklevel=2,
         )
 
+
+class PasswordChangeRequired(Exception):
+    """Raised when an authenticated user must change their password before proceeding.
+
+    Translated into a redirect to /change-password by an exception handler in main.py.
+    Lets the enforcement live in the auth dependencies (centralised, testable) instead
+    of in middleware that bypasses the get_db override.
+    """
+
+
+def _require_password_change(user: "User | None") -> None:
+    """Raise PasswordChangeRequired when the user has a pending mandatory password change."""
+    if user is not None and user.must_change_password == 1:
+        raise PasswordChangeRequired()
+
+
 # Password hashing
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
@@ -121,8 +137,12 @@ async def get_current_user_from_cookie(request: Request, db: Session = Depends(g
     return user
 
 
-async def get_current_user(request: Request, db: Session = Depends(get_db)) -> User:
-    """Get current authenticated user. Raises 401 if not authenticated."""
+async def get_current_user_allow_pwd_change(request: Request, db: Session = Depends(get_db)) -> User:
+    """Get current authenticated user WITHOUT enforcing a pending password change.
+
+    Used by the change-password and logout routes so a user with must_change_password=1
+    can actually reach them instead of being redirected back in a loop.
+    """
     user = await get_current_user_from_cookie(request, db)
     if user is None:
         raise HTTPException(
@@ -133,9 +153,24 @@ async def get_current_user(request: Request, db: Session = Depends(get_db)) -> U
     return user
 
 
+async def get_current_user(request: Request, db: Session = Depends(get_db)) -> User:
+    """Get current authenticated user. Raises 401 if not authenticated.
+
+    Enforces a pending mandatory password change by raising PasswordChangeRequired.
+    """
+    user = await get_current_user_allow_pwd_change(request, db)
+    _require_password_change(user)
+    return user
+
+
 async def get_current_user_optional(request: Request, db: Session = Depends(get_db)) -> User | None:
-    """Get current user if authenticated, None otherwise."""
-    return await get_current_user_from_cookie(request, db)
+    """Get current user if authenticated, None otherwise.
+
+    Still enforces a pending mandatory password change for authenticated users.
+    """
+    user = await get_current_user_from_cookie(request, db)
+    _require_password_change(user)
+    return user
 
 
 async def get_admin_user(current_user: User = Depends(get_current_user)) -> User:

--- a/app/main.py
+++ b/app/main.py
@@ -228,6 +228,22 @@ def _wants_json(request: Request) -> bool:
     return "application/json" in accept and "text/html" not in accept
 
 
+from app.auth.auth import PasswordChangeRequired  # noqa: E402
+
+
+@app.exception_handler(PasswordChangeRequired)
+async def password_change_required_handler(request: Request, exc: PasswordChangeRequired):
+    """Redirect users with a pending mandatory password change to the change form.
+
+    API/JSON clients get 403 instead of an HTML redirect.
+    """
+    from fastapi.responses import RedirectResponse
+
+    if _wants_json(request):
+        return JSONResponse(status_code=403, content={"detail": "Password change required"})
+    return RedirectResponse("/change-password", status_code=302)
+
+
 @app.exception_handler(StarletteHTTPException)
 async def http_exception_handler(request: Request, exc: StarletteHTTPException):
     if _wants_json(request):

--- a/app/routes/auth_routes.py
+++ b/app/routes/auth_routes.py
@@ -13,7 +13,8 @@ from app.auth.auth import (
     authenticate_user,
     clear_auth_cookie,
     create_access_token,
-    get_current_user,
+    get_current_user_allow_pwd_change,
+    get_current_user_from_cookie,
     get_current_user_optional,
     get_password_hash,
     set_auth_cookie,
@@ -103,7 +104,7 @@ async def login(
 
 
 @router.get("/logout", name="logout")
-async def logout(response: Response, current_user: User | None = Depends(get_current_user_optional)):
+async def logout(response: Response, current_user: User | None = Depends(get_current_user_from_cookie)):
     """Log out user."""
     if current_user:
         log_auth_event(
@@ -122,7 +123,7 @@ async def logout(response: Response, current_user: User | None = Depends(get_cur
 @router.get("/change-password", response_class=HTMLResponse, name="change_password_page")
 async def change_password_page(
     request: Request,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user_allow_pwd_change),
 ):
     """Show mandatory password change page for users with must_change_password=1."""
     return render(
@@ -141,7 +142,7 @@ async def change_password_submit(
     current_password: str = Form(...),
     new_password: str = Form(...),
     confirm_password: str = Form(...),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user_allow_pwd_change),
     db: Session = Depends(get_db),
 ):
     """Process mandatory password change."""

--- a/tests/test_password_change_enforcement.py
+++ b/tests/test_password_change_enforcement.py
@@ -1,0 +1,94 @@
+"""Tests for mandatory password-change enforcement (audit item S2).
+
+A user with must_change_password=1 must be redirected to /change-password on every
+protected page, but must still be able to reach the change-password form and log out
+(no redirect loop).
+"""
+
+import pytest
+
+from app.auth.auth import (
+    PasswordChangeRequired,
+    _require_password_change,
+    create_access_token,
+    get_password_hash,
+)
+from app.database.database import User, UserRole
+
+
+class _StubUser:
+    def __init__(self, must_change_password: int):
+        self.must_change_password = must_change_password
+
+
+# --- Unit tests on the core enforcement helper -------------------------------
+
+
+def test_require_password_change_raises_when_pending():
+    with pytest.raises(PasswordChangeRequired):
+        _require_password_change(_StubUser(1))
+
+
+def test_require_password_change_passes_when_not_pending():
+    # Should not raise
+    _require_password_change(_StubUser(0))
+
+
+def test_require_password_change_ignores_anonymous():
+    # No authenticated user -> nothing to enforce
+    _require_password_change(None)
+
+
+# --- Integration tests via the HTTP layer ------------------------------------
+
+
+def _make_user(db, must_change: int) -> User:
+    user = User(
+        username=f"user_mc{must_change}",
+        password_hash=get_password_hash("irrelevant"),
+        name="Test",
+        role=UserRole.USER,
+        wage=30000,
+        vacation={},
+        must_change_password=must_change,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _set_cookie(client, user: User) -> None:
+    token = create_access_token(data={"sub": str(user.id)})
+    client.cookies.set("access_token", f"Bearer {token}")
+
+
+def test_protected_page_redirects_when_pending(test_client, test_db):
+    user = _make_user(test_db, must_change=1)
+    _set_cookie(test_client, user)
+
+    resp = test_client.get("/", follow_redirects=False)
+
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "/change-password"
+
+
+def test_change_password_page_reachable_when_pending(test_client, test_db):
+    """The change-password form itself must not redirect (no loop)."""
+    user = _make_user(test_db, must_change=1)
+    _set_cookie(test_client, user)
+
+    resp = test_client.get("/change-password", follow_redirects=False)
+
+    assert resp.status_code == 200
+
+
+def test_logout_works_when_pending(test_client, test_db):
+    """Logout must succeed for a pending user rather than redirecting to the form."""
+    user = _make_user(test_db, must_change=1)
+    _set_cookie(test_client, user)
+
+    resp = test_client.get("/logout", follow_redirects=False)
+
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "/login"


### PR DESCRIPTION
## Problem

`must_change_password` was only honoured by the post-login redirect. A user with the flag set received a fully valid session cookie and could navigate anywhere in the app, skipping the mandatory password change entirely.

## Fix

Enforce the pending change in the auth dependencies: `get_current_user` and `get_current_user_optional` now raise `PasswordChangeRequired`, which an exception handler in `main.py` turns into a redirect to `/change-password` (or a 403 for JSON/API clients). The change-password and logout routes use a non-enforcing dependency (`get_current_user_allow_pwd_change` / `get_current_user_from_cookie`) to avoid a redirect loop.

Chose dependencies over middleware deliberately: the existing docs-protection middleware calls `SessionLocal()` directly, which bypasses the `get_db` test override and is not unit-testable. Dependencies go through DI and are.

## Tests

New `tests/test_password_change_enforcement.py` (6 cases): unit tests for the enforcement helper (pending / not pending / anonymous) and integration tests for the redirect, change-password reachability, and logout. Confirmed the redirect test fails without enforcement. Full suite green.