### PR TITLE
fix: read database url from environment

### DIFF
--- a/app/database/database.py
+++ b/app/database/database.py
@@ -4,6 +4,7 @@ SQLAlchemy database setup and models.
 """
 
 import enum
+import os
 from datetime import UTC, datetime
 
 from sqlalchemy import (
@@ -27,18 +28,35 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import declarative_base, relationship, sessionmaker
 
-DATABASE_URL = "sqlite:///./app/database/schedule.db"
+DEFAULT_DATABASE_URL = "sqlite:///./app/database/schedule.db"
 
-engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+
+def get_database_url() -> str:
+    """Return the configured database URL, falling back to the bundled SQLite DB."""
+    return os.getenv("DATABASE_URL", DEFAULT_DATABASE_URL)
+
+
+def get_engine_connect_args(database_url: str) -> dict[str, object]:
+    """Return SQLAlchemy connect_args appropriate for the configured backend."""
+    if database_url.startswith("sqlite"):
+        return {"check_same_thread": False}
+    return {}
+
+
+DATABASE_URL = get_database_url()
+
+engine = create_engine(DATABASE_URL, connect_args=get_engine_connect_args(DATABASE_URL))
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 
-@event.listens_for(engine, "connect")
-def set_sqlite_pragmas(dbapi_connection, connection_record):
-    cursor = dbapi_connection.cursor()
-    cursor.execute("PRAGMA journal_mode=WAL")
-    cursor.execute("PRAGMA wal_autocheckpoint=100")
-    cursor.close()
+if engine.url.get_backend_name() == "sqlite":
+
+    @event.listens_for(engine, "connect")
+    def set_sqlite_pragmas(dbapi_connection, connection_record):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA journal_mode=WAL")
+        cursor.execute("PRAGMA wal_autocheckpoint=100")
+        cursor.close()
 
 
 Base = declarative_base()

--- a/tests/test_database_config.py
+++ b/tests/test_database_config.py
@@ -1,0 +1,43 @@
+import os
+import subprocess
+import sys
+
+import app.database.database as db_module
+
+
+def test_database_url_defaults_to_sqlite(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    assert db_module.get_database_url() == db_module.DEFAULT_DATABASE_URL
+
+
+def test_database_url_uses_environment_override(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@example.test/periodical")
+
+    assert db_module.get_database_url() == "postgresql://user:pass@example.test/periodical"
+
+
+def test_sqlite_engine_uses_thread_connect_arg():
+    assert db_module.get_engine_connect_args("sqlite:///./app/database/schedule.db") == {"check_same_thread": False}
+    assert db_module.get_engine_connect_args("sqlite:///:memory:") == {"check_same_thread": False}
+
+
+def test_non_sqlite_engine_has_no_sqlite_connect_args():
+    assert db_module.get_engine_connect_args("postgresql://user:pass@example.test/periodical") == {}
+
+
+def test_module_import_uses_database_url_environment_override(tmp_path):
+    db_path = tmp_path / "custom.db"
+    env = os.environ.copy()
+    env["DATABASE_URL"] = f"sqlite:///{db_path}"
+
+    result = subprocess.run(
+        [sys.executable, "-c", "import app.database.database as db; print(db.DATABASE_URL)"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == f"sqlite:///{db_path}"


### PR DESCRIPTION
## Summary
Makes the database URL configurable through the documented `DATABASE_URL` environment variable while preserving the current SQLite default.

- Read `DATABASE_URL` from the environment with the bundled SQLite path as fallback
- Apply SQLite-only `connect_args` only for SQLite URLs
- Register SQLite PRAGMA setup only for SQLite engines
- Add regression coverage for default, environment override, connect args and import-time configuration

## Testing
- `./venv/bin/pytest tests/test_database_config.py`
- `./venv/bin/ruff check app/database/database.py tests/test_database_config.py`
- `./venv/bin/ruff format --check app/database/database.py tests/test_database_config.py`
- `./venv/bin/pytest --cov=app --cov-report=term-missing --cov-fail-under=50`