### PR TITLE
Clear SQLAlchemy and Pydantic deprecation warnings

### DIFF
--- a/app/core/models.py
+++ b/app/core/models.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class ShiftType(BaseModel):
@@ -94,5 +94,4 @@ class OvertimeShiftResponse(BaseModel):
     ot_pay: float
     created_at: datetime
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)

--- a/app/database/database.py
+++ b/app/database/database.py
@@ -25,8 +25,7 @@ from sqlalchemy import (
 from sqlalchemy import (
     Enum as SQLEnum,
 )
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import relationship, sessionmaker
+from sqlalchemy.orm import declarative_base, relationship, sessionmaker
 
 DATABASE_URL = "sqlite:///./app/database/schedule.db"
 

--- a/tests/test_login_rate_limit.py
+++ b/tests/test_login_rate_limit.py
@@ -4,7 +4,7 @@ After LOGIN_MAX_ATTEMPTS failed attempts for the same (username, ip) within the 
 further attempts are rejected with 429 until they age out; a successful login clears them.
 """
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from app.auth.auth import (
     LOGIN_MAX_ATTEMPTS,
@@ -13,7 +13,7 @@ from app.auth.auth import (
     is_login_locked,
     record_failed_login,
 )
-from app.database.database import LoginAttempt
+from app.database.database import LoginAttempt, utcnow
 
 IP = "1.2.3.4"
 
@@ -47,7 +47,7 @@ def test_clear_attempts_unlocks(test_db):
 
 
 def test_attempts_outside_window_do_not_count(test_db):
-    old = datetime.utcnow() - timedelta(minutes=LOGIN_WINDOW_MINUTES + 1)
+    old = utcnow() - timedelta(minutes=LOGIN_WINDOW_MINUTES + 1)
     for _ in range(LOGIN_MAX_ATTEMPTS):
         test_db.add(LoginAttempt(username="bob", ip=IP, created_at=old))
     test_db.commit()


### PR DESCRIPTION
Behaviour-preserving deprecation cleanup from the audit.

## D2 - SQLAlchemy declarative_base

`declarative_base()` was imported from the deprecated `sqlalchemy.ext.declarative`. Import it from `sqlalchemy.orm` instead (the SQLAlchemy 2.0 location). Removes the `MovedIn20Warning`.

## D3 - Pydantic v2 config

`OvertimeShiftResponse` used the deprecated class-based `Config`. Replaced with `model_config = ConfigDict(from_attributes=True)`.

## Tidy-up

Switched a leftover `datetime.utcnow()` in `test_login_rate_limit.py` to the app's naive-UTC `utcnow()` helper.

No behaviour change. The targeted deprecation warnings are gone; the only ones left in the suite are the test SECRET_KEY notice and passlib's internal `crypt` deprecation (third-party). Full suite: 98 passed, ruff clean.