### PR TITLE
Add brute-force rate limiting to login

### DIFF
--- a/app/auth/auth.py
+++ b/app/auth/auth.py
@@ -12,7 +12,7 @@ from jose import JWTError, jwt
 from passlib.context import CryptContext
 from sqlalchemy.orm import Session
 
-from app.database.database import User, UserRole, get_db
+from app.database.database import LoginAttempt, User, UserRole, get_db
 
 # Configuration - reads from environment variables for security
 SECRET_KEY = os.getenv("SECRET_KEY", "your-secret-key-change-this-in-production")
@@ -47,6 +47,51 @@ def _require_password_change(user: "User | None") -> None:
     """Raise PasswordChangeRequired when the user has a pending mandatory password change."""
     if user is not None and user.must_change_password == 1:
         raise PasswordChangeRequired()
+
+
+# Login brute-force protection
+# After LOGIN_MAX_ATTEMPTS failures for the same (username, ip) within LOGIN_WINDOW_MINUTES,
+# further attempts are rejected until the oldest failure ages out of the window.
+LOGIN_MAX_ATTEMPTS = 5
+LOGIN_WINDOW_MINUTES = 15
+
+
+def _login_window_start() -> datetime:
+    return datetime.utcnow() - timedelta(minutes=LOGIN_WINDOW_MINUTES)
+
+
+def is_login_locked(db: Session, username: str, ip: str) -> bool:
+    """Return True when (username, ip) has reached the failed-attempt limit in the window."""
+    recent = (
+        db.query(LoginAttempt)
+        .filter(
+            LoginAttempt.username == username,
+            LoginAttempt.ip == ip,
+            LoginAttempt.created_at >= _login_window_start(),
+        )
+        .count()
+    )
+    return recent >= LOGIN_MAX_ATTEMPTS
+
+
+def record_failed_login(db: Session, username: str, ip: str) -> None:
+    """Record a failed attempt and prune attempts for this key that fell out of the window."""
+    db.add(LoginAttempt(username=username, ip=ip))
+    db.query(LoginAttempt).filter(
+        LoginAttempt.username == username,
+        LoginAttempt.ip == ip,
+        LoginAttempt.created_at < _login_window_start(),
+    ).delete(synchronize_session=False)
+    db.commit()
+
+
+def clear_login_attempts(db: Session, username: str, ip: str) -> None:
+    """Clear recorded attempts for a key, called after a successful login."""
+    db.query(LoginAttempt).filter(
+        LoginAttempt.username == username,
+        LoginAttempt.ip == ip,
+    ).delete(synchronize_session=False)
+    db.commit()
 
 
 # Password hashing

--- a/app/database/database.py
+++ b/app/database/database.py
@@ -439,6 +439,24 @@ class EmploymentTransition(Base):
         )
 
 
+class LoginAttempt(Base):
+    """A failed login attempt, used for brute-force rate limiting on /login.
+
+    Rows are keyed by (username, ip) and pruned once they age out of the rate-limit
+    window. A successful login clears the matching rows.
+    """
+
+    __tablename__ = "login_attempts"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    username = Column(String(50), nullable=False, index=True)
+    ip = Column(String(64), nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)
+
+    def __repr__(self):
+        return f"<LoginAttempt(username={self.username!r}, ip={self.ip!r}, at={self.created_at})>"
+
+
 def create_tables():
     """Create all database tables."""
     Base.metadata.create_all(bind=engine)

--- a/app/routes/auth_routes.py
+++ b/app/routes/auth_routes.py
@@ -12,11 +12,14 @@ from sqlalchemy.orm import Session
 from app.auth.auth import (
     authenticate_user,
     clear_auth_cookie,
+    clear_login_attempts,
     create_access_token,
     get_current_user_allow_pwd_change,
     get_current_user_from_cookie,
     get_current_user_optional,
     get_password_hash,
+    is_login_locked,
+    record_failed_login,
     set_auth_cookie,
 )
 from app.core.logging_config import get_logger
@@ -61,13 +64,34 @@ async def login(
     db: Session = Depends(get_db),
 ):
     """Process login form."""
