### PR TITLE
Replace deprecated datetime.utcnow and hardcoded monthly-hours divisor

### DIFF
--- a/app/auth/auth.py
+++ b/app/auth/auth.py
@@ -12,7 +12,7 @@ from jose import JWTError, jwt
 from passlib.context import CryptContext
 from sqlalchemy.orm import Session
 
-from app.database.database import LoginAttempt, User, UserRole, get_db
+from app.database.database import LoginAttempt, User, UserRole, get_db, utcnow
 
 # Configuration - reads from environment variables for security
 SECRET_KEY = os.getenv("SECRET_KEY", "your-secret-key-change-this-in-production")
@@ -57,7 +57,7 @@ LOGIN_WINDOW_MINUTES = 15
 
 
 def _login_window_start() -> datetime:
-    return datetime.utcnow() - timedelta(minutes=LOGIN_WINDOW_MINUTES)
+    return utcnow() - timedelta(minutes=LOGIN_WINDOW_MINUTES)
 
 
 def is_login_locked(db: Session, username: str, ip: str) -> bool:
@@ -117,9 +117,9 @@ def create_access_token(data: dict, expires_delta: timedelta | None = None) -> s
     """Create a JWT access token."""
     to_encode = data.copy()
     if expires_delta:
-        expire = datetime.utcnow() + expires_delta
+        expire = utcnow() + expires_delta
     else:
-        expire = datetime.utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+        expire = utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
     to_encode.update({"exp": expire})
     encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt

--- a/app/core/logging_config.py
+++ b/app/core/logging_config.py
@@ -11,7 +11,7 @@ import logging
 import logging.handlers
 import os
 import sys
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 # Determine if running in production
@@ -37,7 +37,7 @@ class JSONFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         log_data = {
-            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "timestamp": datetime.now(UTC).replace(tzinfo=None).isoformat() + "Z",
             "level": record.levelname,
             "logger": record.name,
             "message": record.getMessage(),
@@ -174,9 +174,7 @@ def setup_logging() -> None:
             encoding="utf-8",
         )
         file_handler.setLevel(logging.DEBUG)
-        file_handler.setFormatter(
-            logging.Formatter("%(levelname)s %(asctime)s [%(name)s:%(lineno)d] %(message)s")
-        )
+        file_handler.setFormatter(logging.Formatter("%(levelname)s %(asctime)s [%(name)s:%(lineno)d] %(message)s"))
         root_logger.addHandler(file_handler)
 
     # Configure uvicorn loggers

--- a/app/core/schedule/wages.py
+++ b/app/core/schedule/wages.py
@@ -204,7 +204,7 @@ def calculate_absence_deduction(
         - LEAVE: 100% avdrag (obetald ledighet)
         - OFF: 0% avdrag (betald ledighet)
     """
-    hourly_wage = monthly_wage / 173.33
+    hourly_wage = monthly_wage / _MONTHLY_HOURS
     hours = absent_hours if absent_hours is not None else shift_hours
 
     if absence_type == "SICK":

--- a/app/database/database.py
+++ b/app/database/database.py
@@ -4,7 +4,7 @@ SQLAlchemy database setup and models.
 """
 
 import enum
-from datetime import datetime
+from datetime import UTC, datetime
 
 from sqlalchemy import (
     JSON,
@@ -43,6 +43,15 @@ def set_sqlite_pragmas(dbapi_connection, connection_record):
 
 
 Base = declarative_base()
+
+
+def utcnow() -> datetime:
+    """Naive UTC timestamp, a drop-in replacement for the deprecated utcnow.
+
+    Returns the current UTC time with tzinfo stripped so stored/compared values keep the
+    same naive-UTC semantics the app has always used.
+    """
+    return datetime.now(UTC).replace(tzinfo=None)
 
 
 class UserRole(str, enum.Enum):
@@ -128,8 +137,8 @@ class User(Base):
     custom_rates = Column(JSON, default=dict)  # Per-user rate overrides (OB, OT, oncall, vacation)
     language = Column(String(5), default="sv", nullable=False)  # UI language: "sv" or "en"
     api_key = Column(String(64), unique=True, nullable=True, index=True)
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = Column(DateTime, default=utcnow)
+    updated_at = Column(DateTime, default=utcnow, onupdate=utcnow)
 
     @property
     def rotation_person_id(self) -> int:
@@ -157,7 +166,7 @@ class OvertimeShift(Base):
     hours = Column(Float, nullable=False)
     ot_pay = Column(Float, nullable=False)
     is_extension = Column(Boolean, default=False, nullable=False)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=utcnow)
     created_by = Column(Integer, ForeignKey("users.id"))
 
     # Relationships
@@ -179,7 +188,7 @@ class Absence(Base):
     absence_type = Column(SQLEnum(AbsenceType), nullable=False)
     left_at = Column(String(5), nullable=True)  # "HH:MM" - time they left early (None = full day or on time)
     arrived_at = Column(String(5), nullable=True)  # "HH:MM" - time they arrived late (None = full day or on time)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=utcnow)
 
     # Relationships
     user = relationship("User", foreign_keys=[user_id])
@@ -205,7 +214,7 @@ class OnCallOverride(Base):
     date = Column(Date, nullable=False)
     override_type = Column(SQLEnum(OnCallOverrideType), nullable=False)
     reason = Column(String(255), nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=utcnow)
     created_by = Column(Integer, ForeignKey("users.id"), nullable=True)
 
     # Relationships
@@ -225,7 +234,7 @@ class ShiftOverride(Base):
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     date = Column(Date, nullable=False)
     shift_code = Column(String(10), nullable=False)  # N1, N2, N3
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=utcnow)
     created_by = Column(Integer, ForeignKey("users.id"), nullable=True)
 
     user = relationship("User", foreign_keys=[user_id])
