### PR TITLE
Allow manually changing the shift worked on a day

### DIFF
--- a/app/core/translations.py
+++ b/app/core/translations.py
@@ -33,6 +33,7 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "changelog_current_version": "Aktuell version",
         "changelog_latest": "SENASTE",
         "changelog_type_nyhet": "Nyhet",
+        "changelog_type_forbattring": "Förbättring",
         "changelog_type_fix": "Fix",
         # ── Login ──────────────────────────────────────────────────
         "login_title": "Logga in",
@@ -1016,6 +1017,7 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "changelog_current_version": "Current version",
         "changelog_latest": "LATEST",
         "changelog_type_nyhet": "New",
+        "changelog_type_forbattring": "Improvement",
         "changelog_type_fix": "Fix",
         # ── Login ──────────────────────────────────────────────────
         "login_title": "Log in",

--- a/app/core/translations.py
+++ b/app/core/translations.py
@@ -531,6 +531,9 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "day_shift_override_remove": "Ta bort",
         "day_shift_override_remove_confirm": "Ta bort det manuella passet?",
         "day_shift_override_add": "Tilldela pass",
+        "day_shift_override_change": "Byt pass",
+        "day_shift_override_revert": "Återställ till rotation",
+        "day_shift_override_revert_confirm": "Återställa passet till rotationen?",
         "day_shift_override_label": "Pass",
         "day_shift_override_note": "Manuellt tilldelat pass åsidosätter rotationen och visas som ett ordinarie pass.",
         # ── Day pay override ───────────────────────────────────────
@@ -1511,6 +1514,9 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "day_shift_override_remove": "Remove",
         "day_shift_override_remove_confirm": "Remove the manual shift assignment?",
         "day_shift_override_add": "Assign shift",
+        "day_shift_override_change": "Change shift",
+        "day_shift_override_revert": "Revert to rotation",
+        "day_shift_override_revert_confirm": "Revert the shift to the rotation?",
         "day_shift_override_label": "Shift",
         "day_shift_override_note": "A manually assigned shift overrides the rotation and appears as a regular shift.",
         # ── Day pay override ───────────────────────────────────────

