### PR TITLE
test: add unit tests for core business logic, raise coverage 48% to 52%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,4 @@ jobs:
           PRODUCTION: "false"
         run: |
           # Fail the build if coverage drops below the floor (guards against regression, not a target)
-          pytest --cov=app --cov-report=term-missing --cov-fail-under=45
+          pytest --cov=app --cov-report=term-missing --cov-fail-under=50

--- a/tests/test_core_helpers_validators.py
+++ b/tests/test_core_helpers_validators.py
@@ -1,0 +1,244 @@
+"""Unit tests for small pure helpers: time_utils, validators and helpers.
+
+These guard authorization rules, date validation and overtime time parsing,
+which sit on hot paths (every protected route, every OT calculation).
+"""
+
+import datetime
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from app.core.helpers import (
+    can_see_data_for_date,
+    can_see_salary,
+    contrast_color,
+    require_own_or_admin,
+    strip_salary_data,
+    strip_year_summary,
+)
+from app.core.time_utils import parse_ot_times
+from app.core.validators import validate_date_params, validate_person_id
+from app.database.database import PersonHistory, UserRole
+
+# --- time_utils.parse_ot_times -------------------------------------------------
+
+
+def _ot(start, end):
+    return SimpleNamespace(start_time=start, end_time=end)
+
+
+class TestParseOtTimes:
+    def test_string_hh_mm(self):
+        start, end = parse_ot_times(_ot("06:00", "14:00"), datetime.date(2026, 1, 1))
+        assert start == datetime.datetime(2026, 1, 1, 6, 0)
+        assert end == datetime.datetime(2026, 1, 1, 14, 0)
+
+    def test_string_hh_mm_ss(self):
+        start, end = parse_ot_times(_ot("06:00:30", "14:00:45"), datetime.date(2026, 1, 1))
+        assert start.second == 30
+        assert end.second == 45
+
+    def test_time_objects_accepted(self):
+        start, end = parse_ot_times(_ot(datetime.time(22, 0), datetime.time(6, 0)), datetime.date(2026, 1, 1))
+        # End <= start, so the shift crosses midnight onto the next day.
+        assert end == datetime.datetime(2026, 1, 2, 6, 0)
+        assert end > start
+
+    def test_empty_string_raises(self):
+        with pytest.raises(ValueError, match="empty"):
+            parse_ot_times(_ot("", "14:00"), datetime.date(2026, 1, 1))
+
+    def test_invalid_format_raises(self):
+        with pytest.raises(ValueError, match="Invalid OT"):
+            parse_ot_times(_ot("25:99", "14:00"), datetime.date(2026, 1, 1))
+
+    def test_unsupported_type_raises(self):
+        with pytest.raises(ValueError, match="Unsupported"):
+            parse_ot_times(_ot(600, "14:00"), datetime.date(2026, 1, 1))
+
+
+# --- validators ----------------------------------------------------------------
+
+
+class TestValidatePersonId:
+    @pytest.mark.parametrize("pid", [1, 5, 10])
+    def test_valid(self, pid):
+        assert validate_person_id(pid) == pid
+
+    @pytest.mark.parametrize("pid", [0, 11, -1])
+    def test_invalid_raises_404(self, pid):
+        with pytest.raises(HTTPException) as exc:
+            validate_person_id(pid)
+        assert exc.value.status_code == 404
+
+
+class TestValidateDateParams:
+    def test_full_date_returned(self):
+        assert validate_date_params(2026, 2, 15) == datetime.date(2026, 2, 15)
+
+    def test_year_month_only_returns_none(self):
+        assert validate_date_params(2026, 3, None) is None
+
+    def test_year_only_returns_none(self):
+        assert validate_date_params(2026, None, None) is None
+
+    def test_day_without_month_is_400(self):
+        with pytest.raises(HTTPException) as exc:
+            validate_date_params(2026, None, 5)
+        assert exc.value.status_code == 400
+
+    def test_impossible_date_is_400(self):
+        with pytest.raises(HTTPException) as exc:
+            validate_date_params(2026, 2, 30)
+        assert exc.value.status_code == 400
+
+    def test_invalid_month_is_400(self):
+        with pytest.raises(HTTPException) as exc:
+            validate_date_params(2026, 13, None)
+        assert exc.value.status_code == 400
+
+
+# --- helpers -------------------------------------------------------------------
+
+
+class TestRequireOwnOrAdmin:
+    def test_admin_passes_for_any_target(self):
+        admin = SimpleNamespace(role=UserRole.ADMIN, id=99)
+        assert require_own_or_admin(admin, target_user_id=1) is None
+
+    def test_owner_passes(self):
+        user = SimpleNamespace(role=UserRole.USER, id=7)
+        assert require_own_or_admin(user, target_user_id=7) is None
+
+    def test_other_user_forbidden(self):
+        user = SimpleNamespace(role=UserRole.USER, id=7)
+        with pytest.raises(HTTPException) as exc:
+            require_own_or_admin(user, target_user_id=8)
+        assert exc.value.status_code == 403
+
+
+class TestContrastColor:
+    def test_empty_defaults_to_white(self):
+        assert contrast_color("") == "#fff"
+
+    def test_light_background_gets_black_text(self):
+        assert contrast_color("#ffffff") == "#000"
+
+    def test_dark_background_gets_white_text(self):
+        assert contrast_color("#000000") == "#fff"
+
+    def test_three_char_hex_is_expanded(self):
+        assert contrast_color("#fff") == "#000"
+
+    def test_invalid_hex_defaults_to_white(self):
+        assert contrast_color("#zzzzzz") == "#fff"
+
+
+class TestCanSeeSalary:
+    def test_anonymous_denied(self):
+        assert can_see_salary(None, 1) is False
+
+    def test_admin_allowed(self):
+        admin = SimpleNamespace(role=UserRole.ADMIN, rotation_person_id=None)
+        assert can_see_salary(admin, 5) is True
+
+    def test_user_own_position_allowed(self):
+        user = SimpleNamespace(role=UserRole.USER, rotation_person_id=3)
+        assert can_see_salary(user, 3) is True
+
+    def test_user_other_position_denied(self):
+        user = SimpleNamespace(role=UserRole.USER, rotation_person_id=3)
+        assert can_see_salary(user, 4) is False
+
+
+class TestStripSalaryData:
+    def test_nulls_out_salary_fields_and_day_breakdowns(self):
+        data = {
+            "brutto_pay": 100,
+            "netto_pay": 80,
+            "ob_pay": {"OB1": 5},
+            "ob_hours": {"OB1": 2},
+            "total_ob": 5,
+            "days": [{"ob_pay": {"OB1": 5}, "ob_hours": {"OB1": 2}, "other": "kept"}],
+        }
+        result = strip_salary_data(data)
+        assert result["brutto_pay"] is None
+        assert result["netto_pay"] is None
+        assert result["ob_pay"] == {}
+        assert result["total_ob"] is None
+        assert result["days"][0]["ob_pay"] == {}
+        assert result["days"][0]["other"] == "kept"
+        # Original input must not be mutated.
+        assert data["brutto_pay"] == 100
+
+    def test_handles_missing_days_key(self):
+        result = strip_salary_data({"brutto_pay": 1, "netto_pay": 1, "total_ob": 1})
+        assert "days" not in result
+
+
+class TestStripYearSummary:
+    def test_nulls_out_all_aggregate_fields(self):
+        summary = {
+            "total_netto": 1,
+            "total_brutto": 2,
+            "total_ob": 3,
+            "avg_netto": 4,
+            "avg_brutto": 5,
+            "avg_ob": 6,
+            "ob_hours_by_code": {"OB1": 1},
+            "ob_pay_by_code": {"OB1": 1},
+            "total_ob_hours": 10,
+            "keep_me": "yes",
+        }
+        result = strip_year_summary(summary)
+        assert all(
+            result[k] is None
+            for k in ["total_netto", "total_brutto", "total_ob", "avg_netto", "avg_brutto", "avg_ob", "total_ob_hours"]
+        )
+        assert result["ob_hours_by_code"] == {}
+        assert result["keep_me"] == "yes"
+
+
+class TestCanSeeDataForDate:
+    def test_anonymous_denied(self):
+        assert can_see_data_for_date(None, 1, datetime.date(2026, 2, 15), None) is False
+
+    def test_admin_allowed_without_db_lookup(self):
+        admin = SimpleNamespace(role=UserRole.ADMIN, id=99)
+        # Passing None as session is fine: admins short-circuit before any query.
+        assert can_see_data_for_date(admin, 6, datetime.date(2026, 2, 15), None) is True
+
+    def test_user_who_held_position_allowed(self, test_db):
+        test_db.add(
+            PersonHistory(
+                user_id=6,
+                person_id=6,
+                name="Kalle",
+                username="kalle",
+                is_active=1,
+                effective_from=datetime.date(2026, 1, 2),
+                effective_to=datetime.date(2026, 3, 31),
+            )
+        )
+        test_db.commit()
+        user = SimpleNamespace(role=UserRole.USER, id=6)
+        assert can_see_data_for_date(user, 6, datetime.date(2026, 2, 15), test_db) is True
+
+    def test_user_outside_employment_window_denied(self, test_db):
+        test_db.add(
+            PersonHistory(
+                user_id=6,
+                person_id=6,
+                name="Kalle",
+                username="kalle",
+                is_active=1,
+                effective_from=datetime.date(2026, 1, 2),
+                effective_to=datetime.date(2026, 3, 31),
+            )
+        )
+        test_db.commit()
+        user = SimpleNamespace(role=UserRole.USER, id=6)
+        # No PersonHistory record covers May, so access is denied.
+        assert can_see_data_for_date(user, 6, datetime.date(2026, 5, 1), test_db) is False

