### PR TITLE
Extract overtime pay computation from _populate_single_person_day (A1)

### DIFF
--- a/app/core/schedule/period.py
+++ b/app/core/schedule/period.py
@@ -1194,6 +1194,31 @@ def _compute_oncall_pay(
     return oncall_calc["total_pay"], oncall_calc
 
 
+def _compute_overtime_pay(
+    ot_shift, current_day, person_id, session, settings, ot_rate_override
+) -> tuple[float, float, dict]:
+    """Overtime pay/hours/details for an OT shift, using the historical wage for the date."""
+    from .wages import get_ot_hourly_rate_from_stored_wage, get_user_wage
+
+    wage_for_date = get_user_wage(session, person_id, settings.monthly_salary, effective_date=current_day)
+    hourly_rate = (
+        float(ot_rate_override)
+        if ot_rate_override is not None
+        else get_ot_hourly_rate_from_stored_wage(session, person_id, wage_for_date)
+    )
+    ot_hours = ot_shift.hours
+    ot_pay = hourly_rate * ot_hours
+    ot_details = {
+        "start_time": str(ot_shift.start_time),
+        "end_time": str(ot_shift.end_time),
+        "hours": ot_hours,
+        "pay": ot_pay,
+        "hourly_rate": hourly_rate,
+        "is_extension": ot_shift.is_extension,
+    }
+    return ot_pay, ot_hours, ot_details
+
+
 def _populate_single_person_day(
     day_info: dict,
     current_day: datetime.date,
@@ -1364,30 +1389,9 @@ def _populate_single_person_day(
     ot_details = {}
 
     if ot_shift:
-        # Calculate overtime pay using a temporal wage query
-        from .wages import get_ot_hourly_rate_from_stored_wage, get_user_wage
-
-        # Get raw stored wage for this date (temporal query)
-        wage_for_date = get_user_wage(session, person_id, settings.monthly_salary, effective_date=current_day)
-        _ot_custom = _person_rates.get("ot")
-        hourly_rate = (
-            float(_ot_custom)
-            if _ot_custom is not None
-            else get_ot_hourly_rate_from_stored_wage(session, person_id, wage_for_date)
+        ot_pay, ot_hours, ot_details = _compute_overtime_pay(
+            ot_shift, current_day, person_id, session, settings, _person_rates.get("ot")
         )
-
-        # Recalculate overtime pay based on historical wage
-        ot_hours = ot_shift.hours
-        ot_pay = hourly_rate * ot_hours
-
-        ot_details = {
-            "start_time": str(ot_shift.start_time),
-            "end_time": str(ot_shift.end_time),
-            "hours": ot_hours,
-            "pay": ot_pay,
-            "hourly_rate": hourly_rate,
-            "is_extension": ot_shift.is_extension,
-        }
 
         # Ersätt skift med OT för visning – men inte om det är en förlängning
         if not ot_shift.is_extension:

--- a/tests/test_period_characterization.py
+++ b/tests/test_period_characterization.py
@@ -21,7 +21,7 @@ sys.path.insert(0, str(project_root))
 import app.database.database as db_module
 from app.core.schedule import clear_schedule_cache
 from app.core.schedule.period import generate_month_data
-from app.database.database import Absence, AbsenceType, Base, RotationEra, User, UserRole, WageType
+from app.database.database import Absence, AbsenceType, Base, OvertimeShift, RotationEra, User, UserRole, WageType
 
 TEST_DB_URL = "sqlite:///file:test_period_char_memdb?mode=memory&cache=shared&uri=true"
 test_engine = create_engine(TEST_DB_URL, connect_args={"check_same_thread": False, "uri": True})
@@ -165,3 +165,25 @@ def test_oncall_pay_per_day(char_session):
 
     assert len(oncall_days) == 3
     assert round(sum(d["oncall_pay"] for d in days), 2) == 6082.0
+
+
+def test_overtime_day_renders_ot_shift_and_pay(char_session):
+    # A 4h non-extension OT shift renders the OT display shift and pays wage/72 per hour.
+    char_session.add(
+        OvertimeShift(
+            user_id=1,
+            date=datetime.date(2026, 3, 5),
+            start_time=datetime.time(8, 0),
+            end_time=datetime.time(12, 0),
+            hours=4.0,
+            ot_pay=0.0,
+            is_extension=False,
+        )
+    )
+    char_session.commit()
+
+    day = _day(generate_month_data(2026, 3, 1, session=char_session), datetime.date(2026, 3, 5))
+
+    assert day["shift"].code == "OT"
+    assert day["ot_hours"] == 4.0
+    assert round(day["ot_pay"], 2) == 1666.67


### PR DESCRIPTION
Continues the period.py phase of A1.

- Adds an overtime scenario to the period characterization net (a 4h non-extension OT shift renders the OT display shift and pays wage/72 per hour = 1666.67), verified against the current code before refactoring.
- Extracts **`_compute_overtime_pay`**, returning `(ot_pay, ot_hours, ot_details)` from a temporal wage query. The display-shift replacement (swapping in the OT shift, setting hours/start/end) stays inline since it mutates the shared shift state.

Behaviour-preserving: both nets stay green. `_populate_single_person_day` drops from 245 to 224 lines.

Full suite: 117 passed, ruff clean.