--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -15,6 +15,17 @@ router = APIRouter()
 
 VERSIONS = [
     {
+        "version": "0.25.0",
+        "date": "2026-06-02",
+        "entries": [
+            {
+                "type": "ny funktion",
+                "sv": "Dagvy: byt vilket pass du jobbar på en dag – 'Manuellt pass' går nu att använda även på dagar där rotationen redan ger ett arbetspass (N1/N2/N3), inte bara på lediga dagar och jourdagar; välj nytt pass i listan eller återställ till rotationen, och bytet slår igenom i alla vyer",
+                "en": "Day view: change which shift you work on a day – 'Manual shift' can now be used on days where the rotation already assigns a working shift (N1/N2/N3), not only on days off and on-call days; pick a new shift from the list or revert to the rotation, and the change is applied across all views",
+            },
+        ],
+    },
+    {
         "version": "0.24.1",
         "date": "2026-05-31",
         "entries": [

--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -19,7 +19,7 @@ VERSIONS = [
         "date": "2026-06-02",
         "entries": [
             {
-                "type": "ny funktion",
+                "type": "nyhet",
                 "sv": "Dagvy: byt vilket pass du jobbar på en dag – 'Manuellt pass' går nu att använda även på dagar där rotationen redan ger ett arbetspass (N1/N2/N3), inte bara på lediga dagar och jourdagar; välj nytt pass i listan eller återställ till rotationen, och bytet slår igenom i alla vyer",
                 "en": "Day view: change which shift you work on a day – 'Manual shift' can now be used on days where the rotation already assigns a working shift (N1/N2/N3), not only on days off and on-call days; pick a new shift from the list or revert to the rotation, and the change is applied across all views",
             },

--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -51,7 +51,7 @@ VERSIONS = [
         "date": "2026-05-29",
         "entries": [
             {
-                "type": "ny funktion",
+                "type": "nyhet",
                 "sv": "Dagvy: manuell override av OB- och beredskapstimmar – klicka 'Redigera timmar' i lönesektionen för att justera antalet timmar per typ (t.ex. flytta 7h röd dag till vardag); lönen räknas om automatiskt med befintliga taxor och overriden slår igenom i alla vyer (dagvy, månadsvy, löneunderlag)",
                 "en": "Day view: manual override of OB and on-call hours – click 'Edit hours' in the pay section to adjust the number of hours per type (e.g. move 7h public holiday to weekday rate); pay is recalculated automatically using existing rates and the override is applied consistently across all views (day view, month view, pay basis)",
             },
@@ -73,7 +73,7 @@ VERSIONS = [
         "date": "2026-05-28",
         "entries": [
             {
-                "type": "ny funktion",
+                "type": "nyhet",
                 "sv": "Frånvaro: stöd för sen ankomst – man kan nu registrera klockslag för när man kom till jobbet ('Kom HH:MM') på samma sätt som man redan kunde registrera tidig avgång; frånvarotimmar, OB och löneunderlag räknas om korrekt för den jobbade delen av passet",
                 "en": "Absence: support for late arrival – it is now possible to register the time of arrival ('Kom HH:MM') the same way early departure was already supported; absent hours, OB and salary base are recalculated correctly for the worked portion of the shift",
             },
@@ -89,7 +89,7 @@ VERSIONS = [
         "date": "2026-05-27",
         "entries": [
             {
-                "type": "ny funktion",
+                "type": "nyhet",
                 "sv": "Månadsvy: ny toggle i detaljerad breakdown – 'Visa OB per kalenderdag' fördelar OB och ÖT på de kalenderdagar timmarna faktiskt faller på istället för att lägga allt på startdagen; nattpass som sträcker sig över midnatt visas uppdelade",
                 "en": "Month view: new toggle in the detailed breakdown – 'Show OB per calendar day' distributes OB and OT hours across the calendar days they actually fall on instead of attributing everything to the shift start day; night shifts crossing midnight are shown split accordingly",
             },

--- a/app/templates/changelog.html
+++ b/app/templates/changelog.html
@@ -24,6 +24,8 @@
                 <li style="display: flex; gap: 0.6rem; align-items: baseline;">
                     {% if entry.type == "nyhet" %}
                     <span style="flex-shrink: 0; font-size: 0.7rem; font-weight: 700; letter-spacing: 0.05em; background: var(--muted-bg, #2a2a35); color: var(--accent, #4f9cf9); padding: 0.1rem 0.45rem; border-radius: 4px; text-transform: uppercase;">{{ t.changelog_type_nyhet }}</span>
+                    {% elif entry.type == "förbättring" %}
+                    <span style="flex-shrink: 0; font-size: 0.7rem; font-weight: 700; letter-spacing: 0.05em; background: var(--muted-bg, #2a2a35); color: var(--success, #7bd389); padding: 0.1rem 0.45rem; border-radius: 4px; text-transform: uppercase;">{{ t.changelog_type_forbattring }}</span>
                     {% else %}
                     <span style="flex-shrink: 0; font-size: 0.7rem; font-weight: 700; letter-spacing: 0.05em; background: var(--muted-bg, #2a2a35); color: var(--warning, #e0a84e); padding: 0.1rem 0.45rem; border-radius: 4px; text-transform: uppercase;">{{ t.changelog_type_fix }}</span>
                     {% endif %}

--- a/app/templates/day.html
+++ b/app/templates/day.html
@@ -543,9 +543,10 @@
             {% endif %}
         {% endif %}
 
-        {# Manuellt pass – visa om override finns, eller om personen är OFF/OC och saknar frånvaro #}
+        {# Manuellt pass – byt/tilldela vilket pass man jobbar på en dag #}
         {% if user and (user.id == person_id or user.id == 0) %}
-            {% if shift_override or (not absence and shift and shift.code in ('OFF', 'OC')) %}
+            {% if shift_override or (not absence and shift and shift.code in ('N1', 'N2', 'N3', 'OFF', 'OC')) %}
+                {% set is_work_shift = shift and shift.code in ('N1', 'N2', 'N3') %}
                 <h3>{{ t.day_shift_override_title }}</h3>
 
                 {% if shift_override %}
@@ -554,7 +555,6 @@
                             <thead>
                                 <tr>
                                     <th>{{ t.day_shift_override_current }}</th>
-                                    <th></th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -562,36 +562,39 @@
                                     <td>
                                         <span class="badge" style="background: #3b82f6; color: white;">{{ shift_override.shift_code }}</span>
                                     </td>
-                                    <td>
-                                        <form method="POST" action="/shift-override/{{ shift_override.id }}/delete" style="display: inline;">
-                                            <button type="submit" class="btn btn-danger" onclick="return confirm('{{ t.day_shift_override_remove_confirm }}')">{{ t.day_shift_override_remove }}</button>
-                                        </form>
-                                    </td>
                                 </tr>
                             </tbody>
                         </table>
                     </div>
-                {% else %}
-                    <form method="POST" action="/shift-override/add">
-                        <input type="hidden" name="user_id" value="{{ person_id }}">
-                        <input type="hidden" name="date" value="{{ date }}">
-
-                        <div class="form-row">
-                            <div class="form-group">
-                                <label for="shift_code">{{ t.day_shift_override_label }}</label>
-                                <select id="shift_code" name="shift_code" required>
-                                    <option value="N1">N1 – {{ t.handover_morning }}</option>
-                                    <option value="N2">N2 – {{ t.handover_evening }}</option>
-                                    <option value="N3">N3 – {{ t.handover_night }}</option>
-                                </select>
-                            </div>
-                        </div>
-
-                        <button type="submit" class="btn btn-primary">{{ t.day_shift_override_add }}</button>
-                    </form>
-
-                    <p class="info-text">{{ t.day_shift_override_note }}</p>
                 {% endif %}
+
+                <form method="POST" action="/shift-override/add">
+                    <input type="hidden" name="user_id" value="{{ person_id }}">
+                    <input type="hidden" name="date" value="{{ date }}">
+
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label for="shift_code">{{ t.day_shift_override_label }}</label>
+                            <select id="shift_code" name="shift_code" required>
+                                <option value="N1"{% if shift and shift.code == 'N1' %} selected{% endif %}>N1 – {{ t.handover_morning }}</option>
+                                <option value="N2"{% if shift and shift.code == 'N2' %} selected{% endif %}>N2 – {{ t.handover_evening }}</option>
+                                <option value="N3"{% if shift and shift.code == 'N3' %} selected{% endif %}>N3 – {{ t.handover_night }}</option>
+                            </select>
+                        </div>
+                    </div>
+
+                    <button type="submit" class="btn btn-primary">
+                        {%- if shift_override or is_work_shift %}{{ t.day_shift_override_change }}{% else %}{{ t.day_shift_override_add }}{% endif -%}
+                    </button>
+                </form>
+
+                {% if shift_override %}
+                    <form method="POST" action="/shift-override/{{ shift_override.id }}/delete" style="margin-top: 0.75rem;">
+                        <button type="submit" class="btn btn-danger" onclick="return confirm('{{ t.day_shift_override_revert_confirm }}')">{{ t.day_shift_override_revert }}</button>
+                    </form>
+                {% endif %}
+
+                <p class="info-text">{{ t.day_shift_override_note }}</p>
             {% endif %}
         {% endif %}
 


### PR DESCRIPTION
## Summary

Adds the ability to manually change which shift you work on a given day, not just on OFF/on-call days.

Previously the "Manual shift" section in the day view only appeared on days where the rotation left you OFF or on-call. On a day where the rotation already assigned a working shift (N1/N2/N3), there was no way to switch it from the UI, and when an override existed you could only delete it.

## Changes

- **`app/templates/day.html`**: The manual shift section now also shows on working days (N1/N2/N3). A single form always renders a shift dropdown pre-selected to the current shift, with a dynamic Change/Assign button, plus a Revert to rotation button when an override exists.
- **`app/core/translations.py`**: New keys (sv + en): `day_shift_override_change`, `day_shift_override_revert`, `day_shift_override_revert_confirm`.

No database or route changes were needed. The backend already supported this through the upserting `/shift-override/add` route, and overrides are applied centrally so the change propagates to day, period, year and statistics views.

## Testing

- Verified manually in the app.
- Template compiles cleanly; ruff and ruff format pass.