### PR TITLE
Log instead of silently swallowing failed months in vacation pay

### DIFF
--- a/app/core/schedule/vacation.py
+++ b/app/core/schedule/vacation.py
@@ -4,6 +4,9 @@ import datetime
 import math
 
 from app.core.constants import PERSON_IDS
+from app.core.logging_config import get_logger
+
+logger = get_logger(__name__)
 
 
 def get_vacation_dates_for_year(year: int, session=None) -> dict[int, set[datetime.date]]:
@@ -570,7 +573,17 @@ def calculate_vacation_pay(
                 ot_total += summary.get("ot_pay", 0.0)
                 oncall_total += summary.get("oncall_pay", 0.0)
             except Exception:
-                pass
+                # Keep going so one bad month does not break the whole vacation
+                # calculation, but log it: silently dropping a month understates the
+                # variable part of the vacation supplement (0.5% of variable earnings).
+                logger.warning(
+                    "Vacation pay: failed to summarise %d-%02d for user_id=%s; "
+                    "its variable earnings are excluded from the supplement",
+                    current.year,
+                    current.month,
+                    user.id,
+                    exc_info=True,
+                )
 
             if current.month == 12:
                 current = datetime.date(current.year + 1, 1, 1)

--- a/tests/test_vacation_pay_logging.py
+++ b/tests/test_vacation_pay_logging.py
@@ -1,0 +1,58 @@
+"""Regression test for audit item B5.
+
+calculate_vacation_pay used to swallow exceptions from summarize_month_for_person with a
+bare `except Exception: pass`, silently dropping that month's variable earnings (which feed
+the 0.5% variable part of the vacation supplement). It must now log the failure while still
+degrading gracefully instead of crashing the whole vacation calculation.
+"""
+
+import datetime
+from unittest.mock import MagicMock
+
+from app.core.schedule import vacation
+from app.core.schedule.vacation import calculate_vacation_pay
+from app.database.database import User, UserRole
+
+RATES = {"fixed_pct": 0.008, "variable_pct": 0.005, "payout_pct": 0.046}
+
+
+def test_failed_month_is_logged_not_silently_swallowed(test_db, monkeypatch):
+    user = User(
+        id=1,
+        username="vacuser",
+        password_hash="x",
+        name="Vac User",
+        role=UserRole.USER,
+        wage=30000,
+        person_id=1,
+        vacation={},
+        must_change_password=0,
+    )
+    test_db.add(user)
+    test_db.commit()
+    test_db.refresh(user)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("monthly summary exploded")
+
+    monkeypatch.setattr("app.core.schedule.summary.summarize_month_for_person", boom)
+
+    fake_logger = MagicMock()
+    monkeypatch.setattr(vacation, "logger", fake_logger)
+
+    result = calculate_vacation_pay(
+        user=user,
+        entitled_days=25,
+        earning_start=datetime.date(2025, 1, 1),
+        earning_end=datetime.date(2025, 1, 31),
+        db=test_db,
+        vacation_rates=RATES,
+    )
+
+    # Degraded gracefully: no crash, variable part excluded, fixed part still computed.
+    assert result["variable_per_day"] == 0.0
+    assert result["fixed_per_day"] == round(30000 * 0.008, 2)
+    assert result["monthly_salary"] == 30000
+
+    # The failure was logged rather than silently swallowed.
+    assert fake_logger.warning.called


### PR DESCRIPTION
## Problem

`calculate_vacation_pay` sums variable earnings (OB, overtime, on-call) across the earning year to compute the 0.5% variable part of the vacation supplement. The per-month loop wrapped `summarize_month_for_person` in a bare `except Exception: pass`, so if any month failed, its earnings were dropped silently, understating the supplement with no trace in logs or UI.

## Fix

Replace the bare `pass` with a `logger.warning` (month, user, traceback). The loop still continues, so one bad month degrades gracefully instead of crashing the whole vacation calculation, but the failure is now visible (and flows to Sentry, which the app already configures).

## Tests

`tests/test_vacation_pay_logging.py`: asserts the failure is logged and the result degrades gracefully (variable part excluded, fixed part intact). Confirmed the test fails against the old `pass`. Full suite: 93 passed.