### PR TITLE
period.py: characterization net + extract day-person resolution (A1)

### DIFF
--- a/app/core/schedule/period.py
+++ b/app/core/schedule/period.py
@@ -944,31 +944,18 @@ def _build_person_day_basic(
     }
 
 
-def _populate_single_person_day(
-    day_info: dict,
-    current_day: datetime.date,
-    person_id: int,
-    ctx: DayLookupContext,
+def _resolve_day_person(
     session,
-    employment_start: datetime.date | None = None,
-) -> None:
-    """Populates detailed day info for a person."""
-    vacation_dates = ctx.vacation_dates
-    combined_ob_rules = ctx.combined_ob_rules
-    user_wages = ctx.user_wages
-    persons = ctx.persons
-    settings = ctx.settings
-    ot_shift_map = ctx.ot_shift_map
-    absence_map = ctx.absence_map
-    oncall_override_map = ctx.oncall_override_map
-    swap_map = ctx.swap_map
-    user_rates_map = ctx.user_rates_map
-    shift_override_map = ctx.shift_override_map
-    parental_dates = ctx.parental_dates
-    vacation_shift = get_vacation_shift()
-    shift_types = get_shift_types()
+    person_id: int,
+    current_day: datetime.date,
+    persons,
+    employment_start: datetime.date | None,
+) -> tuple[str, bool]:
+    """Resolve (person_name, show_off_before_employment) for a position on a date.
 
-    # Get person name via PersonHistory (shows correct person for this specific date)
+    Uses PersonHistory to find who held the position on the date, falling back to the current
+    holder, and flags before-employment when the date precedes their start (or the viewer's).
+    """
     person_name = persons[person_id - 1].name  # Default fallback
     show_off_before_employment = False
 
