### PR TITLE
Extract absence-day handling from _populate_single_person_day (A1)

### DIFF
--- a/app/core/schedule/period.py
+++ b/app/core/schedule/period.py
@@ -986,6 +986,101 @@ def _resolve_day_person(
     return person_name, show_off_before_employment
 
 
+def _populate_absence_day(
+    day_info: dict,
+    absence,
+    current_day: datetime.date,
+    person_id: int,
+    person_name: str,
+    combined_ob_rules,
+    vacation_shift,
+    shift_types,
+) -> bool:
+    """Fill day_info for a day with an absence. Returns True when handled (caller stops).
+
+    Returns False when the absence does not resolve to a shift (e.g. a partial absence on a
+    day with no scheduled shift, or an unknown absence type), so the caller continues.
+    """
+    from app.database.database import AbsenceType
+
+    # Partial absence: calculate OB and hours for the worked portion of the shift
+    if (absence.left_at is not None or absence.arrived_at is not None) and absence.absence_type != AbsenceType.VACATION:
+        result = determine_shift_for_date(current_day, person_id)
+        if result and result[0]:
+            original_shift, rotation_week = result
+            hours, start, end = calculate_shift_hours(current_day, original_shift.code)
+            if start is not None:
+                if absence.left_at:
+                    left_time = datetime.datetime.strptime(absence.left_at, "%H:%M").time()
+                    end = datetime.datetime.combine(current_day, left_time)
+                    if end <= start:
+                        end = start
+                if absence.arrived_at:
+                    arrived_time = datetime.datetime.strptime(absence.arrived_at, "%H:%M").time()
+                    start = datetime.datetime.combine(current_day, arrived_time)
+                    if start >= end:
+                        start = end
+                hours = (end - start).total_seconds() / 3600.0
+                ob = calculate_ob_hours(start, end, combined_ob_rules) if original_shift.code != "OC" else {}
+            else:
+                ob = {}
+
+            day_info.update(
+                {
+                    "person_id": person_id,
+                    "person_name": person_name,
+                    "shift": original_shift,
+                    "original_shift": original_shift,
+                    "rotation_week": rotation_week,
+                    "hours": hours,
+                    "start": start,
+                    "end": end,
+                    "ob": ob,
+                    "oncall_pay": 0.0,
+                    "oncall_details": {},
+                    "ot_pay": 0.0,
+                    "ot_hours": 0.0,
+                    "ot_details": {},
+                    "partial_absence": absence,
+                }
+            )
+            return True
+
+    # VACATION absences use the SEM shift (same as week-based vacation)
+    # PARENTAL falls back to LEAVE shift since no dedicated shift type exists
+    if absence.absence_type == AbsenceType.VACATION:
+        absence_shift = vacation_shift
+    elif absence.absence_type == AbsenceType.PARENTAL:
+        absence_shift = next((s for s in shift_types if s.code == "LEAVE"), None)
+    else:
+        absence_shift = next((s for s in shift_types if s.code == absence.absence_type.value), None)
+    if absence_shift:
+        # Get original shift for coworker matching
+        result = determine_shift_for_date(current_day, person_id)
+        original_shift, rotation_week = result if result else (None, None)
+        day_info.update(
+            {
+                "person_id": person_id,
+                "person_name": person_name,
+                "shift": absence_shift,
+                "original_shift": original_shift,  # For coworker matching
+                "rotation_week": rotation_week,
+                "hours": 0.0,
+                "start": None,
+                "end": None,
+                "ob": {},
+                "oncall_pay": 0.0,
+                "oncall_details": {},
+                "ot_pay": 0.0,
+                "ot_hours": 0.0,
+                "ot_details": {},
+            }
+        )
+        return True
+
+    return False
+
+
 def _populate_single_person_day(
     day_info: dict,
     current_day: datetime.date,
@@ -1050,94 +1145,10 @@ def _populate_single_person_day(
 
         absence = session.query(Absence).filter(Absence.user_id == person_id, Absence.date == current_day).first()
 
-    if absence:
-        from app.database.database import AbsenceType
-
-        # Partial absence: calculate OB and hours for the worked portion of the shift
-        if (
-            absence.left_at is not None or absence.arrived_at is not None
-        ) and absence.absence_type != AbsenceType.VACATION:
-            result = determine_shift_for_date(current_day, person_id)
-            if result and result[0]:
-                original_shift, rotation_week = result
-                hours, start, end = calculate_shift_hours(current_day, original_shift.code)
-                if start is not None:
-                    if absence.left_at:
-                        left_time = datetime.datetime.strptime(absence.left_at, "%H:%M").time()
-                        end = datetime.datetime.combine(current_day, left_time)
-                        if end <= start:
-                            end = start
-                    if absence.arrived_at:
-                        arrived_time = datetime.datetime.strptime(absence.arrived_at, "%H:%M").time()
-                        start = datetime.datetime.combine(current_day, arrived_time)
-                        if start >= end:
-                            start = end
-                    hours = (end - start).total_seconds() / 3600.0
-                    ob = calculate_ob_hours(start, end, combined_ob_rules) if original_shift.code != "OC" else {}
-                else:
-                    ob = {}
-
-                day_info.update(
-                    {
-                        "person_id": person_id,
-                        "person_name": person_name,
-                        "shift": original_shift,
-                        "original_shift": original_shift,
-                        "rotation_week": rotation_week,
-                        "hours": hours,
-                        "start": start,
-                        "end": end,
-                        "ob": ob,
-                        "oncall_pay": 0.0,
-                        "oncall_details": {},
-                        "ot_pay": 0.0,
-                        "ot_hours": 0.0,
-                        "ot_details": {},
-                        "partial_absence": absence,
-                    }
-                )
-                return
-
-        # VACATION absences use the SEM shift (same as week-based vacation)
-        # PARENTAL falls back to LEAVE shift since no dedicated shift type exists
-        if absence.absence_type == AbsenceType.VACATION:
-            absence_shift = vacation_shift
-        elif absence.absence_type == AbsenceType.PARENTAL:
-            absence_shift = next((s for s in shift_types if s.code == "LEAVE"), None)
-        else:
-            absence_shift = next((s for s in shift_types if s.code == absence.absence_type.value), None)
-        if absence_shift:
-            shift = absence_shift
-            # Get original shift for coworker matching
-            result = determine_shift_for_date(current_day, person_id)
-            original_shift, rotation_week = result if result else (None, None)
-            hours, start, end = 0.0, None, None
-            ob = {}
-            oncall_pay = 0.0
-            oncall_details = {}
-            ot_pay = 0.0
-            ot_hours = 0.0
-            ot_details = {}
-
-            day_info.update(
-                {
-                    "person_id": person_id,
-                    "person_name": person_name,
-                    "shift": shift,
-                    "original_shift": original_shift,  # For coworker matching
-                    "rotation_week": rotation_week,
-                    "hours": hours,
-                    "start": start,
-                    "end": end,
-                    "ob": ob,
-                    "oncall_pay": oncall_pay,
-                    "oncall_details": oncall_details,
-                    "ot_pay": ot_pay,
-                    "ot_hours": ot_hours,
-                    "ot_details": ot_details,
-                }
-            )
-            return
+    if absence and _populate_absence_day(
+        day_info, absence, current_day, person_id, person_name, combined_ob_rules, vacation_shift, shift_types
+    ):
+        return
 
     # Kolla föräldraledighet (veckobaserad + dagsnivå via parental_dates)
     if parental_dates and current_day in parental_dates.get(person_id, set()):

--- a/tests/test_period_characterization.py
+++ b/tests/test_period_characterization.py
@@ -21,7 +21,7 @@ sys.path.insert(0, str(project_root))
 import app.database.database as db_module
 from app.core.schedule import clear_schedule_cache
 from app.core.schedule.period import generate_month_data
-from app.database.database import Base, RotationEra, User, UserRole, WageType
+from app.database.database import Absence, AbsenceType, Base, RotationEra, User, UserRole, WageType
 
 TEST_DB_URL = "sqlite:///file:test_period_char_memdb?mode=memory&cache=shared&uri=true"
 test_engine = create_engine(TEST_DB_URL, connect_args={"check_same_thread": False, "uri": True})
@@ -103,3 +103,30 @@ def test_month_total_scheduled_hours(char_session):
 def test_every_day_has_person_name(char_session):
     days = generate_month_data(2026, 3, 1, session=char_session)
     assert all(d["person_name"] == "Characterization" for d in days)
+
+
+def _day(days, d: datetime.date) -> dict:
+    return next(x for x in days if x["date"] == d)
+
+
+def test_full_day_sick_renders_absence_shift(char_session):
+    # 2026-03-01 is an N2 work day; a full sick day renders the SICK shift with no hours.
+    char_session.add(Absence(user_id=1, date=datetime.date(2026, 3, 1), absence_type=AbsenceType.SICK))
+    char_session.commit()
+
+    day = _day(generate_month_data(2026, 3, 1, session=char_session), datetime.date(2026, 3, 1))
+
+    assert day["shift"].code == "SICK"
+    assert day["hours"] == 0.0
+
+
+def test_partial_absence_renders_worked_portion(char_session):
+    # Leaving an 8.5h N2 shift at 20:00 leaves 6h worked, keeping the original shift.
+    char_session.add(Absence(user_id=1, date=datetime.date(2026, 3, 2), absence_type=AbsenceType.SICK, left_at="20:00"))
+    char_session.commit()
+
+    day = _day(generate_month_data(2026, 3, 1, session=char_session), datetime.date(2026, 3, 2))
+
+    assert day["shift"].code == "N2"
+    assert day["hours"] == 6.0
+    assert "partial_absence" in day


### PR DESCRIPTION
Continues the period.py phase of A1.

## Net extended first

Adds absence scenarios to the period characterization net, verified against the current code *before* refactoring:
- a full sick day renders the SICK shift with no hours;
- a partial absence (leaving early) keeps the original shift and the worked hours, with `partial_absence` set.

## Extraction

Pulls the ~84-line absence block out of `_populate_single_person_day` into **`_populate_absence_day`**, which handles partial and full-day absences and returns `True` when it filled the day (caller stops) or `False` when the absence does not resolve to a shift, faithfully preserving the original fall-through (e.g. a partial absence on a day with no scheduled shift, or an unknown absence type).

Behaviour-preserving: both the period net (incl. the new absence cases) and the summary golden master stay green. `_populate_single_person_day` drops from 401 to 317 lines.

Full suite: 113 passed, ruff clean.