### PR TITLE
chore: hold Renovate Python version updates on 3.12

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,11 @@
   },
   "packageRules": [
     {
+      "description": "Hold the Python version on 3.12 to match the production venv and the compiled lockfile. Bump deliberately as a coordinated change (prod venv + recompile + CI + Dockerfile).",
+      "matchDepNames": ["python"],
+      "enabled": false
+    },
+    {
       "matchManagers": ["pip-compile"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "minor and patch dependencies",


### PR DESCRIPTION
## Summary
Renovate proposed bumping Python from 3.12 to 3.14 (#246, now closed). This adds a Renovate `packageRule` that disables automatic updates to the `python` dependency, so CI (`setup-python`) and the Dockerfile base image stay on 3.12.

## Why
- Production runs Python 3.12 via the deployment venv (`deploy.sh`, not Docker), and `requirements.txt` is compiled for 3.12. CI and the Dockerfile should match the version actually run in production.
- There is no technical blocker on 3.14 itself: passlib's removed-`crypt` import is guarded with try/except and the app uses the bcrypt backend. But an isolated CI/Dockerfile bump would reintroduce test-vs-production version drift.
- Moving to a newer Python should be a coordinated change: upgrade the production venv, recompile the lockfile on the new version, then bump CI and the Dockerfile together. At that point this rule can be relaxed.

## Effect
Renovate will stop opening Python version-bump PRs until this rule is removed or changed.