--- a/tests/test_oncall_intervals.py
+++ b/tests/test_oncall_intervals.py
@@ -1,0 +1,120 @@
+"""Unit tests for the pure interval helpers behind on-call (jour) compensation.
+
+These functions implement the priority-replacement geometry that all jour pay
+relies on:
+- _parse_time: 'HH:MM' parsing incl. the '24:00' midnight sentinel
+- _select_oncall_rules_for_date: weekday and specific-date matching
+- _get_rule_intervals_for_shift: clipping a rule onto a shift, incl. rules that
+  span midnight or end at 24:00
+- _subtract_covered_oncall: time not already claimed by higher-priority rules
+"""
+
+import datetime
+
+from app.core.oncall import (
+    OnCallRule,
+    _get_rule_intervals_for_shift,
+    _parse_time,
+    _select_oncall_rules_for_date,
+    _subtract_covered_oncall,
+)
+
+
+def _dt(day, hour, minute=0):
+    return datetime.datetime(2026, 1, day, hour, minute)
+
+
+class TestParseTime:
+    def test_regular_time(self):
+        assert _parse_time("08:30") == (8, 30)
+
+    def test_midnight_sentinel(self):
+        assert _parse_time("24:00") == (24, 0)
+
+    def test_zero(self):
+        assert _parse_time("00:00") == (0, 0)
+
+
+class TestSelectOncallRulesForDate:
+    def test_matches_by_weekday(self):
+        # 2026-01-05 is a Monday (weekday 0).
+        monday = OnCallRule(code="MON", label="m", days=[0], start_time="00:00", end_time="24:00")
+        sunday = OnCallRule(code="SUN", label="s", days=[6], start_time="00:00", end_time="24:00")
+        selected = _select_oncall_rules_for_date(datetime.date(2026, 1, 5), [monday, sunday])
+        assert [r.code for r in selected] == ["MON"]
+
+    def test_matches_by_specific_date(self):
+        special = OnCallRule(
+            code="SPECIAL", label="x", specific_dates=["2026-01-05"], start_time="00:00", end_time="24:00"
+        )
+        selected = _select_oncall_rules_for_date(datetime.date(2026, 1, 5), [special])
+        assert [r.code for r in selected] == ["SPECIAL"]
+
+    def test_accepts_datetime_as_well_as_date(self):
+        monday = OnCallRule(code="MON", label="m", days=[0], start_time="00:00", end_time="24:00")
+        selected = _select_oncall_rules_for_date(_dt(5, 12), [monday])
+        assert [r.code for r in selected] == ["MON"]
+
+    def test_no_match_returns_empty(self):
+        sunday = OnCallRule(code="SUN", label="s", days=[6], start_time="00:00", end_time="24:00")
+        assert _select_oncall_rules_for_date(datetime.date(2026, 1, 5), [sunday]) == []
+
+
+class TestGetRuleIntervalsForShift:
+    def test_simple_daytime_window(self):
+        rule = OnCallRule(code="D", label="d", days=[0], start_time="08:00", end_time="16:00")
+        intervals = _get_rule_intervals_for_shift(rule, _dt(5, 0), _dt(6, 0))
+        assert intervals == [(_dt(5, 8), _dt(5, 16))]
+
+    def test_full_day_window_with_24_00_end(self):
+        rule = OnCallRule(code="F", label="f", days=[0], start_time="00:00", end_time="24:00")
+        intervals = _get_rule_intervals_for_shift(rule, _dt(5, 0), _dt(6, 0))
+        assert intervals == [(_dt(5, 0), _dt(6, 0))]
+
+    def test_rule_spanning_midnight(self):
+        rule = OnCallRule(code="N", label="n", days=[0], start_time="22:00", end_time="06:00", spans_to_next_day=True)
+        # Monday rule across a Mon 00:00 -> Wed 00:00 shift: 22:00 Mon to 06:00 Tue.
+        intervals = _get_rule_intervals_for_shift(rule, _dt(5, 0), _dt(7, 0))
+        assert intervals == [(_dt(5, 22), _dt(6, 6))]
+
+    def test_ends_at_midnight_rolls_to_next_day(self):
+        rule = OnCallRule(code="E", label="e", days=[0], start_time="18:00", end_time="24:00")
+        intervals = _get_rule_intervals_for_shift(rule, _dt(5, 0), _dt(7, 0))
+        assert intervals == [(_dt(5, 18), _dt(6, 0))]
+
+    def test_rule_clipped_to_shift_boundaries(self):
+        # Rule covers all day, but the shift only runs 10:00-14:00.
+        rule = OnCallRule(code="F", label="f", days=[0], start_time="00:00", end_time="24:00")
+        intervals = _get_rule_intervals_for_shift(rule, _dt(5, 10), _dt(5, 14))
+        assert intervals == [(_dt(5, 10), _dt(5, 14))]
+
+    def test_non_matching_weekday_yields_no_intervals(self):
+        rule = OnCallRule(code="SUN", label="s", days=[6], start_time="08:00", end_time="16:00")
+        assert _get_rule_intervals_for_shift(rule, _dt(5, 0), _dt(6, 0)) == []
+
+
+class TestSubtractCoveredOncall:
+    def test_no_coverage_returns_whole_interval(self):
+        assert _subtract_covered_oncall(_dt(1, 0), _dt(1, 10), []) == [(_dt(1, 0), _dt(1, 10))]
+
+    def test_middle_coverage_splits_into_two_gaps(self):
+        covered = [(_dt(1, 2), _dt(1, 4))]
+        result = _subtract_covered_oncall(_dt(1, 0), _dt(1, 10), covered)
+        assert result == [(_dt(1, 0), _dt(1, 2)), (_dt(1, 4), _dt(1, 10))]
+
+    def test_full_coverage_returns_empty(self):
+        assert _subtract_covered_oncall(_dt(1, 0), _dt(1, 10), [(_dt(1, 0), _dt(1, 10))]) == []
+
+    def test_leading_coverage_leaves_tail(self):
+        covered = [(_dt(1, 0), _dt(1, 6))]
+        assert _subtract_covered_oncall(_dt(1, 0), _dt(1, 10), covered) == [(_dt(1, 6), _dt(1, 10))]
+
+    def test_unsorted_and_overlapping_coverage_is_merged(self):
+        # Out-of-order, overlapping covers should still leave only the true gaps.
+        covered = [(_dt(1, 6), _dt(1, 8)), (_dt(1, 1), _dt(1, 3)), (_dt(1, 2), _dt(1, 4))]
+        result = _subtract_covered_oncall(_dt(1, 0), _dt(1, 10), covered)
+        assert result == [(_dt(1, 0), _dt(1, 1)), (_dt(1, 4), _dt(1, 6)), (_dt(1, 8), _dt(1, 10))]
+
+    def test_coverage_outside_interval_is_ignored(self):
+        covered = [(_dt(2, 0), _dt(2, 5))]  # entirely after the interval
+        assert _subtract_covered_oncall(_dt(1, 0), _dt(1, 10), covered) == [(_dt(1, 0), _dt(1, 10))]

