### PR TITLE
Equalise login timing for unknown usernames

### DIFF
--- a/app/auth/auth.py
+++ b/app/auth/auth.py
@@ -113,6 +113,11 @@ def get_password_hash(password: str) -> str:
     return pwd_context.hash(password)
 
 
+# Precomputed hash used to equalise authentication timing when the username does not exist,
+# so an attacker cannot tell valid usernames apart by measuring response time.
+_DUMMY_PASSWORD_HASH = pwd_context.hash("timing-equalisation-placeholder")
+
+
 def create_access_token(data: dict, expires_delta: timedelta | None = None) -> str:
     """Create a JWT access token."""
     to_encode = data.copy()
@@ -154,6 +159,9 @@ def authenticate_user(db: Session, username: str, password: str) -> User | None:
     """
     user = get_user_by_username(db, username)
     if not user:
+        # Verify against a dummy hash so a missing user costs ~the same time as a wrong
+        # password, preventing username enumeration via response timing.
+        verify_password(password, _DUMMY_PASSWORD_HASH)
         return None
     if not verify_password(password, user.password_hash):
         return None

--- a/tests/test_login_timing.py
+++ b/tests/test_login_timing.py
@@ -1,0 +1,56 @@
+"""Tests for username-enumeration hardening (audit item S3).
+
+authenticate_user used to return immediately when the username did not exist, skipping the
+(slow) bcrypt verification it runs for an existing user. That timing difference leaked which
+usernames are valid. It must now run a dummy verification for a missing user too.
+
+Timing itself is too flaky to assert, so we verify the behaviour: a missing user still
+triggers exactly one password verification.
+"""
+
+from app.auth import auth
+from app.database.database import User, UserRole
+
+
+def test_unknown_user_still_runs_a_verification(test_db, monkeypatch):
+    calls = []
+    monkeypatch.setattr(auth, "verify_password", lambda pw, h: calls.append(h) or False)
+
+    result = auth.authenticate_user(test_db, "no-such-user", "whatever")
+
+    assert result is None
+    # A dummy verify ran despite the user not existing (equalises timing).
+    assert len(calls) == 1
+    assert calls[0] == auth._DUMMY_PASSWORD_HASH
+
+
+def test_valid_credentials_authenticate(test_db):
+    user = User(
+        username="realuser",
+        password_hash=auth.get_password_hash("correct horse"),
+        name="Real",
+        role=UserRole.USER,
+        wage=30000,
+        vacation={},
+        must_change_password=0,
+    )
+    test_db.add(user)
+    test_db.commit()
+
+    assert auth.authenticate_user(test_db, "realuser", "correct horse") is not None
+
+
+def test_wrong_password_fails(test_db):
+    user = User(
+        username="realuser2",
+        password_hash=auth.get_password_hash("correct horse"),
+        name="Real",
+        role=UserRole.USER,
+        wage=30000,
+        vacation={},
+        must_change_password=0,
+    )
+    test_db.add(user)
+    test_db.commit()
+
+    assert auth.authenticate_user(test_db, "realuser2", "wrong") is None


### PR DESCRIPTION
## Problem

`authenticate_user` returned immediately when the username did not exist, skipping the bcrypt verification it runs for an existing user. The resulting response-time difference let an attacker enumerate valid usernames (a present username is slow, an absent one is fast).

## Fix

When the user is missing, run `verify_password` against a precomputed dummy bcrypt hash before returning `None`, so a non-existent user costs about the same time as a wrong password. The dummy hash is computed once at import.

## Tests

`tests/test_login_timing.py`: asserts a dummy verification runs for an unknown user (timing itself is too flaky to assert directly) and that valid / invalid credentials still behave correctly. Confirmed the enumeration test fails without the fix. Full suite: 98 passed.