### PR TITLE
Extract parental-leave day handling from _populate_single_person_day (A1)

### DIFF
--- a/app/core/schedule/period.py
+++ b/app/core/schedule/period.py
@@ -1081,6 +1081,43 @@ def _populate_absence_day(
     return False
 
 
+def _populate_parental_day(
+    day_info: dict,
+    current_day: datetime.date,
+    person_id: int,
+    person_name: str,
+    parental_dates,
+    shift_types,
+) -> bool:
+    """Fill day_info for a week-based parental-leave day (LEAVE shift). Returns True when handled."""
+    if not (parental_dates and current_day in parental_dates.get(person_id, set())):
+        return False
+    leave_shift = next((s for s in shift_types if s.code == "LEAVE"), None)
+    if not leave_shift:
+        return False
+    result = determine_shift_for_date(current_day, person_id)
+    original_shift, rotation_week = result if result else (None, None)
+    day_info.update(
+        {
+            "person_id": person_id,
+            "person_name": person_name,
+            "shift": leave_shift,
+            "original_shift": original_shift,
+            "rotation_week": rotation_week,
+            "hours": 0.0,
+            "start": None,
+            "end": None,
+            "ob": {},
+            "oncall_pay": 0.0,
+            "oncall_details": {},
+            "ot_pay": 0.0,
+            "ot_hours": 0.0,
+            "ot_details": {},
+        }
+    )
+    return True
+
+
 def _populate_single_person_day(
     day_info: dict,
     current_day: datetime.date,
@@ -1151,30 +1188,8 @@ def _populate_single_person_day(
         return
 
     # Kolla föräldraledighet (veckobaserad + dagsnivå via parental_dates)
-    if parental_dates and current_day in parental_dates.get(person_id, set()):
-        leave_shift = next((s for s in shift_types if s.code == "LEAVE"), None)
-        if leave_shift:
-            result = determine_shift_for_date(current_day, person_id)
-            original_shift, rotation_week = result if result else (None, None)
-            day_info.update(
-                {
-                    "person_id": person_id,
-                    "person_name": person_name,
-                    "shift": leave_shift,
-                    "original_shift": original_shift,
-                    "rotation_week": rotation_week,
-                    "hours": 0.0,
-                    "start": None,
-                    "end": None,
-                    "ob": {},
-                    "oncall_pay": 0.0,
-                    "oncall_details": {},
-                    "ot_pay": 0.0,
-                    "ot_hours": 0.0,
-                    "ot_details": {},
-                }
-            )
-            return
+    if _populate_parental_day(day_info, current_day, person_id, person_name, parental_dates, shift_types):
+        return
 
     # Kolla semester
     if vacation_shift and current_day in vacation_dates.get(person_id, set()):

--- a/tests/test_period_characterization.py
+++ b/tests/test_period_characterization.py
@@ -130,3 +130,16 @@ def test_partial_absence_renders_worked_portion(char_session):
     assert day["shift"].code == "N2"
     assert day["hours"] == 6.0
     assert "partial_absence" in day
+
+
+def test_week_based_parental_leave_renders_leave(char_session):
+    # Week-based parental leave (User.parental_leave JSON) renders LEAVE for the whole ISO week.
+    user = char_session.query(User).filter(User.id == 1).first()
+    user.parental_leave = {"2026": [11]}  # ISO week 11 = 9-15 March 2026
+    char_session.commit()
+
+    days = generate_month_data(2026, 3, 1, session=char_session)
+    leave_days = [d for d in days if d["shift"] and d["shift"].code == "LEAVE"]
+
+    assert len(leave_days) == 7
+    assert all(d["hours"] == 0.0 for d in leave_days)


### PR DESCRIPTION
Continues the period.py phase of A1.

- Adds a week-based parental-leave scenario to the period characterization net (User.parental_leave renders the LEAVE shift for the whole ISO week), verified against the current code before refactoring.
- Extracts `_populate_parental_day`, returning True when it filled the day so the caller stops.

Behaviour-preserving: both the period net and the summary golden master stay green. `_populate_single_person_day` drops from 317 to 295 lines.

Full suite: 114 passed, ruff clean.