### PR TITLE
chore: move Python pin from 3.12 to 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Set up Python 3.12
+      - name: Set up Python 3.14
         uses: actions/setup-python@v6
         with:
           # Match the version run in production (venv) and used to compile requirements.txt
-          python-version: "3.12"
+          python-version: "3.14"
           cache: "pip" # Enables automatic caching of dependencies
 
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # STAGE 1: Base
 # Gemensam grund för alla stages.
 # -------------------------------------------------------------------
-FROM python:3.12-slim AS base
+FROM python:3.14-slim AS base
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1

--- a/renovate.json
+++ b/renovate.json
@@ -25,7 +25,7 @@
       "groupName": "ruff"
     },
     {
-      "description": "Hold the Python version on 3.12 to match the production venv and the compiled lockfile. Bump deliberately as a coordinated change (prod venv + recompile + CI + Dockerfile).",
+      "description": "Hold the Python version on 3.14 to match the production venv and the compiled lockfile. Bump deliberately as a coordinated change (prod venv + recompile + CI + Dockerfile).",
       "matchDepNames": ["python"],
       "enabled": false
     },


### PR DESCRIPTION
## Summary

Ubuntu 26.04 LTS ships Python 3.14 as the default interpreter. This aligns the runtime pin so a fresh production venv built on 26.04 matches CI and the container base image, ahead of migrating production to a new machine.

## Changes
- `ci.yml`: run the lint/test job on Python 3.14
- `Dockerfile`: bump base stage to `python:3.14-slim` (`deployment/Dockerfile` was already on 3.14)
- `renovate.json`: update the held-version policy note to 3.14

## Deliberately unchanged
- `requires-python` stays at `>=3.11` (compatibility floor, not the run version)
- ruff `target-version` stays at `py311` so no 3.14-only syntax is introduced
- `requirements.txt` is recompiled separately on a 3.14 interpreter; it is not on the install path (deploy and CI both `pip install` from `pyproject.toml`)

## Testing
- 307 tests pass locally on 3.12. CI on this PR is the first run under 3.14; the key path it exercises that local 3.12 cannot is passlib's guarded `crypt` import (removed in 3.13+).