### PR TITLE
Add v0.24.1 changelog entry (payroll fixes + login security)

### DIFF
--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -15,6 +15,27 @@ router = APIRouter()
 
 VERSIONS = [
     {
+        "version": "0.24.1",
+        "date": "2026-05-31",
+        "entries": [
+            {
+                "type": "fix",
+                "sv": "Karens vid sjukfrånvaro som sträcker sig över ett månadsskifte beräknas nu korrekt; tidigare kunde hela karensavdraget (8h) dras en gång till i den nya månaden, vilket gav ett för stort löneavdrag",
+                "en": "Waiting-day (karens) deductions for sick leave that spans a month boundary are now calculated correctly; previously the full 8h waiting period could be charged again in the new month, over-deducting from pay",
+            },
+            {
+                "type": "fix",
+                "sv": "Veckobaserad semester räknas nu i schemalagda arbetsdagar (OFF-dagar exkluderas), precis som dag-baserad semester; tidigare räknades alltid 5 vardagar per vecka vilket gav fel semestersaldo för skiftarbetare",
+                "en": "Week-based vacation is now counted in scheduled work days (OFF days excluded), the same way as day-level vacation; previously a flat 5 weekdays per week were counted, giving an incorrect balance for shift workers",
+            },
+            {
+                "type": "förbättring",
+                "sv": "Säkerhet vid inloggning: skydd mot lösenordsgissning (tillfälligt kontolås efter upprepade misslyckade försök), obligatoriskt lösenordsbyte tvingas nu fram på alla sidor (inte bara direkt efter inloggning), och inloggningssvar avslöjar inte längre om ett användarnamn finns",
+                "en": "Login security: brute-force protection (temporary lockout after repeated failed attempts), the mandatory password change is now enforced on every page (not only right after login), and login responses no longer reveal whether a username exists",
+            },
+        ],
+    },
+    {
         "version": "0.24.0",
         "date": "2026-05-29",
         "entries": [


### PR DESCRIPTION
Patch release notes for the user-facing changes from this round.

**v0.24.1** (patch, consistent with the project convention where minor = new feature, patch = fix/improvement; this release has no new feature):

- **fix**: karens (waiting-day) deduction no longer recharged across a month boundary
- **fix**: week-based vacation counted in scheduled work days, correct for shift workers
- **förbättring**: login brute-force protection, mandatory password change enforced on every page, and the username-enumeration timing difference removed

Internal refactoring (A1) and dependency/deprecation cleanups are intentionally omitted from the user-facing changelog.

Note: the branch is named `chore/changelog-0.25.0` (leftover from an initial draft); the entry itself is correctly 0.24.1.

Full suite: 120 passed.