-    user = authenticate_user(db, username, password)
-    if not user:
+    ip = request.client.host if request.client else "unknown"
+
+    # Brute-force protection: reject further attempts once the limit is reached.
+    if is_login_locked(db, username, ip):
         log_auth_event(
             event_type="login",
             username=username,
             success=False,
-            details={"ip": request.client.host if request.client else "unknown"},
+            details={"ip": ip, "reason": "rate_limited"},
+        )
+        return render(
+            "login.html",
+            {
+                "request": request,
+                "error": "För många misslyckade försök. Försök igen om en stund.",
+                "next": next,
+            },
+            status_code=429,
+        )
+
+    user = authenticate_user(db, username, password)
+    if not user:
+        record_failed_login(db, username, ip)
+        log_auth_event(
+            event_type="login",
+            username=username,
+            success=False,
+            details={"ip": ip},
         )
 
         return render(
@@ -75,6 +99,9 @@ async def login(
             {"request": request, "error": "Fel användarnamn eller lösenord", "next": next},
             status_code=401,
         )
+
+    # Successful login clears the failed-attempt counter for this key.
+    clear_login_attempts(db, username, ip)
 
     log_auth_event(
         event_type="login",

--- a/migrations/migrate_add_login_attempts.py
+++ b/migrations/migrate_add_login_attempts.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Migration script to add the login_attempts table (login brute-force protection).
+
+Note: create_tables() (Base.metadata.create_all) also creates this table automatically
+on startup. This script exists so the table can be created explicitly during a controlled
+prod deploy. Always back up the prod DB before running migrations.
+"""
+
+import sqlite3
+import sys
+from pathlib import Path
+
+
+def migrate(db_path: str = "app/database/schedule.db"):
+    path = Path(db_path)
+    if not path.exists():
+        print(f"Error: Database not found at {path}")
+        sys.exit(1)
+
+    conn = sqlite3.connect(path)
+    cursor = conn.cursor()
+
+    try:
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='login_attempts'")
+        exists = cursor.fetchone() is not None
+
+        if exists:
+            print("Table login_attempts already exists.")
+            return
+
+        print("Creating table login_attempts...")
+        cursor.execute(
+            """
+            CREATE TABLE login_attempts (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                username VARCHAR(50) NOT NULL,
+                ip VARCHAR(64) NOT NULL,
+                created_at DATETIME NOT NULL
+            )
+            """
+        )
+        cursor.execute("CREATE INDEX ix_login_attempts_username ON login_attempts (username)")
+        cursor.execute("CREATE INDEX ix_login_attempts_created_at ON login_attempts (created_at)")
+        conn.commit()
+        print("Table login_attempts created.")
+
+    except sqlite3.Error as e:
+        print(f"Error during migration: {e}")
+        conn.rollback()
+        sys.exit(1)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("Migration: Add login_attempts table")
+    print("=" * 60)
+    db = sys.argv[1] if len(sys.argv) > 1 else "app/database/schedule.db"
+    migrate(db)
+    print("\nMigration completed successfully!")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
 # Add project root to path for imports
 project_root = Path(__file__).parent.parent
@@ -37,8 +38,15 @@ def test_db():
     Yields:
         SQLAlchemy Session: Database session for test use
     """
-    # Create in-memory database
-    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    # Create in-memory database.
+    # StaticPool keeps a single shared connection so the schema survives commits and is
+    # visible across threads (the TestClient runs requests off the main thread); without
+    # it, an in-memory SQLite DB silently loses its tables after a mid-request commit.
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
     TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
     # Create all tables

--- a/tests/test_login_rate_limit.py
+++ b/tests/test_login_rate_limit.py
@@ -1,0 +1,85 @@
+"""Tests for login brute-force protection (audit item S1).
+
+After LOGIN_MAX_ATTEMPTS failed attempts for the same (username, ip) within the window,
+further attempts are rejected with 429 until they age out; a successful login clears them.
+"""
+
+from datetime import datetime, timedelta
+
+from app.auth.auth import (
+    LOGIN_MAX_ATTEMPTS,
+    LOGIN_WINDOW_MINUTES,
+    clear_login_attempts,
+    is_login_locked,
+    record_failed_login,
+)
+from app.database.database import LoginAttempt
+
+IP = "1.2.3.4"
+
+
+# --- Unit tests on the rate-limit helpers ------------------------------------
+
+
+def test_locks_after_max_attempts(test_db):
+    for _ in range(LOGIN_MAX_ATTEMPTS):
+        record_failed_login(test_db, "bob", IP)
+
+    assert is_login_locked(test_db, "bob", IP) is True
+    # A different IP and a different username share neither the count nor the lock.
+    assert is_login_locked(test_db, "bob", "9.9.9.9") is False
+    assert is_login_locked(test_db, "alice", IP) is False
+
+
+def test_below_threshold_not_locked(test_db):
+    for _ in range(LOGIN_MAX_ATTEMPTS - 1):
+        record_failed_login(test_db, "bob", IP)
+
+    assert is_login_locked(test_db, "bob", IP) is False
+
+
+def test_clear_attempts_unlocks(test_db):
+    for _ in range(LOGIN_MAX_ATTEMPTS):
+        record_failed_login(test_db, "bob", IP)
+    clear_login_attempts(test_db, "bob", IP)
+
+    assert is_login_locked(test_db, "bob", IP) is False
+
+
+def test_attempts_outside_window_do_not_count(test_db):
+    old = datetime.utcnow() - timedelta(minutes=LOGIN_WINDOW_MINUTES + 1)
+    for _ in range(LOGIN_MAX_ATTEMPTS):
+        test_db.add(LoginAttempt(username="bob", ip=IP, created_at=old))
+    test_db.commit()
+
+    assert is_login_locked(test_db, "bob", IP) is False
+
+
+# --- Integration tests via the login route -----------------------------------
+
+
+def _post_login(client, password):
+    return client.post(
+        "/login",
+        data={"username": "testuser", "password": password},
+        follow_redirects=False,
+    )
+
+
+def test_login_blocks_after_max_failures(test_client, test_user):
+    for _ in range(LOGIN_MAX_ATTEMPTS):
+        resp = _post_login(test_client, "wrongpass")
+        assert resp.status_code == 401
+
+    # Even the correct password is now rejected with 429 (locked).
+    resp = _post_login(test_client, "testpass123")
+    assert resp.status_code == 429
+
+
+def test_successful_login_resets_counter(test_client, test_user, test_db):
+    for _ in range(LOGIN_MAX_ATTEMPTS - 1):
+        _post_login(test_client, "wrongpass")
+
+    resp = _post_login(test_client, "testpass123")
+    assert resp.status_code == 302  # success redirect
+    assert test_db.query(LoginAttempt).count() == 0


### PR DESCRIPTION
## Problem

The login route accepted unlimited password guesses with no rate limiting or lockout.

## Fix

A DB-backed limiter (chosen over `slowapi` to avoid a new dependency / Redis, fits the SQLite-only stack):

- New `login_attempts` table keyed by (username, ip).
- After 5 failed attempts for the same (username, ip) within 15 minutes, further attempts are rejected with **429** until the oldest failure ages out of the window.
- A successful login clears the counter.
- Helpers live in `auth.py` (`is_login_locked` / `record_failed_login` / `clear_login_attempts`) and are wired into the login route before authentication.

The table is created automatically by `create_tables` on startup; `migrations/migrate_add_login_attempts.py` is provided for an explicit prod deploy (idempotent). No new runtime dependency.

## Test infrastructure

Hardened the in-memory test fixture with `StaticPool`. Without it, an in-memory SQLite DB silently loses its schema after a mid-request commit (the new limiter commits during `/login`), and the schema must be visible across the TestClient request thread. This only affects tests, not production behaviour.

## Tests

`tests/test_login_rate_limit.py` (6 cases): unit tests for the limiter helpers (lock threshold, window expiry, clearing) and integration tests for the 429 lockout and the counter reset on success. Confirmed the lockout test fails without the limiter. Full suite: 92 passed.