### PR TITLE
chore: regenerate requirements.txt to sync with pyproject

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ anyio==4.12.1
     # via
     #   starlette
     #   watchfiles
-bcrypt==4.0.1
+bcrypt==4.3.0
     # via
     #   passlib
     #   periodical (pyproject.toml)
@@ -26,6 +26,8 @@ cryptography==46.0.3
     # via python-jose
 ecdsa==0.19.1
     # via python-jose
+et-xmlfile==2.0.0
+    # via openpyxl
 fastapi==0.128.0
     # via
     #   periodical (pyproject.toml)
@@ -78,7 +80,7 @@ six==1.17.0
     #   python-dateutil
 sqlalchemy==2.0.46
     # via periodical (pyproject.toml)
-starlette==0.52.1
+starlette==0.50.0
     # via fastapi
 typing-extensions==4.15.0
     # via


### PR DESCRIPTION
## Summary
The compiled lockfile had drifted from `pyproject.toml`. Regenerating with `pip-compile --output-file=requirements.txt pyproject.toml` corrects three inconsistencies:

- **bcrypt 4.0.1 -> 4.3.0** to match the pyproject constraint `>=4.3,<4.4` (bumped in Feb 2026 but never recompiled). CI installed 4.3 via the project extras while the lockfile still pinned 4.0.1, so tests ran against a different bcrypt than a locked install would use.
- **starlette 0.52.1 -> 0.50.0**. fastapi 0.128.0 requires `starlette<0.51.0`, so the previous pin violated fastapi's own constraint.
- **Add et-xmlfile==2.0.0**, a required dependency of openpyxl that was missing from the lockfile.

## Testing
- Installed the regenerated lockfile into the venv (bcrypt 4.3.0, starlette 0.50.0 confirmed)
- Auth smoke test: password hash + verify works with passlib + bcrypt 4.3 (the passlib `__about__` lookup is trapped internally and does not affect functionality)
- Full test suite: 120 passed