### PR TITLE
Extract on-call override application from _populate_single_person_day (A1)

### DIFF
--- a/app/core/schedule/period.py
+++ b/app/core/schedule/period.py
@@ -1219,6 +1219,30 @@ def _compute_overtime_pay(
     return ot_pay, ot_hours, ot_details
 
 
+def _apply_oncall_override(override, shift, hours, start, end, ob, shift_types):
+    """Apply a manual on-call override to the day's shift.
+
+    ADD replaces the shift with OC; REMOVE turns an OC shift into OFF. Returns the (possibly
+    modified) (shift, hours, start, end, ob); unchanged when there is no override.
+    """
+    if override is None:
+        return shift, hours, start, end, ob
+
+    from app.database.database import OnCallOverrideType
+
+    if override.override_type == OnCallOverrideType.ADD:
+        oc_shift = next((s for s in shift_types if s.code == "OC"), None)
+        if oc_shift:
+            return oc_shift, 0.0, None, None, {}  # OC har inga specifika tider
+    elif override.override_type == OnCallOverrideType.REMOVE:
+        if shift and shift.code == "OC":
+            off_shift = next((s for s in shift_types if s.code == "OFF"), None)
+            if off_shift:
+                return off_shift, 0.0, None, None, {}
+
+    return shift, hours, start, end, ob
+
+
 def _populate_single_person_day(
     day_info: dict,
     current_day: datetime.date,
@@ -1321,24 +1345,7 @@ def _populate_single_person_day(
             .first()
         )
 
-    if oncall_override:
-        from app.database.database import OnCallOverrideType
-
-        if oncall_override.override_type == OnCallOverrideType.ADD:
-            # Add on-call shift, replacing the regular shift
-            oc_shift = next((s for s in shift_types if s.code == "OC"), None)
-            if oc_shift:
-                shift = oc_shift
-                hours, start, end = 0.0, None, None  # OC har inga specifika tider
-                ob = {}
-        elif oncall_override.override_type == OnCallOverrideType.REMOVE:
-            # Ta bort OC-pass - om skiftet är OC, ersätt med OFF
-            if shift and shift.code == "OC":
-                off_shift = next((s for s in shift_types if s.code == "OFF"), None)
-                if off_shift:
-                    shift = off_shift
-                    hours, start, end = 0.0, None, None
-                    ob = {}
+    shift, hours, start, end, ob = _apply_oncall_override(oncall_override, shift, hours, start, end, ob, shift_types)
 
     # Calculate on-call pay
     _person_rates = (user_rates_map or {}).get(person_id) or {}

--- a/tests/test_period_characterization.py
+++ b/tests/test_period_characterization.py
@@ -21,7 +21,18 @@ sys.path.insert(0, str(project_root))
 import app.database.database as db_module
 from app.core.schedule import clear_schedule_cache
 from app.core.schedule.period import generate_month_data
-from app.database.database import Absence, AbsenceType, Base, OvertimeShift, RotationEra, User, UserRole, WageType
+from app.database.database import (
+    Absence,
+    AbsenceType,
+    Base,
+    OnCallOverride,
+    OnCallOverrideType,
+    OvertimeShift,
+    RotationEra,
+    User,
+    UserRole,
+    WageType,
+)
 
 TEST_DB_URL = "sqlite:///file:test_period_char_memdb?mode=memory&cache=shared&uri=true"
 test_engine = create_engine(TEST_DB_URL, connect_args={"check_same_thread": False, "uri": True})
@@ -187,3 +198,27 @@ def test_overtime_day_renders_ot_shift_and_pay(char_session):
     assert day["shift"].code == "OT"
     assert day["ot_hours"] == 4.0
     assert round(day["ot_pay"], 2) == 1666.67
+
+
+def test_oncall_override_add_creates_oc_day(char_session):
+    # Manually adding on-call on an OFF day turns it into an OC shift with on-call pay.
+    char_session.add(OnCallOverride(user_id=1, date=datetime.date(2026, 3, 6), override_type=OnCallOverrideType.ADD))
+    char_session.commit()
+
+    day = _day(generate_month_data(2026, 3, 1, session=char_session), datetime.date(2026, 3, 6))
+
+    assert day["shift"].code == "OC"
+    assert day["oncall_pay"] > 0
+
+
+def test_oncall_override_remove_clears_oc_day(char_session):
+    # Removing on-call on a rotation OC day turns it into OFF with no on-call pay.
+    char_session.add(
+        OnCallOverride(user_id=1, date=datetime.date(2026, 3, 17), override_type=OnCallOverrideType.REMOVE)
+    )
+    char_session.commit()
+
+    day = _day(generate_month_data(2026, 3, 1, session=char_session), datetime.date(2026, 3, 17))
+
+    assert day["shift"].code == "OFF"
+    assert day["oncall_pay"] == 0.0


### PR DESCRIPTION
Continues the period.py phase of A1.

- Adds on-call-override scenarios to the period characterization net (ADD on an OFF day becomes an OC day with on-call pay; REMOVE on a rotation OC day becomes OFF with no pay), verified against the current code before refactoring.
- Extracts **`_apply_oncall_override`**, returning the (possibly modified) `(shift, hours, start, end, ob)`, unchanged when there is no override.

Behaviour-preserving: both nets stay green. `_populate_single_person_day` drops from 224 to 207 lines.

Full suite: 119 passed, ruff clean.