@@ -245,7 +254,7 @@ class WageHistory(Base):
     wage = Column(Integer, nullable=False)  # Monthly wage in SEK
     effective_from = Column(Date, nullable=False)  # When this wage becomes effective
     effective_to = Column(Date, nullable=True)  # When this wage ends (NULL = current wage)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=utcnow)
     created_by = Column(Integer, ForeignKey("users.id"), nullable=True)
 
     # Relationships
@@ -273,7 +282,7 @@ class RateHistory(Base):
     rates = Column(JSON, nullable=False)  # Same format as User.custom_rates
     effective_from = Column(Date, nullable=False)
     effective_to = Column(Date, nullable=True)  # NULL = current
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=utcnow)
     created_by = Column(Integer, ForeignKey("users.id"), nullable=True)
 
     user = relationship("User", foreign_keys=[user_id])
@@ -302,7 +311,7 @@ class DayPayOverride(Base):
     ob_hours_override = Column(JSON, nullable=True)  # {code: hours} e.g. {"OB1": 3.5, "OB2": 0.0}
     oncall_hours_override = Column(JSON, nullable=True)  # {code: hours} e.g. {"OC_WEEKDAY": 24.0}
     reason = Column(String(255), nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=utcnow)
     created_by = Column(Integer, ForeignKey("users.id"), nullable=True)
 
     user = relationship("User", foreign_keys=[user_id])
@@ -335,7 +344,7 @@ class PersonHistory(Base):
     is_active = Column(Integer, nullable=False)  # 1=active, 0=inactive during this period
     effective_from = Column(Date, nullable=False)  # Start date of this employment period
     effective_to = Column(Date, nullable=True)  # End date (NULL = currently employed)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=utcnow)
     created_by = Column(Integer, ForeignKey("users.id"), nullable=True)
 
     # Relationships
@@ -364,7 +373,7 @@ class RotationEra(Base):
     end_date = Column(Date, nullable=True, index=True)  # When this era ends (NULL = current/ongoing)
     rotation_length = Column(Integer, nullable=False)  # Number of weeks in rotation cycle
     weeks_pattern = Column(JSON, nullable=False)  # Week definitions: {"1": ["OFF", "OFF", ...], ...}
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=utcnow)
     created_by = Column(Integer, ForeignKey("users.id"), nullable=True)
 
     # Relationships
@@ -392,7 +401,7 @@ class ShiftSwap(Base):
     status = Column(SQLEnum(SwapStatus), default=SwapStatus.PENDING, nullable=False)
     message = Column(String(255), nullable=True)
     responded_at = Column(DateTime, nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=utcnow)
 
     # Relationships
     requester = relationship("User", foreign_keys=[requester_id])
