### PR TITLE
fix: upsert overtime shifts by day

### DIFF
--- a/app/routes/overtime.py
+++ b/app/routes/overtime.py
@@ -65,19 +65,34 @@ async def add_overtime_shift(
     start_t = datetime.strptime(start_time, "%H:%M").time()
     end_t = datetime.strptime(end_time, "%H:%M").time()
 
-    # Create overtime shift record
-    ot_shift = OvertimeShift(
-        user_id=user_id,
-        date=ot_date,
-        start_time=start_t,
-        end_time=end_t,
-        hours=hours,
-        ot_pay=ot_pay,
-        is_extension=is_extension,
-        created_by=current_user.id,
+    existing_shifts = (
+        session.query(OvertimeShift)
+        .filter(OvertimeShift.user_id == user_id, OvertimeShift.date == ot_date)
+        .order_by(OvertimeShift.id)
+        .all()
     )
+    if existing_shifts:
+        ot_shift = existing_shifts[0]
+        ot_shift.start_time = start_t
+        ot_shift.end_time = end_t
+        ot_shift.hours = hours
+        ot_shift.ot_pay = ot_pay
+        ot_shift.is_extension = is_extension
+        for duplicate in existing_shifts[1:]:
+            session.delete(duplicate)
+    else:
+        ot_shift = OvertimeShift(
+            user_id=user_id,
+            date=ot_date,
+            start_time=start_t,
+            end_time=end_t,
+            hours=hours,
+            ot_pay=ot_pay,
+            is_extension=is_extension,
+            created_by=current_user.id,
+        )
+        session.add(ot_shift)
 
-    session.add(ot_shift)
     session.commit()
 
     # Clear schedule cache to reflect changes

--- a/tests/test_overtime_upsert.py
+++ b/tests/test_overtime_upsert.py
@@ -1,0 +1,139 @@
+import datetime
+
+import pytest
+
+from app.database.database import OvertimeShift
+from app.routes.overtime import add_overtime_shift
+
+
+@pytest.mark.anyio
+async def test_add_overtime_creates_shift(test_db, test_user):
+    response = await add_overtime_shift(
+        user_id=test_user.id,
+        date="2026-01-15",
+        start_time="06:00",
+        end_time="14:00",
+        hours=8.0,
+        is_extension=False,
+        session=test_db,
+        current_user=test_user,
+    )
+
+    shifts = test_db.query(OvertimeShift).all()
+    assert len(shifts) == 1
+    assert shifts[0].user_id == test_user.id
+    assert shifts[0].date == datetime.date(2026, 1, 15)
+    assert shifts[0].start_time == datetime.time(6, 0)
+    assert shifts[0].end_time == datetime.time(14, 0)
+    assert shifts[0].hours == 8.0
+    assert shifts[0].is_extension is False
+    assert response.status_code == 303
+
+
+@pytest.mark.anyio
+async def test_add_overtime_updates_existing_shift_for_same_user_and_date(test_db, test_user):
+    await add_overtime_shift(
+        user_id=test_user.id,
+        date="2026-01-15",
+        start_time="06:00",
+        end_time="14:00",
+        hours=8.0,
+        is_extension=False,
+        session=test_db,
+        current_user=test_user,
+    )
+    original = test_db.query(OvertimeShift).one()
+    original_id = original.id
+    original_pay = original.ot_pay
+
+    await add_overtime_shift(
+        user_id=test_user.id,
+        date="2026-01-15",
+        start_time="14:00",
+        end_time="22:00",
+        hours=7.5,
+        is_extension=True,
+        session=test_db,
+        current_user=test_user,
+    )
+
+    shifts = test_db.query(OvertimeShift).all()
+    assert len(shifts) == 1
+    assert shifts[0].id == original_id
+    assert shifts[0].start_time == datetime.time(14, 0)
+    assert shifts[0].end_time == datetime.time(22, 0)
+    assert shifts[0].hours == 7.5
+    assert shifts[0].is_extension is True
+    assert shifts[0].ot_pay != original_pay
+
+
+@pytest.mark.anyio
+async def test_add_overtime_keeps_different_dates_separate(test_db, test_user):
+    await add_overtime_shift(
+        user_id=test_user.id,
+        date="2026-01-15",
+        start_time="06:00",
+        end_time="14:00",
+        hours=8.0,
+        is_extension=False,
+        session=test_db,
+        current_user=test_user,
+    )
+    await add_overtime_shift(
+        user_id=test_user.id,
+        date="2026-01-16",
+        start_time="14:00",
+        end_time="22:00",
+        hours=8.0,
+        is_extension=False,
+        session=test_db,
+        current_user=test_user,
+    )
+
+    dates = {shift.date for shift in test_db.query(OvertimeShift).all()}
+    assert dates == {datetime.date(2026, 1, 15), datetime.date(2026, 1, 16)}
+
+
+@pytest.mark.anyio
+async def test_add_overtime_cleans_up_legacy_duplicates(test_db, test_user):
+    target_date = datetime.date(2026, 1, 15)
+    first = OvertimeShift(
+        user_id=test_user.id,
+        date=target_date,
+        start_time=datetime.time(6, 0),
+        end_time=datetime.time(14, 0),
+        hours=8.0,
+        ot_pay=100.0,
+        is_extension=False,
+        created_by=test_user.id,
+    )
+    duplicate = OvertimeShift(
+        user_id=test_user.id,
+        date=target_date,
+        start_time=datetime.time(14, 0),
+        end_time=datetime.time(22, 0),
+        hours=8.0,
+        ot_pay=200.0,
+        is_extension=False,
+        created_by=test_user.id,
+    )
+    test_db.add_all([first, duplicate])
+    test_db.commit()
+
+    await add_overtime_shift(
+        user_id=test_user.id,
+        date="2026-01-15",
+        start_time="22:00",
+        end_time="06:00",
+        hours=8.5,
+        is_extension=False,
+        session=test_db,
+        current_user=test_user,
+    )
+
+    shifts = test_db.query(OvertimeShift).all()
+    assert len(shifts) == 1
+    assert shifts[0].id == first.id
+    assert shifts[0].start_time == datetime.time(22, 0)
+    assert shifts[0].end_time == datetime.time(6, 0)
+    assert shifts[0].hours == 8.5


### PR DESCRIPTION
## Summary
Prevents duplicate overtime rows for the same user and day by upserting through the existing add route.

- Update the existing overtime shift for a matching `user_id` and date instead of inserting another row
- Preserve separate rows for different dates
- Clean up legacy duplicate rows for the same user/date when the day is edited again
- Add regression tests for create, update, separate dates and duplicate cleanup

## Testing
- `./venv/bin/pytest tests/test_overtime_upsert.py`
- `./venv/bin/ruff check app/routes/overtime.py tests/test_overtime_upsert.py`
- `./venv/bin/ruff format --check app/routes/overtime.py tests/test_overtime_upsert.py`
- `./venv/bin/pytest --cov=app --cov-report=term-missing --cov-fail-under=50`