### PR TITLE
Make dev CORS valid with credentials by reflecting the origin

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -147,14 +147,19 @@ if IS_PRODUCTION:
         )
 
     allowed_origins = CORS_ORIGINS
+    allowed_origin_regex = None
     allow_credentials = True
     allowed_methods = ["GET", "POST"]  # Only allow methods we use
     allowed_headers = ["*"]
 
     logger.info(f"CORS configured for production with origins: {allowed_origins}")
 else:
-    # Development: Permissive CORS for easier testing
-    allowed_origins = ["*"]
+    # Development: Permissive CORS for easier testing.
+    # Use an origin regex rather than allow_origins=["*"]: a literal "*" is invalid with
+    # allow_credentials=True (browsers reject it), so Starlette must reflect the request
+    # origin instead for cookies/credentials to work cross-origin in dev.
+    allowed_origins = []
+    allowed_origin_regex = ".*"
     allow_credentials = True
     allowed_methods = ["*"]
     allowed_headers = ["*"]
@@ -164,6 +169,7 @@ else:
 app.add_middleware(
     CORSMiddleware,
     allow_origins=allowed_origins,
+    allow_origin_regex=allowed_origin_regex,
     allow_credentials=allow_credentials,
     allow_methods=allowed_methods,
     allow_headers=allowed_headers,

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,0 +1,14 @@
+"""Test for dev CORS configuration (audit item D5).
+
+In development the app must reflect the request Origin (not return a literal "*") so that
+allow_credentials=True is valid: browsers reject "*" combined with credentials. The tests
+run with PRODUCTION unset, i.e. the development CORS branch.
+"""
+
+
+def test_dev_cors_reflects_origin_with_credentials(test_client):
+    resp = test_client.get("/health", headers={"Origin": "http://localhost:3000"})
+
+    # Origin is reflected, not "*", so credentials are allowed per the CORS spec.
+    assert resp.headers.get("access-control-allow-origin") == "http://localhost:3000"
+    assert resp.headers.get("access-control-allow-credentials") == "true"


### PR DESCRIPTION
## Problem

The development CORS branch combined `allow_origins=["*"]` with `allow_credentials=True`. That combination is invalid per the CORS spec, browsers reject a literal `*` when credentials are present, so a credentialed (cookie) cross-origin request in dev would fail.

## Fix

Use `allow_origin_regex=".*"` in development instead of `allow_origins=["*"]`, so Starlette reflects the request Origin and the credentialed combination is valid. Production is unchanged: it keeps its explicit `CORS_ORIGINS` allowlist (regex unset).

## Tests

`tests/test_cors.py`: asserts the dev response reflects the request Origin (not `*`) and sets `access-control-allow-credentials: true`. Confirmed it fails against the old `["*"]` config. Full suite: 99 passed.