--- a/tests/test_rates.py
+++ b/tests/test_rates.py
@@ -1,0 +1,247 @@
+"""Unit tests for app.core.rates.
+
+Covers both the pure resolution helpers and the temporal RateHistory CRUD,
+which mirrors the wage-history pattern: a current snapshot on User.custom_rates
+plus an effective_from/effective_to audit trail.
+"""
+
+import datetime
+
+import pytest
+
+from app.core.rates import (
+    DEFAULT_ONCALL_RATES,
+    DEFAULT_VACATION_RATES,
+    _resolve_rates,
+    add_new_rates,
+    delete_rate_history,
+    get_all_defaults,
+    get_rate_history,
+    get_user_rates,
+)
+from app.core.utils import get_today
+from app.database.database import RateHistory, User, UserRole
+
+
+def _make_user(db, custom_rates=None, employment_start_date=None):
+    user = User(
+        username="rateuser",
+        password_hash="x",
+        name="Rate User",
+        role=UserRole.USER,
+        wage=30000,
+        vacation={},
+        must_change_password=0,
+        custom_rates=custom_rates,
+        employment_start_date=employment_start_date,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+class TestResolveRates:
+    def test_empty_custom_fills_all_defaults(self):
+        r = _resolve_rates({})
+        assert r["ob"] == {}
+        assert r["ot"] is None
+        assert r["oncall"] == DEFAULT_ONCALL_RATES
+        assert r["vacation"] == DEFAULT_VACATION_RATES
+        assert r["sick"] == {"ob_compensation": False}
+
+    def test_overrides_win_per_key_but_keep_other_defaults(self):
+        r = _resolve_rates({"oncall": {"OC_WEEKDAY": 80}})
+        assert r["oncall"]["OC_WEEKDAY"] == 80
+        # Unspecified on-call keys still fall back to the system default.
+        assert r["oncall"]["OC_WEEKEND"] == DEFAULT_ONCALL_RATES["OC_WEEKEND"]
+
+    def test_sick_ob_compensation_coerced_to_bool(self):
+        assert _resolve_rates({"sick": {"ob_compensation": 1}})["sick"]["ob_compensation"] is True
+        assert _resolve_rates({"sick": {}})["sick"]["ob_compensation"] is False
+
+    def test_ot_and_ob_passthrough(self):
+        r = _resolve_rates({"ot": 72, "ob": {"OB1": 500}})
+        assert r["ot"] == 72
+        assert r["ob"] == {"OB1": 500}
+
+
+class TestGetAllDefaults:
+    def test_returns_copies_not_references(self):
+        defaults = get_all_defaults()
+        defaults["oncall"]["OC_WEEKDAY"] = 999
+        # Mutating the returned dict must not corrupt the module-level default.
+        assert DEFAULT_ONCALL_RATES["OC_WEEKDAY"] != 999
+
+    def test_contains_expected_sections(self):
+        assert set(get_all_defaults()) == {"ob_divisors", "ot_divisor", "oncall", "vacation"}
+
+
+class TestGetUserRates:
+    def test_falls_back_to_custom_rates_without_date(self, test_db):
+        user = _make_user(test_db, custom_rates={"ot": 60})
+        assert get_user_rates(user)["ot"] == 60
+
+    def test_none_custom_rates_resolves_to_defaults(self, test_db):
+        user = _make_user(test_db, custom_rates=None)
+        assert get_user_rates(user)["oncall"] == DEFAULT_ONCALL_RATES
+
+    def test_temporal_query_returns_record_effective_on_date(self, test_db):
+        user = _make_user(test_db)
+        test_db.add(
+            RateHistory(
+                user_id=user.id,
+                rates={"ot": 50},
+                effective_from=datetime.date(2025, 1, 1),
+                effective_to=datetime.date(2025, 12, 31),
+            )
+        )
+        test_db.add(
+            RateHistory(
+                user_id=user.id,
+                rates={"ot": 70},
+                effective_from=datetime.date(2026, 1, 1),
+                effective_to=None,
+            )
+        )
+        test_db.commit()
+        assert get_user_rates(user, test_db, datetime.date(2025, 6, 1))["ot"] == 50
+        assert get_user_rates(user, test_db, datetime.date(2026, 6, 1))["ot"] == 70
+
+    def test_temporal_query_with_no_record_falls_back_to_custom(self, test_db):
+        user = _make_user(test_db, custom_rates={"ot": 99})
+        # No RateHistory rows exist, so it falls back to the User snapshot.
+        assert get_user_rates(user, test_db, datetime.date(2026, 6, 1))["ot"] == 99
+
+
+class TestAddNewRates:
+    def test_seeds_initial_history_from_existing_custom_rates(self, test_db):
+        user = _make_user(
+            test_db,
+            custom_rates={"ot": 55},
+            employment_start_date=datetime.date(2024, 1, 1),
+        )
+        new_from = get_today() + datetime.timedelta(days=30)
+        add_new_rates(test_db, user.id, {"ot": 65}, new_from)
+
+        history = test_db.query(RateHistory).filter(RateHistory.user_id == user.id).all()
+        # One seeded entry (old custom_rates) + one new future entry.
+        assert len(history) == 2
+        seed = next(h for h in history if h.rates == {"ot": 55})
+        assert seed.effective_from == datetime.date(2024, 1, 1)
+        # The seed got closed the day before the new entry starts.
+        assert seed.effective_to == new_from - datetime.timedelta(days=1)
+
+    def test_future_rate_does_not_update_current_snapshot(self, test_db):
+        user = _make_user(test_db, custom_rates={"ot": 40})
+        future = get_today() + datetime.timedelta(days=10)
+        add_new_rates(test_db, user.id, {"ot": 90}, future)
+        test_db.refresh(user)
+        # Future-dated rate must not overwrite the live snapshot yet.
+        assert user.custom_rates == {"ot": 40}
+
+    def test_current_rate_updates_snapshot(self, test_db):
+        user = _make_user(test_db, custom_rates={"ot": 40})
+        add_new_rates(test_db, user.id, {"ot": 100}, get_today())
+        test_db.refresh(user)
+        assert user.custom_rates == {"ot": 100}
+
+
+class TestGetRateHistory:
+    def test_status_classification(self, test_db):
+        user = _make_user(test_db)
+        today = get_today()
+        test_db.add_all(
+            [
+                RateHistory(
+                    user_id=user.id,
+                    rates={"ot": 1},
+                    effective_from=today - datetime.timedelta(days=400),
+                    effective_to=today - datetime.timedelta(days=200),
+                ),
+                RateHistory(
+                    user_id=user.id,
+                    rates={"ot": 2},
+                    effective_from=today - datetime.timedelta(days=199),
+                    effective_to=None,
+                ),
+                RateHistory(
+                    user_id=user.id,
+                    rates={"ot": 3},
+                    effective_from=today + datetime.timedelta(days=30),
+                    effective_to=None,
+                ),
+            ]
+        )
+        test_db.commit()
+        history = get_rate_history(test_db, user.id)
+        status_by_ot = {h["rates"]["ot"]: h["status"] for h in history}
+        assert status_by_ot == {1: "historical", 2: "current", 3: "future"}
+        # Newest first ordering by effective_from.
+        assert [h["rates"]["ot"] for h in history] == [3, 2, 1]
+
+
+class TestDeleteRateHistory:
+    def test_delete_reopens_previous_record(self, test_db):
+        user = _make_user(test_db)
+        prev = RateHistory(
+            user_id=user.id,
+            rates={"ot": 10},
+            effective_from=datetime.date(2025, 1, 1),
+            effective_to=datetime.date(2025, 12, 31),
+        )
+        latest = RateHistory(
+            user_id=user.id,
+            rates={"ot": 20},
+            effective_from=datetime.date(2026, 1, 1),
+            effective_to=None,
+        )
+        test_db.add_all([prev, latest])
+        test_db.commit()
+
+        delete_rate_history(test_db, latest.id, user.id)
+        test_db.refresh(prev)
+        # Deleting the open latest entry reopens the one it had closed.
+        assert prev.effective_to is None
+        assert test_db.query(RateHistory).filter(RateHistory.user_id == user.id).count() == 1
+
+    def test_delete_does_not_reopen_when_a_later_record_remains(self, test_db):
+        user = _make_user(test_db)
+        first = RateHistory(
+            user_id=user.id,
+            rates={"ot": 10},
+            effective_from=datetime.date(2025, 1, 1),
+            effective_to=datetime.date(2025, 6, 30),
+        )
+        middle = RateHistory(
+            user_id=user.id,
+            rates={"ot": 20},
+            effective_from=datetime.date(2025, 7, 1),
+            effective_to=datetime.date(2025, 12, 31),
+        )
+        last = RateHistory(
+            user_id=user.id,
+            rates={"ot": 30},
+            effective_from=datetime.date(2026, 1, 1),
+            effective_to=None,
+        )
+        test_db.add_all([first, middle, last])
+        test_db.commit()
+
+        # Delete the middle entry: 'first' should stay closed because 'last' is later.
+        delete_rate_history(test_db, middle.id, user.id)
+        test_db.refresh(first)
+        assert first.effective_to == datetime.date(2025, 6, 30)
+
+    def test_delete_missing_record_is_noop(self, test_db):
+        user = _make_user(test_db)
+        # Should not raise even when the id does not exist.
+        delete_rate_history(test_db, 9999, user.id)
+
+
+@pytest.mark.parametrize("invalid", [None, {}])
+def test_resolve_rates_handles_falsy_sections(invalid):
+    # ob/oncall/vacation given as None or {} must still resolve cleanly.
+    r = _resolve_rates({"ob": invalid, "oncall": invalid, "vacation": invalid})
+    assert r["oncall"] == DEFAULT_ONCALL_RATES
+    assert r["vacation"] == DEFAULT_VACATION_RATES

--- a/tests/test_utils_core.py
+++ b/tests/test_utils_core.py
@@ -1,0 +1,136 @@
+"""Unit tests for app.core.utils pure helpers.
+
+These functions are pure (no DB, no clock dependency except get_today) and drive
+date navigation, overtime shift labelling and salary payment dates, so their
+correctness is directly visible to users. Tests assert against the documented
+contract in each docstring.
+"""
+
+import datetime
+
+import pytest
+
+from app.core.utils import (
+    calculate_payment_date,
+    get_navigation_dates,
+    get_ot_shift_display_code,
+    get_safe_today,
+    get_today,
+)
+
+
+class TestGetToday:
+    def test_returns_a_date(self):
+        assert isinstance(get_today(), datetime.date)
+
+
+class TestGetSafeToday:
+    def test_returns_today_when_after_start(self):
+        start = datetime.date(2000, 1, 1)
+        assert get_safe_today(start) == get_today()
+
+    def test_clamps_to_start_when_today_is_earlier(self):
+        # A far-future rotation start can never be before today.
+        future_start = get_today() + datetime.timedelta(days=365)
+        assert get_safe_today(future_start) == future_start
+
+
+class TestGetNavigationDates:
+    def test_day_view_neighbours(self):
+        result = get_navigation_dates("day", datetime.date(2026, 3, 15))
+        assert result == {
+            "prev_year": 2026,
+            "prev_month": 3,
+            "prev_day": 14,
+            "next_year": 2026,
+            "next_month": 3,
+            "next_day": 16,
+        }
+
+    def test_day_view_crosses_month_boundary(self):
+        result = get_navigation_dates("day", datetime.date(2026, 1, 31))
+        assert (result["next_month"], result["next_day"]) == (2, 1)
+
+    def test_week_view_crosses_iso_year_boundary(self):
+        # 2025-12-29 is ISO week 1 of 2026; the previous week is week 52 of 2025.
+        result = get_navigation_dates("week", datetime.date(2025, 12, 29))
+        assert result["prev_year"] == 2025
+        assert result["prev_week"] == 52
+        assert result["next_year"] == 2026
+        assert result["next_week"] == 2
+
+    def test_month_view_december_wraps_to_january(self):
+        result = get_navigation_dates("month", datetime.date(2026, 12, 10))
+        assert (result["prev_year"], result["prev_month"]) == (2026, 11)
+        assert (result["next_year"], result["next_month"]) == (2027, 1)
+
+    def test_month_view_january_wraps_back(self):
+        result = get_navigation_dates("month", datetime.date(2026, 1, 10))
+        assert (result["prev_year"], result["prev_month"]) == (2025, 12)
+        assert (result["next_year"], result["next_month"]) == (2026, 2)
+
+    def test_year_view(self):
+        result = get_navigation_dates("year", datetime.date(2026, 6, 1))
+        assert result == {"prev_year": 2025, "next_year": 2027}
+
+    def test_unsupported_view_raises(self):
+        with pytest.raises(ValueError):
+            get_navigation_dates("decade", datetime.date(2026, 1, 1))  # type: ignore[arg-type]
+
+
+class TestGetOtShiftDisplayCode:
+    def test_none_returns_plain_ot(self):
+        assert get_ot_shift_display_code(None) == "OT"
+
+    @pytest.mark.parametrize(
+        "hour,expected",
+        [(6, "N1-OT"), (14, "N2-OT"), (22, "N3-OT"), (9, "OT"), (0, "OT")],
+    )
+    def test_datetime_maps_by_hour(self, hour, expected):
+        dt = datetime.datetime(2026, 1, 1, hour, 0)
+        assert get_ot_shift_display_code(dt) == expected
+
+    @pytest.mark.parametrize(
+        "iso,expected",
+        [
+            ("2026-01-01T06:00", "N1-OT"),
+            ("2026-01-01T14:30", "N2-OT"),
+            ("2026-01-01T22:15", "N3-OT"),
+            ("2026-01-01T08:00", "OT"),
+        ],
+    )
+    def test_iso_string_parsed_by_hour(self, iso, expected):
+        assert get_ot_shift_display_code(iso) == expected
+
+    def test_unparseable_string_falls_back_to_ot(self):
+        assert get_ot_shift_display_code("not-a-timestamp") == "OT"
+
+
+class TestCalculatePaymentDate:
+    def test_weekday_25th_is_used_directly(self):
+        # Jan 2026 work -> Feb 25 2026 (Wednesday).
+        assert calculate_payment_date(2026, 1) == datetime.date(2026, 2, 25)
+
+    def test_year_rolls_over_for_december_work(self):
+        # Dec 2025 work -> Jan 25 2026, which is a Sunday -> Friday Jan 23.
+        assert calculate_payment_date(2025, 12) == datetime.date(2026, 1, 23)
+
+    def test_saturday_25th_moves_to_friday(self):
+        # Mar 2026 work -> Apr 25 2026 (Saturday) -> Apr 24.
+        assert calculate_payment_date(2026, 3) == datetime.date(2026, 4, 24)
+
+    def test_sunday_25th_moves_to_friday(self):
+        # Sep 2026 work -> Oct 25 2026 (Sunday) -> Oct 23.
+        assert calculate_payment_date(2026, 9) == datetime.date(2026, 10, 23)
+
+    def test_november_work_uses_christmas_rule(self):
+        # Nov work -> Dec 25 (juldagen) is red, so payment moves to Dec 23.
+        assert calculate_payment_date(2026, 11) == datetime.date(2026, 12, 23)
+
+    def test_christmas_rule_when_dec_23_is_saturday(self):
+        # Dec 23 2017 is a Saturday -> move back to Friday Dec 22.
+        assert calculate_payment_date(2017, 11) == datetime.date(2017, 12, 22)
+
+    def test_christmas_rule_when_dec_23_is_sunday(self):
+        # Dec 23 2018 is a Sunday -> move back two days to Friday Dec 21.
+        assert calculate_payment_date(2018, 11) == datetime.date(2018, 12, 21)

--- a/tests/test_vacation_balance.py
+++ b/tests/test_vacation_balance.py
@@ -1,0 +1,319 @@
+"""Unit tests for vacation balance and pay calculations (Handelns avtal §9).
+
+Focus on the money-critical, schedule-independent units:
+- vacation-year boundaries and proration (§9 punkt 2)
+- counting consumed days from week-based and day-level sources
+- saved-day balances (semesterlag §18, 5-year validity)
+- closing a year (semesterersättning §9.5)
+- merging week-based + absence vacation dates
+
+The full schedule-dependent orchestration (calculate_vacation_balance,
+_scheduled_off_dates) is exercised elsewhere; here we inject a session so no
+rotation era is required.
+"""
+
+import datetime
+from types import SimpleNamespace
+
+from app.core.schedule.vacation import (
+    _calculate_prorated_days,
+    _count_weekdays_in_vacation_weeks,
+    calculate_vacation_balance,
+    calculate_vacation_pay,
+    close_vacation_year,
+    count_vacation_days_used,
+    get_parental_dates_for_year,
+    get_saved_days_balance,
+    get_vacation_dates_for_year,
+    get_vacation_year_boundaries,
+)
+from app.database.database import Absence, AbsenceType, User, UserRole
+
+
+def _make_user(db, **kwargs):
+    defaults = dict(
+        username="vacuser",
+        password_hash="x",
+        name="Vac User",
+        role=UserRole.USER,
+        wage=30000,
+        vacation={},
+        must_change_password=0,
+        is_active=True,
+    )
+    defaults.update(kwargs)
+    user = User(**defaults)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+class TestVacationYearBoundaries:
+    def test_april_break_spans_two_calendar_years(self):
+        start, end = get_vacation_year_boundaries(2026, 4)
+        assert start == datetime.date(2026, 4, 1)
+        assert end == datetime.date(2027, 3, 31)
+
+    def test_january_break_is_a_single_calendar_year(self):
+        start, end = get_vacation_year_boundaries(2026, 1)
+        assert start == datetime.date(2026, 1, 1)
+        assert end == datetime.date(2026, 12, 31)
+
+
+class TestCountWeekdaysInVacationWeeks:
+    def test_without_off_dates_counts_mon_to_fri(self):
+        ps, pe = datetime.date(2026, 1, 1), datetime.date(2026, 12, 31)
+        # Two full weeks, Mon-Fri each.
+        assert _count_weekdays_in_vacation_weeks([10, 11], 2026, ps, pe) == 10
+
+    def test_invalid_week_number_is_skipped(self):
+        ps, pe = datetime.date(2026, 1, 1), datetime.date(2026, 12, 31)
+        assert _count_weekdays_in_vacation_weeks([99], 2026, ps, pe) == 0
+
+    def test_with_off_dates_uses_all_seven_days_minus_off(self):
+        ps, pe = datetime.date(2026, 1, 1), datetime.date(2026, 12, 31)
+        off = {
+            datetime.date.fromisocalendar(2026, 10, 6),  # Sat
+            datetime.date.fromisocalendar(2026, 10, 7),  # Sun
+        }
+        # 7 scheduled days minus 2 OFF days = 5 consumed.
+        assert _count_weekdays_in_vacation_weeks([10], 2026, ps, pe, off) == 5
+
+    def test_days_outside_period_are_excluded(self):
+        # Period ends mid-week; only the in-window weekdays count.
+        ps = datetime.date(2026, 1, 1)
+        pe = datetime.date.fromisocalendar(2026, 10, 2)  # Tuesday of week 10
+        assert _count_weekdays_in_vacation_weeks([10], 2026, ps, pe) == 2
+
+
+class TestCalculateProratedDays:
+    def test_full_year_employment_via_half_year(self):
+        # Started 2025-10-01 within the 2025-04 -> 2026-03 earning year.
+        result = _calculate_prorated_days(
+            datetime.date(2025, 10, 1),
+            datetime.date(2025, 4, 1),
+            datetime.date(2026, 3, 31),
+            25,
+        )
+        # 182 employment days / 365 total, ceil(25 * 182 / 365) = 13.
+        assert result == 13
+
+    def test_start_after_earning_year_yields_zero(self):
+        assert (
+            _calculate_prorated_days(
+                datetime.date(2027, 1, 1),
+                datetime.date(2025, 4, 1),
+                datetime.date(2026, 3, 31),
+                25,
+            )
+            == 0
+        )
+
+    def test_start_before_earning_year_gives_full_entitlement(self):
+        # Employment predates the earning year -> clamped to full year -> all 25.
+        assert (
+            _calculate_prorated_days(
+                datetime.date(2020, 1, 1),
+                datetime.date(2025, 4, 1),
+                datetime.date(2026, 3, 31),
+                25,
+            )
+            == 25
+        )
+
+
+class TestGetSavedDaysBalance:
+    def test_sums_only_last_five_years_with_positive_saved(self):
+        user = SimpleNamespace(
+            vacation_saved={
+                "2019": {"saved": 9},  # older than 5 years -> excluded
+                "2022": {"saved": 3},
+                "2024": {"saved": 5},
+                "2025": {"saved": 0},  # zero -> excluded
+            }
+        )
+        result = get_saved_days_balance(user, 2026)
+        assert result["total_saved"] == 8
+        assert result["breakdown"] == [
+            {"year": "2022", "days": 3},
+            {"year": "2024", "days": 5},
+        ]
+
+    def test_no_saved_days_returns_empty(self):
+        user = SimpleNamespace(vacation_saved=None)
+        assert get_saved_days_balance(user, 2026) == {"total_saved": 0, "breakdown": []}
+
+
+class TestCountVacationDaysUsed:
+    def test_combines_week_based_and_day_level(self, test_db):
+        user = _make_user(test_db, person_id=1, vacation={"2026": [10]})
+        # One day-level VACATION absence outside week 10.
+        test_db.add(
+            Absence(
+                user_id=user.id,
+                date=datetime.date(2026, 6, 1),
+                absence_type=AbsenceType.VACATION,
+            )
+        )
+        test_db.commit()
+        result = count_vacation_days_used(
+            user_id=user.id,
+            year_start=datetime.date(2026, 1, 1),
+            year_end=datetime.date(2026, 12, 31),
+            db=test_db,
+            vacation_json=user.vacation,
+        )
+        assert result["week_based"] == 5  # week 10, Mon-Fri
+        assert result["day_level"] == 1
+        assert result["total"] == 6
+
+    def test_loads_vacation_json_from_db_when_not_passed(self, test_db):
+        user = _make_user(test_db, person_id=2, vacation={"2026": [11]})
+        result = count_vacation_days_used(
+            user_id=user.id,
+            year_start=datetime.date(2026, 1, 1),
+            year_end=datetime.date(2026, 12, 31),
+            db=test_db,
+        )
+        assert result["week_based"] == 5
+        assert result["total"] == 5
+
+
+class TestCloseVacationYear:
+    def test_saves_up_to_five_and_pays_out_rest(self, test_db):
+        user = _make_user(test_db, person_id=3, vacation_saved={})
+        pay = {"monthly_salary": 30000, "supplement_per_day": 100, "payout_pct": 0.046}
+        # 8 remaining -> save 5, pay out 3.
+        result = close_vacation_year(user, 2025, remaining_total=8, pay=pay, db=test_db)
+        assert result["saved"] == 5
+        assert result["paid_out"] == 3
+        # payout_per_day = 30000 * 0.046 + 100 = 1480.
+        assert result["payout_per_day"] == 1480.0
+        assert result["payout_amount"] == round(3 * 1480.0, 2)
+        # Persisted onto the user.
+        test_db.refresh(user)
+        assert user.vacation_saved["2025"]["saved"] == 5
+
+    def test_negative_remaining_saves_nothing(self, test_db):
+        user = _make_user(test_db, person_id=4, vacation_saved={})
+        pay = {"monthly_salary": 30000, "supplement_per_day": 0, "payout_pct": 0.046}
+        result = close_vacation_year(user, 2025, remaining_total=-2, pay=pay, db=test_db)
+        assert result["saved"] == 0
+        assert result["paid_out"] == 0
+        assert result["payout_amount"] == 0
+
+
+class TestGetVacationDatesForYear:
+    def test_merges_week_based_and_absences_and_skips_invalid_week(self, test_db):
+        user = _make_user(test_db, person_id=1, vacation={"2026": [10, 99]})
+        test_db.add(
+            Absence(
+                user_id=user.id,
+                date=datetime.date(2026, 8, 15),
+                absence_type=AbsenceType.VACATION,
+            )
+        )
+        test_db.commit()
+        per_person = get_vacation_dates_for_year(2026, session=test_db)
+        dates = per_person[1]
+        # Week 10 Monday is present, the invalid week 99 contributed nothing.
+        assert datetime.date.fromisocalendar(2026, 10, 1) in dates
+        # The day-level absence is merged in.
+        assert datetime.date(2026, 8, 15) in dates
+        # Week 10 has 7 days + 1 absence day = 8 dates total.
+        assert len(dates) == 8
+
+    def test_inactive_user_excluded(self, test_db):
+        _make_user(test_db, person_id=5, is_active=False, vacation={"2026": [12]})
+        per_person = get_vacation_dates_for_year(2026, session=test_db)
+        assert per_person[5] == set()
+
+
+class TestGetParentalDatesForYear:
+    def test_merges_week_based_and_absences(self, test_db):
+        user = _make_user(test_db, person_id=2, parental_leave={"2026": [20]})
+        test_db.add(
+            Absence(
+                user_id=user.id,
+                date=datetime.date(2026, 9, 3),
+                absence_type=AbsenceType.PARENTAL,
+            )
+        )
+        test_db.commit()
+        per_person = get_parental_dates_for_year(2026, session=test_db)
+        dates = per_person[2]
+        assert datetime.date.fromisocalendar(2026, 20, 1) in dates
+        assert datetime.date(2026, 9, 3) in dates
+        assert len(dates) == 8  # 7 days of week 20 + 1 absence day
+
+
+class TestCalculateVacationBalanceIntegration:
+    """End-to-end §9 pipeline against a real rotation era (rotation_session fixture)."""
+
+    def test_open_year_returns_projection_not_closed(self, rotation_session):
+        user = rotation_session.query(User).filter(User.id == 1).first()
+        user.vacation_year_start_month = 4
+        user.vacation_days_per_year = 25
+        user.employment_start_date = datetime.date(2020, 1, 1)
+        user.vacation = {}
+        user.vacation_saved = {}
+        rotation_session.commit()
+
+        # 2026 vacation year (Apr 2026 - Mar 2027) is still open as of the test clock.
+        balance = calculate_vacation_balance(user, 2026, rotation_session)
+
+        assert balance["entitled_days"] == 25
+        assert balance["is_first_year"] is False
+        assert balance["used_days"] == 0
+        assert balance["remaining_days"] == 25
+        assert balance["year_start"] == datetime.date(2026, 4, 1)
+        assert balance["year_end"] == datetime.date(2027, 3, 31)
+        # Open year: a projection is produced and the year is not yet closed.
+        assert balance["closed"] is None
+        assert balance["projection"] is not None
+        assert balance["projection"]["days_to_save"] == 5
+        assert balance["projection"]["days_to_pay_out"] == 20
+        assert "supplement_per_day" in balance["pay"]
+
+    def test_past_year_is_auto_closed(self, rotation_session):
+        user = rotation_session.query(User).filter(User.id == 1).first()
+        user.vacation_year_start_month = 4
+        user.vacation_days_per_year = 25
+        user.employment_start_date = datetime.date(2020, 1, 1)
+        user.vacation = {}
+        user.vacation_saved = {}
+        rotation_session.commit()
+
+        # 2023 vacation year ended long ago -> lazy auto-close on first access.
+        balance = calculate_vacation_balance(user, 2023, rotation_session)
+
+        assert balance["projection"] is None
+        assert balance["closed"] is not None
+        # 25 entitled, none used -> save 5, pay out 20.
+        assert balance["closed"]["saved"] == 5
+        assert balance["closed"]["paid_out"] == 20
+        # Persisted onto the user for future lookups.
+        rotation_session.refresh(user)
+        assert user.vacation_saved["2023"]["saved"] == 5
+
+
+class TestCalculateVacationPay:
+    def test_fixed_supplement_without_rotation_position(self, test_db):
+        # person_id outside 1..10 means rotation_person_id is out of range, so the
+        # variable-earnings loop is skipped and only the fixed part applies.
+        user = _make_user(test_db, person_id=99, wage=30000)
+        pay = calculate_vacation_pay(
+            user=user,
+            entitled_days=25,
+            earning_start=datetime.date(2025, 4, 1),
+            earning_end=datetime.date(2026, 3, 31),
+            db=test_db,
+            vacation_rates={"fixed_pct": 0.008, "variable_pct": 0.005, "payout_pct": 0.046},
+        )
+        # Fixed part = 30000 * 0.008 = 240, no variable earnings.
+        assert pay["fixed_per_day"] == 240.0
+        assert pay["variable_per_day"] == 0.0
+        assert pay["supplement_per_day"] == 240.0
+        assert pay["supplement_total"] == round(240.0 * 25, 2)
+        assert pay["payout_pct"] == 0.046

--- a/tests/test_wages.py
+++ b/tests/test_wages.py
@@ -1,0 +1,242 @@
+"""Unit tests for wage and absence-deduction calculations.
+
+Covers the schedule-independent units of app.core.schedule.wages:
+- absence deductions (karens budget, sjuklön, VAB/leave/parental)
+- partial-day absent-hour math (left_at / arrived_at)
+- temporal wage history (add/query/current) and monthly-equivalent wages
+"""
+
+import datetime
+from types import SimpleNamespace
+
+import pytest
+
+from app.core.schedule.wages import (
+    _MONTHLY_HOURS,
+    _get_user_id_for_position,
+    _get_wage_type,
+    add_new_wage,
+    calculate_absence_deduction,
+    get_absent_hours_for_absence,
+    get_absent_hours_from_left_at,
+    get_all_user_wages,
+    get_current_wage_record,
+    get_effective_monthly_wage,
+    get_ot_hourly_rate_from_stored_wage,
+    get_user_wage,
+    get_wage_history,
+)
+from app.core.utils import get_today
+from app.database.database import User, UserRole, WageHistory, WageType
+
+
+def _make_user(db, **kwargs):
+    defaults = dict(
+        username="wageuser",
+        password_hash="x",
+        name="Wage User",
+        role=UserRole.USER,
+        wage=30000,
+        vacation={},
+        must_change_password=0,
+        is_active=True,
+        wage_type=WageType.MONTHLY,
+    )
+    defaults.update(kwargs)
+    user = User(**defaults)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+HOURLY_WAGE = 30000 / _MONTHLY_HOURS
+
+
+class TestCalculateAbsenceDeduction:
+    def test_sick_with_karens_budget_distributes_waiting_then_sjuklon(self):
+        # 8h waiting-day budget remaining, 8.5h absent: 8h at full deduction,
+        # remaining 0.5h at the 20% sjuklön deduction.
+        result = calculate_absence_deduction(30000, "SICK", 8.5, absent_hours=8.5, karens_remaining=8.0)
+        expected = HOURLY_WAGE * 8 + HOURLY_WAGE * 0.5 * 0.2
+        assert result == pytest.approx(expected)
+
+    def test_sick_first_day_fallback_consumes_full_karens_budget(self):
+        # Legacy call path without karens_remaining and no partial hours.
+        result = calculate_absence_deduction(30000, "SICK", 8.5, is_first_sick_day=True)
+        assert result == pytest.approx(HOURLY_WAGE * 8.0)
+
+    def test_sick_subsequent_day_is_twenty_percent(self):
+        result = calculate_absence_deduction(30000, "SICK", 8.5)
+        assert result == pytest.approx(HOURLY_WAGE * 8.5 * 0.2)
+
+    def test_vab_is_full_deduction(self):
+        assert calculate_absence_deduction(30000, "VAB", 8.5) == pytest.approx(HOURLY_WAGE * 8.5)
+
+    def test_leave_is_full_deduction(self):
+        assert calculate_absence_deduction(30000, "LEAVE", 8.5) == pytest.approx(HOURLY_WAGE * 8.5)
+
+    @pytest.mark.parametrize("absence_type", ["OFF", "PARENTAL", "SOMETHING_ELSE"])
+    def test_no_deduction_types(self, absence_type):
+        assert calculate_absence_deduction(30000, absence_type, 8.5) == 0.0
+
+    def test_partial_absent_hours_override_shift_hours(self):
+        # Only 3 absent hours on a VAB day, regardless of the 8.5h shift.
+        result = calculate_absence_deduction(30000, "VAB", 8.5, absent_hours=3.0)
+        assert result == pytest.approx(HOURLY_WAGE * 3.0)
+
+
+class TestGetAbsentHoursFromLeftAt:
+    def test_leaving_early_counts_missed_tail(self):
+        end = datetime.datetime(2026, 1, 1, 22, 0)
+        assert get_absent_hours_from_left_at("18:00", end, 8.5) == 4.0
+
+    def test_leaving_at_or_after_end_is_zero(self):
+        end = datetime.datetime(2026, 1, 1, 22, 0)
+        assert get_absent_hours_from_left_at("23:00", end, 8.5) == 0.0
+
+    def test_missing_end_time_falls_back_to_shift_hours(self):
+        assert get_absent_hours_from_left_at("18:00", None, 8.5) == 8.5
+
+    def test_unparseable_left_at_falls_back(self):
+        end = datetime.datetime(2026, 1, 1, 22, 0)
+        assert get_absent_hours_from_left_at("nonsense", end, 8.5) == 8.5
+
+
+class TestGetAbsentHoursForAbsence:
+    def test_full_day_when_no_partial_markers(self):
+        ab = SimpleNamespace(left_at=None, arrived_at=None)
+        start = datetime.datetime(2026, 1, 1, 14, 0)
+        end = datetime.datetime(2026, 1, 1, 22, 0)
+        assert get_absent_hours_for_absence(ab, start, end, 8.0) == 8.0
+
+    def test_combines_late_arrival_and_early_leave(self):
+        # Shift 14-22; arrived 15:00 (missed 1h start) and left 21:00 (missed 1h tail).
+        ab = SimpleNamespace(left_at="21:00", arrived_at="15:00")
+        start = datetime.datetime(2026, 1, 1, 14, 0)
+        end = datetime.datetime(2026, 1, 1, 22, 0)
+        assert get_absent_hours_for_absence(ab, start, end, 8.0) == 2.0
+
+    def test_result_capped_at_shift_hours(self):
+        ab = SimpleNamespace(left_at="20:00", arrived_at="20:00")
+        start = datetime.datetime(2026, 1, 1, 14, 0)
+        end = datetime.datetime(2026, 1, 1, 22, 0)
+        # Overlapping missed windows must not exceed the shift length.
+        assert get_absent_hours_for_absence(ab, start, end, 8.0) <= 8.0
+
+
+class TestGetOtHourlyRate:
+    def test_monthly_divides_by_72(self):
+        assert get_ot_hourly_rate_from_stored_wage(None, 1, 30000) == pytest.approx(30000 / 72)
+
+    def test_hourly_returns_stored_rate_directly(self, test_db):
+        user = _make_user(test_db, wage_type=WageType.HOURLY, wage=200)
+        assert get_ot_hourly_rate_from_stored_wage(test_db, user.id, 200) == 200.0
+
+
+class TestGetWageType:
+    def test_no_session_defaults_to_monthly(self):
+        assert _get_wage_type(None, 1) == WageType.MONTHLY
+
+    def test_reads_user_wage_type(self, test_db):
+        user = _make_user(test_db, wage_type=WageType.HOURLY)
+        assert _get_wage_type(test_db, user.id) == WageType.HOURLY
+
+
+class TestGetUserWage:
+    def test_no_session_uses_fallback(self):
+        assert get_user_wage(None, 1, fallback=12345) == 12345
+
+    def test_current_wage_from_user_table(self, test_db):
+        user = _make_user(test_db, wage=41000)
+        assert get_user_wage(test_db, user.id) == 41000
+
+    def test_temporal_wage_from_history(self, test_db):
+        user = _make_user(test_db, wage=50000)
+        test_db.add_all(
+            [
+                WageHistory(
+                    user_id=user.id,
+                    wage=40000,
+                    effective_from=datetime.date(2025, 1, 1),
+                    effective_to=datetime.date(2025, 12, 31),
+                ),
+                WageHistory(
+                    user_id=user.id,
+                    wage=50000,
+                    effective_from=datetime.date(2026, 1, 1),
+                    effective_to=None,
+                ),
+            ]
+        )
+        test_db.commit()
+        assert get_user_wage(test_db, user.id, effective_date=datetime.date(2025, 6, 1)) == 40000
+        assert get_user_wage(test_db, user.id, effective_date=datetime.date(2026, 6, 1)) == 50000
+
+    def test_temporal_with_no_history_falls_back_to_user_wage(self, test_db):
+        user = _make_user(test_db, wage=33000)
+        assert get_user_wage(test_db, user.id, effective_date=datetime.date(2020, 1, 1)) == 33000
+
+
+class TestGetEffectiveMonthlyWage:
+    def test_monthly_returns_wage_as_is(self, test_db):
+        user = _make_user(test_db, wage=30000, wage_type=WageType.MONTHLY)
+        assert get_effective_monthly_wage(test_db, user.id) == 30000
+
+    def test_hourly_scales_to_monthly_equivalent(self, test_db):
+        user = _make_user(test_db, wage=200, wage_type=WageType.HOURLY)
+        # 200 * 173.33 so that monthly / 173.33 == 200.
+        assert get_effective_monthly_wage(test_db, user.id) == int(200 * _MONTHLY_HOURS)
+
+
+class TestGetUserIdForPosition:
+    def test_returns_holder_user_id(self, test_db):
+        _make_user(test_db, id=11, person_id=3)
+        assert _get_user_id_for_position(test_db, 3) == 11
+
+    def test_legacy_fallback_to_person_id(self, test_db):
+        # No user holds position 7 -> legacy user_id == person_id behavior.
+        assert _get_user_id_for_position(test_db, 7) == 7
+
+
+class TestGetAllUserWages:
+    def test_mixes_monthly_hourly_and_fallback(self, test_db):
+        _make_user(test_db, id=1, username="m", person_id=1, wage=30000, wage_type=WageType.MONTHLY)
+        _make_user(test_db, id=2, username="h", person_id=2, wage=200, wage_type=WageType.HOURLY)
+        wages = get_all_user_wages(test_db)
+        assert wages[1] == 30000
+        assert wages[2] == int(200 * _MONTHLY_HOURS)
+        # All rotation positions are present, missing ones filled with the default.
+        assert set(wages.keys()) >= set(range(1, 11))
+
+
+class TestWageHistoryCrud:
+    def test_add_new_wage_closes_previous_and_updates_snapshot(self, test_db):
+        user = _make_user(test_db, wage=30000)
+        # First entry (current).
+        add_new_wage(test_db, user.id, 30000, datetime.date(2024, 1, 1))
+        # Raise effective today so the live snapshot updates.
+        add_new_wage(test_db, user.id, 35000, get_today())
+
+        history = get_wage_history(test_db, user.id)
+        assert [h["wage"] for h in history] == [35000, 30000]  # newest first
+        # Previous entry got an end date; newest is open/current.
+        assert history[0]["is_current"] is True
+        assert history[1]["is_current"] is False
+        test_db.refresh(user)
+        assert user.wage == 35000
+
+    def test_future_wage_does_not_update_snapshot(self, test_db):
+        user = _make_user(test_db, wage=30000)
+        future = get_today() + datetime.timedelta(days=30)
+        add_new_wage(test_db, user.id, 99000, future)
+        test_db.refresh(user)
+        assert user.wage == 30000
+
+    def test_get_current_wage_record(self, test_db):
+        user = _make_user(test_db, wage=30000)
+        add_new_wage(test_db, user.id, 30000, datetime.date(2024, 1, 1))
+        record = get_current_wage_record(test_db, user.id)
+        assert record is not None
+        assert record.wage == 30000
+        assert record.effective_to is None


### PR DESCRIPTION
## Summary

Adds 156 unit tests covering money-critical business logic that had no test coverage. Four new test files focus on pure functions and DB-injected helpers where bugs produce wrong salaries — these are the cheapest to test and highest value per line.

- `test_utils_core.py`: payment date rules (weekend/Christmas adjustment), navigation dates, OT shift labelling
- `test_rates.py`: temporal RateHistory CRUD, rate resolution fallbacks
- `test_core_helpers_validators.py`: authorization checks, salary data stripping, OT time parsing, date/person-id validation
- `test_vacation_balance.py`: vacation year boundaries, §9 proration, saved-day balances, year closing (§9.5), end-to-end balance pipeline
- `test_wages.py`: karens budget distribution, sjuklön/VAB/leave deductions, partial-day hour math, temporal wage history CRUD
- `test_oncall_intervals.py`: interval geometry for on-call pay (priority replacement, midnight-spanning rules, 24:00 sentinel)

Coverage improvement per module: `utils.py` 32% -> 100%, `rates.py` 42% -> 100%, `time_utils.py` 48% -> 100%, `validators.py` 67% -> 100%, `helpers.py` 65% -> 92%, `vacation.py` 39% -> 92%, `wages.py` 64% -> 87%, `oncall.py` 63% -> 67%.

Also raises the CI coverage floor from 45% to 50% to lock in the regression protection with ~2% safety margin.

## Testing

- Full suite: 280 passed (up from 124), total coverage 52% (above the new 50% floor)
- ruff clean on all new test files