@@ -426,8 +435,8 @@ class EmploymentTransition(Base):
     earning_year_end = Column(Date, nullable=True)  # NULL = auto: day before transition_date
     advance_vacation_days = Column(Integer, nullable=True, default=None)  # Forskottsemester fran Handels
     notes = Column(Text, nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = Column(DateTime, default=utcnow)
+    updated_at = Column(DateTime, default=utcnow, onupdate=utcnow)
 
     # Relationships
     user = relationship("User", back_populates="employment_transition")
@@ -451,7 +460,7 @@ class LoginAttempt(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     username = Column(String(50), nullable=False, index=True)
     ip = Column(String(64), nullable=False)
-    created_at = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)
+    created_at = Column(DateTime, default=utcnow, nullable=False, index=True)
 
     def __repr__(self):
         return f"<LoginAttempt(username={self.username!r}, ip={self.ip!r}, at={self.created_at})>"

--- a/app/routes/admin_users.py
+++ b/app/routes/admin_users.py
@@ -14,7 +14,7 @@ from app.core.constants import DEFAULT_PASSWORD
 from app.core.logging_config import get_logger
 from app.core.request_logging import log_auth_event
 from app.core.schedule import clear_schedule_cache
-from app.database.database import User, UserRole, WageType, get_db
+from app.database.database import User, UserRole, WageType, get_db, utcnow
 from app.routes.shared import _parse_rates_form, render
 
 logger = get_logger(__name__)
@@ -633,7 +633,7 @@ async def admin_transition_save(
     transition.earning_year_start = earning_start
     transition.earning_year_end = earning_end
     transition.notes = notes.strip() or None
-    transition.updated_at = _dt.datetime.utcnow()
+    transition.updated_at = utcnow()
 
     try:
         db.commit()

--- a/app/routes/shift_swap.py
+++ b/app/routes/shift_swap.py
@@ -13,7 +13,7 @@ from app.core.helpers import render_template
 from app.core.schedule import build_week_data, calculate_shift_hours, clear_schedule_cache
 from app.core.schedule.core import determine_shift_for_date
 from app.core.utils import get_today
-from app.database.database import ShiftSwap, SwapStatus, User, get_db
+from app.database.database import ShiftSwap, SwapStatus, User, get_db, utcnow
 from app.routes.shared import templates
 
 router = APIRouter(prefix="/swaps", tags=["shift_swaps"])
@@ -442,7 +442,7 @@ async def accept_swap(
         raise HTTPException(status_code=400, detail="Bytet är inte längre väntande")
 
     swap.status = SwapStatus.ACCEPTED
-    swap.responded_at = datetime.utcnow()
+    swap.responded_at = utcnow()
     db.commit()
     clear_schedule_cache()
 
@@ -465,7 +465,7 @@ async def reject_swap(
         raise HTTPException(status_code=400, detail="Bytet är inte längre väntande")
 
     swap.status = SwapStatus.REJECTED
-    swap.responded_at = datetime.utcnow()
+    swap.responded_at = utcnow()
     db.commit()
 
     return RedirectResponse(url="/swaps", status_code=303)
@@ -491,7 +491,7 @@ async def cancel_swap(
         raise HTTPException(status_code=400, detail="Kan bara avbryta väntande eller accepterade byten")
 
     swap.status = SwapStatus.CANCELLED
-    swap.responded_at = datetime.utcnow()
+    swap.responded_at = utcnow()
     db.commit()
     clear_schedule_cache()
 

--- a/app/routes/transition.py
+++ b/app/routes/transition.py
@@ -12,7 +12,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from sqlalchemy.orm import Session
 
 from app.auth.auth import get_current_user
-from app.database.database import ConsultantSalaryType, EmploymentTransition, User, get_db
+from app.database.database import ConsultantSalaryType, EmploymentTransition, User, get_db, utcnow
 from app.routes.shared import render
 
 router = APIRouter(tags=["transition"])
@@ -168,7 +168,7 @@ async def transition_save(
     transition.earning_year_start = earning_start
     transition.earning_year_end = earning_end
     transition.notes = notes.strip() or None
-    transition.updated_at = datetime.datetime.utcnow()
+    transition.updated_at = utcnow()
 
     try:
         db.commit()

--- a/tests/test_utcnow_helper.py
+++ b/tests/test_utcnow_helper.py
@@ -1,0 +1,22 @@
+"""Test for the utcnow() helper (audit item D1).
+
+The helper replaces the deprecated datetime.utcnow(). It must keep returning a NAIVE UTC
+datetime, since timestamps and DateTime column defaults across the app assume naive UTC and
+mixing naive/aware values would break comparisons.
+"""
+
+from datetime import UTC, datetime
+
+from app.database.database import utcnow
+
+
+def test_utcnow_is_naive():
+    now = utcnow()
+    assert now.tzinfo is None
+
+
+def test_utcnow_matches_current_utc():
+    before = datetime.now(UTC).replace(tzinfo=None)
+    value = utcnow()
+    after = datetime.now(UTC).replace(tzinfo=None)
+    assert before <= value <= after


### PR DESCRIPTION
Two small, behaviour-preserving cleanups from the audit.

## D1 - datetime.utcnow() (deprecated in Python 3.12)

`datetime.utcnow()` is deprecated. Added a naive-UTC `utcnow()` helper in the database module and used it for every timestamp call and `DateTime` column default. It returns `datetime.now(UTC).replace(tzinfo=None)`, keeping the exact naive-UTC semantics the app has always relied on, so there is no behaviour change (stored values and comparisons stay naive). Touched: `database.py` (helper + 15 column defaults), `auth.py`, `shift_swap.py`, `transition.py`, `admin_users.py`, `logging_config.py`. This also clears the bulk of the deprecation warnings in the test run (218 to ~5; the rest are Pydantic v1 / SQLAlchemy 1.x, tracked separately).

## B6 - hardcoded divisor

`calculate_absence_deduction` divided by a literal `173.33` instead of the existing `_MONTHLY_HOURS` constant. Now uses the constant so the monthly-hours divisor has a single source of truth.

## Tests

Added `tests/test_utcnow_helper.py` pinning the naive-UTC contract. Full suite: 93 passed, ruff clean.