### PR TITLE
fix: block conflicting shift swaps

### DIFF
--- a/app/routes/shift_swap.py
+++ b/app/routes/shift_swap.py
@@ -138,6 +138,59 @@ def _check_weekly_rest_ok(work_date, new_shift_code, rotation_person_id, origina
     return True
 
 
+def _swap_participant_dates(requester_id: int, target_id: int, requester_date, target_date) -> set[tuple[int, object]]:
+    """Return every user/date slot affected by a swap."""
+    return {
+        (requester_id, requester_date),
+        (target_id, requester_date),
+        (requester_id, target_date),
+        (target_id, target_date),
+    }
+
+
+def _find_active_swap_conflict(
+    db: Session,
+    participant_dates: set[tuple[int, object]],
+    statuses: tuple[SwapStatus, ...],
+    exclude_swap_id: int | None = None,
+) -> ShiftSwap | None:
+    """Return an active swap that already uses any of the affected user/date slots."""
+    if not participant_dates:
+        return None
+
+    user_ids = {user_id for user_id, _ in participant_dates}
+    dates = {date for _, date in participant_dates}
+    query = db.query(ShiftSwap).filter(
+        ShiftSwap.status.in_(statuses),
+        (ShiftSwap.requester_id.in_(user_ids) | ShiftSwap.target_id.in_(user_ids)),
+        (ShiftSwap.requester_date.in_(dates) | ShiftSwap.target_date.in_(dates)),
+    )
+    if exclude_swap_id is not None:
+        query = query.filter(ShiftSwap.id != exclude_swap_id)
+
+    for swap in query.all():
+        existing_dates = _swap_participant_dates(
+            swap.requester_id, swap.target_id, swap.requester_date, swap.target_date
+        )
+        if participant_dates & existing_dates:
+            return swap
+    return None
+
+
+def _raise_if_swap_conflicts(
+    db: Session,
+    requester_id: int,
+    target_id: int,
+    requester_date,
+    target_date,
+    statuses: tuple[SwapStatus, ...],
+    exclude_swap_id: int | None = None,
+) -> None:
+    participant_dates = _swap_participant_dates(requester_id, target_id, requester_date, target_date)
+    if _find_active_swap_conflict(db, participant_dates, statuses, exclude_swap_id):
+        raise HTTPException(status_code=400, detail="Ett byte finns redan för någon av personerna på dessa datum")
+
+
 @router.get("/api/shifts/{user_id}")
 async def get_user_shifts(
     user_id: int,
@@ -371,6 +424,15 @@ async def propose_swap(
     if existing:
         raise HTTPException(status_code=400, detail="Byte redan föreslaget för dessa datum")
 
+    _raise_if_swap_conflicts(
+        db,
+        current_user.id,
+        target_id,
+        req_date,
+        tgt_date,
+        (SwapStatus.PENDING, SwapStatus.ACCEPTED),
+    )
+
     # Get shift codes for both dates
     req_result = determine_shift_for_date(req_date, start_week=current_user.rotation_person_id)
     tgt_result = determine_shift_for_date(tgt_date, start_week=target_user.rotation_person_id)
@@ -440,6 +502,16 @@ async def accept_swap(
         raise HTTPException(status_code=403, detail="Inte behörig")
     if swap.status != SwapStatus.PENDING:
         raise HTTPException(status_code=400, detail="Bytet är inte längre väntande")
+
+    _raise_if_swap_conflicts(
+        db,
+        swap.requester_id,
+        swap.target_id,
+        swap.requester_date,
+        swap.target_date,
+        (SwapStatus.ACCEPTED,),
+        exclude_swap_id=swap.id,
+    )
 
     swap.status = SwapStatus.ACCEPTED
     swap.responded_at = utcnow()

--- a/tests/test_shift_swap_conflicts.py
+++ b/tests/test_shift_swap_conflicts.py
@@ -1,0 +1,110 @@
+import datetime
+
+import pytest
+from fastapi import HTTPException
+
+from app.auth.auth import get_password_hash
+from app.database.database import ShiftSwap, SwapStatus, User, UserRole
+from app.routes.shift_swap import accept_swap, propose_swap
+
+
+def _add_user(db, user_id: int, username: str, person_id: int) -> User:
+    user = User(
+        id=user_id,
+        username=username,
+        password_hash=get_password_hash("testpass123"),
+        name=f"User {user_id}",
+        role=UserRole.USER,
+        wage=35000,
+        vacation={},
+        must_change_password=0,
+        person_id=person_id,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@pytest.mark.anyio
+async def test_propose_swap_rejects_conflicting_pending_slot(test_db, test_user, admin_user):
+    existing = ShiftSwap(
+        requester_id=test_user.id,
+        target_id=admin_user.id,
+        requester_date=datetime.date(2026, 7, 10),
+        target_date=datetime.date(2026, 7, 11),
+        requester_shift_code="N1",
+        target_shift_code="N2",
+        status=SwapStatus.PENDING,
+    )
+    test_db.add(existing)
+    test_db.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        await propose_swap(
+            target_id=admin_user.id,
+            requester_date="2026-07-10",
+            target_date="2026-07-12",
+            message=None,
+            current_user=test_user,
+            db=test_db,
+        )
+
+    assert exc.value.status_code == 400
+    assert "byte finns redan" in exc.value.detail
+    assert test_db.query(ShiftSwap).count() == 1
+
+
+@pytest.mark.anyio
+async def test_accept_swap_rejects_conflicting_accepted_slot(test_db, test_user, admin_user):
+    other_user = _add_user(test_db, 3, "other", 3)
+    accepted = ShiftSwap(
+        requester_id=other_user.id,
+        target_id=test_user.id,
+        requester_date=datetime.date(2026, 7, 10),
+        target_date=datetime.date(2026, 7, 11),
+        requester_shift_code="N1",
+        target_shift_code="N2",
+        status=SwapStatus.ACCEPTED,
+    )
+    pending = ShiftSwap(
+        requester_id=admin_user.id,
+        target_id=test_user.id,
+        requester_date=datetime.date(2026, 7, 10),
+        target_date=datetime.date(2026, 7, 12),
+        requester_shift_code="N3",
+        target_shift_code="N1",
+        status=SwapStatus.PENDING,
+    )
+    test_db.add_all([accepted, pending])
+    test_db.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        await accept_swap(pending.id, current_user=test_user, db=test_db)
+
+    assert exc.value.status_code == 400
+    assert "byte finns redan" in exc.value.detail
+    test_db.refresh(pending)
+    assert pending.status == SwapStatus.PENDING
+
+
+@pytest.mark.anyio
+async def test_accept_swap_allows_non_conflicting_pending_swap(test_db, test_user, admin_user):
+    pending = ShiftSwap(
+        requester_id=admin_user.id,
+        target_id=test_user.id,
+        requester_date=datetime.date(2026, 7, 10),
+        target_date=datetime.date(2026, 7, 12),
+        requester_shift_code="N3",
+        target_shift_code="N1",
+        status=SwapStatus.PENDING,
+    )
+    test_db.add(pending)
+    test_db.commit()
+
+    response = await accept_swap(pending.id, current_user=test_user, db=test_db)
+
+    test_db.refresh(pending)
+    assert pending.status == SwapStatus.ACCEPTED
+    assert pending.responded_at is not None
+    assert response.status_code == 303


### PR DESCRIPTION
## Summary
- block new swap proposals when either participant already has a pending or accepted swap on an affected date
- block accepting a pending swap if it conflicts with an already accepted swap
- add focused regression tests for conflicting and non-conflicting swap acceptance

## Tests
- ruff check app/routes/shift_swap.py tests/test_shift_swap_conflicts.py
- ruff format --check app/routes/shift_swap.py tests/test_shift_swap_conflicts.py
- pytest