### PR TITLE
Count week-based vacation in scheduled work days

### DIFF
--- a/app/core/schedule/vacation.py
+++ b/app/core/schedule/vacation.py
@@ -162,20 +162,45 @@ def _count_weekdays_in_vacation_weeks(
     iso_year: int,
     period_start: datetime.date,
     period_end: datetime.date,
+    off_dates: set[datetime.date] | None = None,
 ) -> int:
     """
-    Count weekdays (Mon-Fri) in the given ISO weeks that fall within [period_start, period_end].
+    Count vacation days consumed by the given ISO weeks within [period_start, period_end].
+
+    When off_dates is provided, a week consumes only the days the employee was actually
+    scheduled to work (all seven weekdays minus OFF-shift days), so week-based vacation is
+    counted the same way as day-level vacation. Without off_dates it falls back to a flat
+    Mon-Fri (5 days/week).
     """
     count = 0
+    # With a known schedule, consider all 7 days and drop the OFF ones; otherwise Mon-Fri.
+    day_range = range(1, 8) if off_dates is not None else range(1, 6)
     for week in weeks:
-        for iso_day in range(1, 6):  # 1=Monday .. 5=Friday
+        for iso_day in day_range:
             try:
                 d = datetime.date.fromisocalendar(iso_year, week, iso_day)
             except ValueError:
                 continue
-            if period_start <= d <= period_end:
-                count += 1
+            if not (period_start <= d <= period_end):
+                continue
+            if off_dates is not None and d in off_dates:
+                continue
+            count += 1
     return count
+
+
+def _scheduled_off_dates(user, start: datetime.date, end: datetime.date) -> set[datetime.date]:
+    """Return the OFF-shift dates for a user across [start, end] based on the rotation."""
+    from app.core.schedule.core import determine_shift_for_date
+
+    off: set[datetime.date] = set()
+    d = start
+    while d <= end:
+        shift, _ = determine_shift_for_date(d, user.rotation_person_id)
+        if shift and shift.code == "OFF":
+            off.add(d)
+        d += datetime.timedelta(days=1)
+    return off
 
 
 def count_vacation_days_used(
@@ -224,7 +249,7 @@ def count_vacation_days_used(
     for cal_year in calendar_years:
         weeks = vacation_json.get(str(cal_year), []) or []
         if weeks:
-            week_based += _count_weekdays_in_vacation_weeks(weeks, cal_year, year_start, year_end)
+            week_based += _count_weekdays_in_vacation_weeks(weeks, cal_year, year_start, year_end, off_dates)
 
     # Count day-level vacation from absences (exclude OFF-shift days)
     absences = (
@@ -386,6 +411,12 @@ def calculate_vacation_balance(user, target_year: int, db, off_dates: set[dateti
 
     # Vacation year boundaries
     year_start, year_end = get_vacation_year_boundaries(target_year, start_month)
+
+    # Count vacation in scheduled work days: both week-based and day-level vacation exclude
+    # the employee's OFF-shift days. Compute the OFF days for the vacation year when the
+    # caller did not supply them, so every entry point counts consistently.
+    if off_dates is None:
+        off_dates = _scheduled_off_dates(user, year_start, year_end)
 
     # Earning year is the year before the vacation year
     earning_start, earning_end = get_vacation_year_boundaries(target_year - 1, start_month)

--- a/tests/test_vacation_week_count.py
+++ b/tests/test_vacation_week_count.py
@@ -1,0 +1,43 @@
+"""Tests for week-based vacation counting in scheduled work days (audit item B4).
+
+Decision: a week of vacation consumes only the days the employee was actually scheduled to
+work (all 7 weekdays minus OFF-shift days), consistent with day-level vacation. Without a
+known schedule it falls back to a flat Mon-Fri.
+"""
+
+import datetime
+
+from app.core.schedule.vacation import _count_weekdays_in_vacation_weeks
+
+YEAR = 2025
+WEEK = 10
+START = datetime.date(YEAR, 1, 1)
+END = datetime.date(YEAR, 12, 31)
+
+
+def _week_days(week: int) -> list[datetime.date]:
+    return [datetime.date.fromisocalendar(YEAR, week, i) for i in range(1, 8)]
+
+
+def test_without_off_dates_falls_back_to_mon_fri():
+    # No schedule known -> flat Monday..Friday = 5 days.
+    assert _count_weekdays_in_vacation_weeks([WEEK], YEAR, START, END, None) == 5
+
+
+def test_with_schedule_counts_only_worked_days():
+    days = _week_days(WEEK)
+    # Scheduled OFF on Mon, Sat, Sun -> 4 scheduled work days remain (incl. a worked weekend day).
+    off = {days[0], days[5], days[6]}
+    assert _count_weekdays_in_vacation_weeks([WEEK], YEAR, START, END, off) == 4
+
+
+def test_weekend_work_day_is_counted():
+    days = _week_days(WEEK)
+    # Off the whole standard week except a worked Sunday -> only that Sunday counts.
+    off = set(days) - {days[6]}  # everything off except Sunday
+    assert _count_weekdays_in_vacation_weeks([WEEK], YEAR, START, END, off) == 1
+
+
+def test_empty_off_set_counts_all_seven():
+    # An explicit empty set means "schedule known, no OFF days" -> all 7 days worked.
+    assert _count_weekdays_in_vacation_weeks([WEEK], YEAR, START, END, set()) == 7


### PR DESCRIPTION
## Problem

Week-based vacation was counted as a flat Monday-Friday (5 days/week) regardless of the employee's rotation, while day-level vacation (VACATION absences) already excluded OFF-shift days. For shift workers the two ways of registering vacation produced **different balances** for the same actual time off.

## Decision

Per product decision: a week of vacation should consume only the days the employee was actually scheduled to work.

## Fix

Week-based counting now consumes scheduled work days, all 7 weekdays in the week minus OFF-shift days, matching how day-level vacation is counted. `calculate_vacation_balance` computes the OFF days for the vacation year when the caller does not pass them, so every entry point (profile, admin, API, statistics) counts consistently. Without a known schedule the helper still falls back to Mon-Fri.

This changes displayed `used_days` / `remaining_days` for shift workers whose vacation weeks include scheduled OFF days or worked weekends, that is the intended correction.

## Tests

`tests/test_vacation_week_count.py`: fallback to Mon-Fri without a schedule, OFF-day exclusion, a worked weekend day counting, and the all-worked case. Full suite: 103 passed.