### PR TITLE
Reuse _resolve_day_person in _build_person_day_basic (A1)

### DIFF
--- a/app/core/schedule/period.py
+++ b/app/core/schedule/period.py
@@ -659,33 +659,8 @@ def _build_person_day_basic(
     vacation_shift = get_vacation_shift()
     rotation_length = get_rotation_length_for_date(date)
 
-    # Get person name via PersonHistory (shows correct person for this specific date)
-    # Also check if date is before any person's employment at this position
-    person_name = persons[person_id - 1].name  # Default fallback
-    show_off_before_employment = False
-
-    if session:
-        # First check who held this position on this specific date
-        date_person = get_person_for_date(session, person_id, date)
-        if date_person:
-            # Someone held this position on this date - use their name, no OFF
-            person_name = date_person["name"]
-        else:
-            # No one held the position on this date - check if there's a future person
-            current_person = get_current_person_for_position(session, person_id)
-            if current_person:
-                person_name = current_person["name"]
-                # Only show OFF if date is before the current person's employment started
-                if current_person.get("effective_from") and date < current_person["effective_from"]:
-                    show_off_before_employment = True
-
-    # Override: if the viewing user hasn't started yet, show before_employment
-    if employment_start and date < employment_start and not show_off_before_employment:
-        if session:
-            current_person = get_current_person_for_position(session, person_id)
-            if current_person:
-                person_name = current_person["name"]
-        show_off_before_employment = True
+    # Get person name via PersonHistory and whether the date precedes employment.
+    person_name, show_off_before_employment = _resolve_day_person(session, person_id, date, persons, employment_start)
 
     # If date is before current person's employment, show OFF
     if show_off_before_employment:

--- a/tests/test_period_characterization.py
+++ b/tests/test_period_characterization.py
@@ -20,7 +20,7 @@ sys.path.insert(0, str(project_root))
 # ruff: noqa: E402
 import app.database.database as db_module
 from app.core.schedule import clear_schedule_cache
-from app.core.schedule.period import generate_month_data
+from app.core.schedule.period import build_week_data, generate_month_data
 from app.database.database import (
     Absence,
     AbsenceType,
@@ -222,3 +222,13 @@ def test_oncall_override_remove_clears_oc_day(char_session):
 
     assert day["shift"].code == "OFF"
     assert day["oncall_pay"] == 0.0
+
+
+def test_build_week_data_basic(char_session):
+    # build_week_data feeds _build_person_day_basic (coworker matching); pin its per-day output.
+    days = build_week_data(2026, 11, person_id=1, session=char_session)
+
+    assert len(days) == 7
+    assert [d["shift"].code for d in days] == ["OFF", "OFF", "OFF", "N3", "N3", "N3", "N3"]
+    assert all(d["person_name"] == "Characterization" for d in days)
+    assert all(d["rotation_length"] == 10 for d in days)


### PR DESCRIPTION
Continues the period.py phase of A1, now removing duplication between the two day-builders rather than just extracting.

- Adds a `build_week_data` characterization net. `build_week_data` feeds `_build_person_day_basic` (used for coworker matching), which the `generate_month_data` net does not exercise. The test pins the week's shift codes, person names and rotation length.
- `_build_person_day_basic` duplicated the exact PersonHistory-name / before-employment block already extracted as `_resolve_day_person`. Replace it with a call to that helper.

Behaviour-preserving: both nets stay green. `_build_person_day_basic` drops from 303 to 278 lines and the duplicated resolution logic now lives in one tested place.

Full suite: 120 passed, ruff clean.