### PR TITLE
Extract on-call pay computation from _populate_single_person_day (A1)

### DIFF
--- a/app/core/schedule/period.py
+++ b/app/core/schedule/period.py
@@ -1178,6 +1178,22 @@ def _resolve_effective_shift(
     return _with_ob(result[0], result[1])
 
 
+def _compute_oncall_pay(
+    shift, current_day, person_id, user_wages, settings, oncall_rate_override
+) -> tuple[float, dict]:
+    """On-call pay for a day. Returns (pay, details); (0.0, {}) for non-OC shifts."""
+    if not (shift and shift.code == "OC"):
+        return 0.0, {}
+    oncall_rules = get_oncall_rules(current_day.year)
+    oncall_calc = calculate_oncall_pay(
+        current_day,
+        user_wages.get(person_id, settings.monthly_salary),
+        oncall_rules,
+        rate_overrides=oncall_rate_override,
+    )
+    return oncall_calc["total_pay"], oncall_calc
+
+
 def _populate_single_person_day(
     day_info: dict,
     current_day: datetime.date,
@@ -1300,19 +1316,10 @@ def _populate_single_person_day(
                     ob = {}
 
     # Calculate on-call pay
-    oncall_pay = 0.0
-    oncall_details = {}
     _person_rates = (user_rates_map or {}).get(person_id) or {}
-    if shift and shift.code == "OC":
-        oncall_rules = get_oncall_rules(current_day.year)
-        oncall_calc = calculate_oncall_pay(
-            current_day,
-            user_wages.get(person_id, settings.monthly_salary),
-            oncall_rules,
-            rate_overrides=_person_rates.get("oncall"),
-        )
-        oncall_pay = oncall_calc["total_pay"]
-        oncall_details = oncall_calc
+    oncall_pay, oncall_details = _compute_oncall_pay(
+        shift, current_day, person_id, user_wages, settings, _person_rates.get("oncall")
+    )
 
     # Kolla övertid - både på aktuell dag (för visning) och föregående dag (för beredskap)
     ot_shift = None

--- a/tests/test_period_characterization.py
+++ b/tests/test_period_characterization.py
@@ -156,3 +156,12 @@ def test_week_based_vacation_renders_sem(char_session):
 
     assert len(sem_days) == 7
     assert all(d["hours"] == 0.0 for d in sem_days)
+
+
+def test_oncall_pay_per_day(char_session):
+    # The rotation has three OC days in March 2026; their on-call pay sums to a fixed total.
+    days = generate_month_data(2026, 3, 1, session=char_session)
+    oncall_days = [d for d in days if d["oncall_pay"] > 0]
+
+    assert len(oncall_days) == 3
+    assert round(sum(d["oncall_pay"] for d in days), 2) == 6082.0


### PR DESCRIPTION
Continues the period.py phase of A1.

- Adds an on-call scenario to the period characterization net (the rotation's three OC days in March 2026 sum to a fixed on-call total of 6082), verified against the current code before refactoring.
- Extracts **`_compute_oncall_pay`**, returning `(pay, details)` and `(0.0, {})` for non-OC shifts.

Behaviour-preserving: both nets stay green; the summary golden master already pins the same monthly on-call total, giving a second backstop.

This section (`_populate_single_person_day`) is the most entangled in the function. The on-call-override application and the overtime block mutate several shared variables and will be extracted in follow-ups, each with its own net scenario (they need OnCallOverride / OvertimeShift rows). This PR takes the cleanest self-contained piece.

Full suite: 116 passed, ruff clean.