### PR TITLE
security: anonymize PII in data/persons.json

### DIFF
--- a/data/persons.json
+++ b/data/persons.json
@@ -1,9 +1,9 @@
 [
     {
         "id": 1,
-        "username": "exkaau",
-        "name": "Al-Amin",
-        "wage": 37000,
+        "username": "user01",
+        "name": "Person 1",
+        "wage": 30000,
         "vacation": {
             "2026": [],
             "2027": [],
@@ -12,9 +12,9 @@
     },
     {
         "id": 2,
-        "username": "jqu453",
-        "name": "Adriana",
-        "wage": 31500,
+        "username": "user02",
+        "name": "Person 2",
+        "wage": 30000,
         "vacation": {
             "2026": [],
             "2027": [],
@@ -23,9 +23,9 @@
     },
     {
         "id": 3,
-        "username": "gjc023",
-        "name":  "Christopher",
-        "wage": 47000,
+        "username": "user03",
+        "name": "Person 3",
+        "wage": 30000,
         "vacation": {
             "2026": [],
             "2027": [],
@@ -34,9 +34,9 @@
     },
     {
         "id": 4,
-        "username": "tbz193",
-        "name":  "Ahmed",
-        "wage": 27000,
+        "username": "user04",
+        "name": "Person 4",
+        "wage": 30000,
         "vacation": {
             "2026": [],
             "2027": [],
@@ -45,9 +45,9 @@
     },
     {
         "id": 5,
-        "username": "isa082",
-        "name":  "Isak",
-        "wage": 42000,
+        "username": "user05",
+        "name": "Person 5",
+        "wage": 30000,
         "vacation": {
             "2026": [],
             "2027": [],
@@ -56,9 +56,9 @@
     },
     {
         "id": 6,
-        "username": "ddf412",
-        "name":  "Kalle",
-        "wage": 37000,
+        "username": "user06",
+        "name": "Person 6",
+        "wage": 30000,
         "vacation": {
             "2026": [],
             "2027": [],
@@ -67,9 +67,9 @@
     },
     {
         "id": 7,
-        "username": "pnf956",
-        "name":  "Marcus",
-        "wage": 27000,
+        "username": "user07",
+        "name": "Person 7",
+        "wage": 30000,
         "vacation": {
             "2026": [],
             "2027": [],
@@ -78,9 +78,9 @@
     },
     {
         "id": 8,
-        "username": "yzt114",
-        "name":  "Okan",
-        "wage": 39500,
+        "username": "user08",
+        "name": "Person 8",
+        "wage": 30000,
         "vacation": {
             "2026": [],
             "2027": [],
@@ -89,9 +89,9 @@
     },
     {
         "id": 9,
-        "username": "uyr674",
-        "name":  "Pierre",
-        "wage": 37000,
+        "username": "user09",
+        "name": "Person 9",
+        "wage": 30000,
         "vacation": {
             "2026": [],
             "2027": [],
@@ -100,9 +100,9 @@
     },
     {
         "id": 10,
-        "username": "mgu229",
-        "name":  "Robin",
-        "wage": 37000,
+        "username": "user10",
+        "name": "Person 10",
+        "wage": 30000,
         "vacation": {
             "2026": [],
             "2027": [],
@@ -111,9 +111,9 @@
     },
     {
         "id": 11,
-        "username": "bwx196",
-        "name":  "Rickard",
-        "wage": 37000,
+        "username": "user11",
+        "name": "Person 11",
+        "wage": 30000,
         "vacation": {
             "2026": [],
             "2027": [],


### PR DESCRIPTION
## Summary
`data/persons.json` was tracked in this public repository containing real employee names mapped to monthly salaries. This replaces the contents with generic placeholders (`Person 1`..`Person 11`, neutral wage, opaque usernames).

## Why this is safe for production
The running app reads names from the database / PersonHistory and wages from the `User` table whenever a DB session exists (always, in the live app). `persons.json` is only used as a session-less fallback and as the rotation-structure seed, so anonymizing it does not change production behaviour. Verified locally: app imports cleanly and the full test suite passes (120 passed).

The file stays tracked (rather than removed and git-ignored) because production deploys via `git checkout <tag>` and the test suite imports it at module load; untracking it would risk the app losing a required file on the next deploy.

## Important: this does not remove the data from git history
The real names and salaries remain in previous commits of this public repo. A working-tree change cannot undo that. Removing them requires a history rewrite (git filter-repo + force push) or making the repository private. That decision is intentionally left out of this PR.