### PR TITLE
chore: sync pre-commit ruff pin and let Renovate manage it

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.15  # Keep in sync with the ruff pin in pyproject.toml [project.optional-dependencies] dev
+    rev: v0.15.16  # Keep in sync with the ruff pin in pyproject.toml [project.optional-dependencies] dev
     hooks:
       - id: ruff        # Runs ruff check --fix
       - id: ruff-format # Runs ruff format

--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,15 @@
   "pip-compile": {
     "enabled": true
   },
+  "pre-commit": {
+    "enabled": true
+  },
   "packageRules": [
+    {
+      "description": "Bump ruff in pyproject.toml and .pre-commit-config.yaml together so the pins stay in sync.",
+      "matchPackageNames": ["ruff", "astral-sh/ruff-pre-commit"],
+      "groupName": "ruff"
+    },
     {
       "description": "Hold the Python version on 3.12 to match the production venv and the compiled lockfile. Bump deliberately as a coordinated change (prod venv + recompile + CI + Dockerfile).",
       "matchDepNames": ["python"],


### PR DESCRIPTION
## Summary
- Bump astral-sh/ruff-pre-commit to v0.15.16 to match the ruff pin in pyproject.toml (updated in #259)
- Enable Renovate's pre-commit manager so the hook rev is bumped automatically
- Group ruff and astral-sh/ruff-pre-commit updates in Renovate so both pins move together in one PR

## Test plan
- [x] pre-commit run --all-files passes with the new rev
- [x] renovate.json validates against the schema