@@ -995,6 +982,38 @@ def _populate_single_person_day(
             if current_person:
                 person_name = current_person["name"]
         show_off_before_employment = True
+
+    return person_name, show_off_before_employment
+
+
+def _populate_single_person_day(
+    day_info: dict,
+    current_day: datetime.date,
+    person_id: int,
+    ctx: DayLookupContext,
+    session,
+    employment_start: datetime.date | None = None,
+) -> None:
+    """Populates detailed day info for a person."""
+    vacation_dates = ctx.vacation_dates
+    combined_ob_rules = ctx.combined_ob_rules
+    user_wages = ctx.user_wages
+    persons = ctx.persons
+    settings = ctx.settings
+    ot_shift_map = ctx.ot_shift_map
+    absence_map = ctx.absence_map
+    oncall_override_map = ctx.oncall_override_map
+    swap_map = ctx.swap_map
+    user_rates_map = ctx.user_rates_map
+    shift_override_map = ctx.shift_override_map
+    parental_dates = ctx.parental_dates
+    vacation_shift = get_vacation_shift()
+    shift_types = get_shift_types()
+
+    # Get person name via PersonHistory (shows correct person for this specific date)
+    person_name, show_off_before_employment = _resolve_day_person(
+        session, person_id, current_day, persons, employment_start
+    )
 
     # If date is before current person's employment, show OFF
     if show_off_before_employment:

--- a/tests/test_period_characterization.py
+++ b/tests/test_period_characterization.py
@@ -1,0 +1,105 @@
+"""Characterization tests for period.py day generation (A1, period.py phase).
+
+Pins the current per-day output of generate_month_data so the breakup of the oversized
+period.py functions (_populate_single_person_day, 424 lines) can be done safely. Like the
+summary net, it seeds its own rotation era and monkeypatches SessionLocal so the schedule is
+deterministic in any environment.
+"""
+
+import datetime
+import sys
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+# ruff: noqa: E402
+import app.database.database as db_module
+from app.core.schedule import clear_schedule_cache
+from app.core.schedule.period import generate_month_data
+from app.database.database import Base, RotationEra, User, UserRole, WageType
+
+TEST_DB_URL = "sqlite:///file:test_period_char_memdb?mode=memory&cache=shared&uri=true"
+test_engine = create_engine(TEST_DB_URL, connect_args={"check_same_thread": False, "uri": True})
+TestSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=test_engine)
+
+ERA_PATTERN = {
+    "1": ["OFF", "OFF", "OFF", "N3", "N3", "N3", "N3"],
+    "2": ["OFF", "OC", "N3", "N3", "N3", "N3", "OFF"],
+    "3": ["OFF", "OFF", "N1", "N1", "N1", "N1", "OC"],
+    "4": ["OC", "OFF", "N2", "N2", "N2", "OFF", "N1"],
+    "5": ["N1", "N1", "N1", "N1", "OC", "OFF", "OFF"],
+    "6": ["N3", "N3", "N3", "OFF", "OFF", "OC", "N3"],
+    "7": ["N3", "N3", "OFF", "OC", "N2", "N2", "N2"],
+    "8": ["N2", "N2", "OFF", "OFF", "N1", "N1", "N1"],
+    "9": ["N1", "N1", "OC", "OFF", "OFF", "N2", "N2"],
+    "10": ["N2", "N2", "N2", "N2", "OFF", "OFF", "OFF"],
+}
+
+
+@pytest.fixture
+def char_session(monkeypatch):
+    Base.metadata.create_all(bind=test_engine)
+    monkeypatch.setattr(db_module, "SessionLocal", TestSessionLocal)
+    clear_schedule_cache()
+
+    session = TestSessionLocal()
+    session.query(RotationEra).delete()
+    session.add(
+        RotationEra(
+            start_date=datetime.date(2026, 1, 2),
+            end_date=None,
+            rotation_length=10,
+            weeks_pattern=ERA_PATTERN,
+        )
+    )
+    session.add(
+        User(
+            id=1,
+            username="charuser",
+            password_hash="x",
+            name="Characterization",
+            role=UserRole.USER,
+            wage=30000,
+            wage_type=WageType.MONTHLY,
+            person_id=1,
+            tax_table="33",
+            vacation={},
+            must_change_password=0,
+        )
+    )
+    session.commit()
+
+    yield session
+
+    session.close()
+    clear_schedule_cache()
+    Base.metadata.drop_all(bind=test_engine)
+
+
+def test_month_day_count_and_first_day(char_session):
+    days = generate_month_data(2026, 3, 1, session=char_session)
+
+    assert len(days) == 31
+
+    first = days[0]
+    assert first["date"] == datetime.date(2026, 3, 1)
+    assert first["shift"].code == "N2"
+    assert first["original_shift"].code == "N2"
+    assert first["hours"] == 8.5
+    # Name resolution (the block being refactored) returns the position holder's name.
+    assert first["person_name"] == "Characterization"
+
+
+def test_month_total_scheduled_hours(char_session):
+    days = generate_month_data(2026, 3, 1, session=char_session)
+    assert round(sum(d.get("hours", 0.0) for d in days), 2) == 216.5
+
+
+def test_every_day_has_person_name(char_session):
+    days = generate_month_data(2026, 3, 1, session=char_session)
+    assert all(d["person_name"] == "Characterization" for d in days)


### PR DESCRIPTION
Begins the period.py phase of the A1 refactor (the largest function in the codebase, _populate_single_person_day at 424 lines).

## Safety net

Adds `tests/test_period_characterization.py`, pinning `generate_month_data`'s per-day output (day count, the first day's shift/hours/name, total scheduled hours) using the same seeded-era + monkeypatched-SessionLocal harness as the summary net. This protects period.py refactors directly, not only indirectly via the summary totals.

## Extraction

Pulls `_resolve_day_person` out of `_populate_single_person_day`: the PersonHistory name lookup and before-employment resolution, returning `(person_name, show_off_before_employment)`.

Behaviour-preserving: both the new period net and the existing summary golden master stay green. `_populate_single_person_day` drops from 424 to 401 lines, the first cut, with the net now in place for further extractions.

Full suite: 111 passed, ruff clean.