### PR TITLE
chore: add coverage gate, LICENSE and SECURITY.md, trim ops changelog entry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,5 @@ jobs:
           SECRET_KEY: "test_secret_key_for_ci"
           PRODUCTION: "false"
         run: |
-          pytest
+          # Fail the build if coverage drops below the floor (guards against regression, not a target)
+          pytest --cov=app --cov-report=term-missing --cov-fail-under=45

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,18 @@
+Copyright (c) 2026 Kalle Lodin
+
+All rights reserved.
+
+This software and its associated source code, documentation, and data files
+(the "Software") are the private property of the copyright holder. The Software
+is published publicly for reference and transparency only.
+
+No permission is granted to any person or organization to use, copy, modify,
+merge, publish, distribute, sublicense, or sell copies of the Software, in
+whole or in part, without the prior written permission of the copyright holder.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it
+privately so it can be fixed before any public disclosure.
+
+Use GitHub's private vulnerability reporting: open the repository's **Security**
+tab and click **Report a vulnerability**. This creates a private advisory that
+is visible only to the maintainer.
+
+Please do **not** open a public issue, pull request, or discussion for security
+problems.
+
+When reporting, please include:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce, or a proof of concept
+- Any relevant logs, requests, or affected endpoints
+
+You can expect an initial acknowledgement within a few days. Once the issue is
+confirmed and fixed, the advisory will be published and credit given to the
+reporter unless anonymity is requested.
+
+## Scope
+
+This policy covers the application code in this repository. Issues in
+third-party dependencies should be reported to the respective upstream
+projects; if a dependency vulnerability affects this application, a report here
+is still welcome so the dependency can be updated.

--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -767,11 +767,6 @@ VERSIONS = [
                 "sv": "Komplett frånvarohantering med karens och OB-justering",
                 "en": "Complete absence tracking with deductible and OB adjustment",
             },
-            {
-                "type": "nyhet",
-                "sv": "Automatisk databasbackup vid driftsättning",
-                "en": "Automatic database backup on deployment",
-            },
         ],
     },
     {


### PR DESCRIPTION
## Summary
Bundles the remaining repo-hygiene findings from the audit.

### CI coverage gate
The test step now runs `pytest --cov=app --cov-report=term-missing --cov-fail-under=45`. Current coverage is ~48%, so the floor guards against regression without failing the build today. Raise the threshold as coverage improves.

### LICENSE
Adds a proprietary (all-rights-reserved) LICENSE. A public repo with no license is legally "all rights reserved" but ambiguous to visitors; this states it explicitly. Proprietary is the reversible default for an internal tool (it can be opened later; an open license cannot easily be revoked).

### SECURITY.md
Adds a security policy directing reporters to GitHub private vulnerability reporting (Security tab -> Report a vulnerability) instead of a public issue. No personal contact details are published.

### Changelog cleanup
Removes "Automatic database backup on deployment" from the user-facing changelog. Like the earlier DB-schema entry, it is ops/infra detail with no user-facing action.

## Testing
- CI command run locally: 124 passed, total coverage 47.72% (above the 45% floor)
- ruff clean
- changelog imports cleanly

## Note
GitHub private vulnerability reporting must be enabled in repo settings (Settings -> Security -> Private vulnerability reporting) for the SECURITY.md flow to work.