### PR TITLE
Add monthly report and overtime/absence tracking for substitutes

### DIFF
--- a/app/core/schedule/__init__.py
+++ b/app/core/schedule/__init__.py
@@ -45,6 +45,7 @@ from .period import (
 )
 from .summary import (
     build_calendar_grid_for_month,
+    build_month_report,
     summarize_month_for_person,
     summarize_year_by_month,
     summarize_year_for_person,
@@ -111,6 +112,7 @@ __all__ = [
     "get_vacation_dates_for_year",
     # period
     "build_week_data",
+    "build_month_report",
     "build_substitute_month_summaries",
     "generate_period_data",
     "generate_year_data",

--- a/app/core/schedule/period.py
+++ b/app/core/schedule/period.py
@@ -437,10 +437,34 @@ def _fetch_substitute_shifts(
     return {(r.substitute_id, r.date): r for r in rows}
 
 
-def _build_substitute_day(date: datetime.date, sub, sub_shift_map: dict, shift_types: list) -> dict:
+def _substitute_absence_shift_code(absence_type) -> str:
+    """Map a substitute's absence type to the shift code used to render it.
+
+    Mirrors the agent mapping: VACATION shows as SEM, PARENTAL falls back to LEAVE,
+    everything else uses the absence type's own code (SICK, VAB, LEAVE, OFF).
+    """
+    from app.database.database import AbsenceType
+
+    if absence_type == AbsenceType.VACATION:
+        return "SEM"
+    if absence_type == AbsenceType.PARENTAL:
+        return "LEAVE"
+    return absence_type.value
+
+
+def _build_substitute_day(
+    date: datetime.date,
+    sub,
+    sub_shift_map: dict,
+    shift_types: list,
+    absence_map: dict | None = None,
+    ot_map: dict | None = None,
+) -> dict:
     """Build a single day's schedule dict for a substitute.
 
     The base schedule is OFF; a working shift only appears where a SubstituteShift exists.
+    Priority mirrors the agent chain: an absence wins, then an overtime entry (shown as OT,
+    like agents), then the scheduled shift, otherwise OFF.
     Matches the shape produced by _build_person_day_basic so the templates can render
     substitutes alongside regular persons. The person_id uses a "sub-<id>" namespace to
     avoid colliding with rotation positions (1-10).
@@ -448,6 +472,58 @@ def _build_substitute_day(date: datetime.date, sub, sub_shift_map: dict, shift_t
     rotation_length = get_rotation_length_for_date(date)
     off_shift = next((s for s in shift_types if s.code == "OFF"), None)
     pid = f"sub-{sub.id}"
+
+    absence = absence_map.get((sub.id, date)) if absence_map else None
+    if absence is not None:
+        code = _substitute_absence_shift_code(absence.absence_type)
+        absence_shift = next((s for s in shift_types if s.code == code), None)
+        if absence_shift:
+            return {
+                "date": date,
+                "person_id": pid,
+                "substitute_id": sub.id,
+                "person_name": sub.name,
+                "shift": absence_shift,
+                "original_shift": None,
+                "rotation_week": None,
+                "rotation_length": rotation_length,
+                "hours": 0.0,
+                "start": None,
+                "end": None,
+                "is_substitute": True,
+                "is_absence": True,
+            }
+
+    # Overtime is shown as the OT shift (same convention as agents), taking display
+    # priority over the scheduled shift. Substitute overtime is never an extension.
+    ot_entries = ot_map.get((sub.id, date)) if ot_map else None
+    ot_entry = ot_entries[0] if ot_entries else None
+    if ot_entry is not None:
+        ot_shift_type = next((s for s in shift_types if s.code == "OT"), None)
+        if ot_shift_type:
+            start = datetime.datetime.combine(date, ot_entry.start_time) if ot_entry.start_time else None
+            end = datetime.datetime.combine(date, ot_entry.end_time) if ot_entry.end_time else None
+            if start and end and end <= start:
+                end += datetime.timedelta(days=1)
+            return {
+                "date": date,
+                "person_id": pid,
+                "substitute_id": sub.id,
+                "person_name": sub.name,
+                "shift": ot_shift_type,
+                "original_shift": next(
+                    (s for s in shift_types if s.code == sub_shift_map[(sub.id, date)].shift_code), None
+                )
+                if (sub.id, date) in sub_shift_map
+                else None,
+                "rotation_week": None,
+                "rotation_length": rotation_length,
+                "hours": ot_entry.hours or 0.0,
+                "start": start,
+                "end": end,
+                "is_substitute": True,
+            }
+
     entry = sub_shift_map.get((sub.id, date))
     if entry:
         shift = next((s for s in shift_types if s.code == entry.shift_code), None)
@@ -483,28 +559,204 @@ def _build_substitute_day(date: datetime.date, sub, sub_shift_map: dict, shift_t
     }
 
 
-def build_substitute_month_summaries(year: int, month: int, session) -> list[dict]:
+def _fetch_substitute_ot_by_date(
+    session, sub_ids: list[int], start_date: datetime.date, end_date: datetime.date
+) -> dict[tuple[int, datetime.date], list]:
+    """Batch-fetch substitute overtime entries, keyed by (substitute_id, date)."""
+    if not session or not sub_ids:
+        return {}
+    from app.database.database import OvertimeShift
+
+    rows = (
+        session.query(OvertimeShift)
+        .filter(
+            OvertimeShift.substitute_id.in_(sub_ids),
+            OvertimeShift.date >= start_date,
+            OvertimeShift.date <= end_date,
+        )
+        .order_by(OvertimeShift.date, OvertimeShift.start_time)
+        .all()
+    )
+    by_date: dict[tuple[int, datetime.date], list] = {}
+    for r in rows:
+        by_date.setdefault((r.substitute_id, r.date), []).append(r)
+    return by_date
+
+
+def _fetch_substitute_ot_hours(
+    session, sub_ids: list[int], start_date: datetime.date, end_date: datetime.date
+) -> dict[int, float]:
+    """Sum overtime hours per substitute for the range (no pay; hours only)."""
+    if not session or not sub_ids:
+        return {}
+    from app.database.database import OvertimeShift
+
+    rows = (
+        session.query(OvertimeShift)
+        .filter(
+            OvertimeShift.substitute_id.in_(sub_ids),
+            OvertimeShift.date >= start_date,
+            OvertimeShift.date <= end_date,
+        )
+        .all()
+    )
+    totals: dict[int, float] = {}
+    for r in rows:
+        totals[r.substitute_id] = totals.get(r.substitute_id, 0.0) + (r.hours or 0.0)
+    return totals
+
+
+def _fetch_substitute_absences_by_date(
+    session, sub_ids: list[int], start_date: datetime.date, end_date: datetime.date
+) -> dict[tuple[int, datetime.date], object]:
+    """Batch-fetch substitute absences, keyed by (substitute_id, date)."""
+    if not session or not sub_ids:
+        return {}
+    from app.database.database import Absence
+
+    rows = (
+        session.query(Absence)
+        .filter(
+            Absence.substitute_id.in_(sub_ids),
+            Absence.date >= start_date,
+            Absence.date <= end_date,
+        )
+        .all()
+    )
+    return {(r.substitute_id, r.date): r for r in rows}
+
+
+def _fetch_substitute_absence_counts(
+    session, sub_ids: list[int], start_date: datetime.date, end_date: datetime.date
+) -> dict[int, dict[str, int]]:
+    """Count absence days per type per substitute for the range."""
+    if not session or not sub_ids:
+        return {}
+    from app.database.database import Absence
+
+    rows = (
+        session.query(Absence)
+        .filter(
+            Absence.substitute_id.in_(sub_ids),
+            Absence.date >= start_date,
+            Absence.date <= end_date,
+        )
+        .all()
+    )
+    counts: dict[int, dict[str, int]] = {}
+    for r in rows:
+        bucket = counts.setdefault(r.substitute_id, {})
+        key = str(r.absence_type)
+        bucket[key] = bucket.get(key, 0) + 1
+    return counts
+
+
+def _get_substitutes_with_activity(
+    session, start_date: datetime.date, end_date: datetime.date, include_overtime: bool = True
+) -> list:
+    """Active substitutes with activity in range: a shift or an absence (and optionally overtime).
+
+    The month schedule view shows substitutes with a shift or an absence (an absence renders
+    as a day shift). The report additionally pulls in overtime-only substitutes (include_overtime)
+    so their hours appear in the totals even without a scheduled day.
+    """
+    if not session:
+        return []
+    from app.database.database import Absence, OvertimeShift, Substitute
+
+    subs = session.query(Substitute).filter(Substitute.is_active == 1).all()
+    if not subs:
+        return []
+    sub_ids = [s.id for s in subs]
+
+    active_ids = {s.id for s in _get_substitutes_with_shifts(session, start_date, end_date)}
+    models = [Absence, OvertimeShift] if include_overtime else [Absence]
+    for model in models:
+        rows = (
+            session.query(model.substitute_id)
+            .filter(
+                model.substitute_id.in_(sub_ids),
+                model.date >= start_date,
+                model.date <= end_date,
+            )
+            .distinct()
+            .all()
+        )
+        active_ids.update(r[0] for r in rows)
+
+    return [s for s in subs if s.id in active_ids]
+
+
+def build_substitute_month_summaries(year: int, month: int, session, include_overtime: bool = False) -> list[dict]:
     """Build per-substitute month summaries (schedule only, no salary) for the month view.
 
     Each summary mirrors the shape produced by summarize_month_for_person enough for
-    month_all.html to render: person_id, person_name, days and an empty ob_pay.
+    month_all.html to render: person_id, person_name, days and an empty ob_pay. It also
+    carries aggregate totals (hours, overtime, on-call, absence days per type) used by the
+    monthly report. Substitutes have no salary, so all pay figures are zero.
+
+    Substitutes with a scheduled shift or an absence in the month are returned (an absence
+    renders as a day shift). With include_overtime=True, overtime-only substitutes are also
+    included so their hours appear in the report totals (used by the report).
     """
     start_date = datetime.date(year, month, 1)
     end_date = datetime.date(year, month, calendar.monthrange(year, month)[1])
-    substitutes = _get_substitutes_with_shifts(session, start_date, end_date)
+    substitutes = _get_substitutes_with_activity(session, start_date, end_date, include_overtime=include_overtime)
     if not substitutes:
         return []
 
-    shift_map = _fetch_substitute_shifts(session, [s.id for s in substitutes], start_date, end_date)
+    sub_ids = [s.id for s in substitutes]
+    shift_map = _fetch_substitute_shifts(session, sub_ids, start_date, end_date)
+    ot_hours_map = _fetch_substitute_ot_hours(session, sub_ids, start_date, end_date)
+    ot_by_date = _fetch_substitute_ot_by_date(session, sub_ids, start_date, end_date)
+    absence_counts = _fetch_substitute_absence_counts(session, sub_ids, start_date, end_date)
+    absence_by_date = _fetch_substitute_absences_by_date(session, sub_ids, start_date, end_date)
     shift_types = get_shift_types()
+
+    # OB rules for the month (same rules agents use); covers any year in range.
+    combined_ob_rules: list = []
+    for yr in {start_date.year, end_date.year}:
+        combined_ob_rules.extend(get_combined_rules_for_year(yr))
 
     summaries = []
     for sub in substitutes:
         days = []
+        worked_hours = 0.0
+        oncall_hours = 0.0
+        num_shifts = 0
+        ob_hours: dict[str, float] = {}
         current = start_date
         while current <= end_date:
-            days.append(_build_substitute_day(current, sub, shift_map, shift_types))
+            day = _build_substitute_day(current, sub, shift_map, shift_types, absence_by_date, ot_by_date)
+            days.append(day)
+
+            # Counting reads raw data, not the displayed shift, so that a day shown as OT
+            # is still counted by its underlying scheduled shift (e.g. OC + OT same day).
+            absence = absence_by_date.get((sub.id, current))
+            entry = shift_map.get((sub.id, current))
+            code = entry.shift_code if entry else None
+            day_ot_hours = sum(o.hours or 0.0 for o in ot_by_date.get((sub.id, current), []))
+
+            if absence is not None:
+                # Absence days are counted via absence_counts below, not as worked shifts.
+                pass
+            elif code == "OC":
+                # On-call standby is reduced by overtime worked during the on-call period.
+                oc_hours, _, _ = calculate_shift_hours(current, "OC")
+                oncall_hours += max(oc_hours - day_ot_hours, 0.0)
+            elif code in ("N1", "N2", "N3"):
+                hours, start, end = calculate_shift_hours(current, code)
+                worked_hours += hours
+                num_shifts += 1
+                # OB hours for the worked shift, accumulated per OB code
+                day_ob = calculate_ob_hours(start, end, combined_ob_rules)
+                for ob_code, ob_h in day_ob.items():
+                    if ob_h:
+                        ob_hours[ob_code] = ob_hours.get(ob_code, 0.0) + ob_h
             current += datetime.timedelta(days=1)
+
+        ot_hours = ot_hours_map.get(sub.id, 0.0)
+        counts = absence_counts.get(sub.id, {})
         summaries.append(
             {
                 "person_id": f"sub-{sub.id}",
@@ -512,7 +764,22 @@ def build_substitute_month_summaries(year: int, month: int, session) -> list[dic
                 "person_name": sub.name,
                 "days": days,
                 "ob_pay": {},
+                "ob_hours": ob_hours,
                 "is_substitute": True,
+                "num_shifts": num_shifts,
+                "total_hours": worked_hours + ot_hours,
+                "ot_hours": ot_hours,
+                "ot_pay": 0.0,
+                "oncall_hours": oncall_hours,
+                "oncall_pay": 0.0,
+                "sick_days": counts.get("SICK", 0),
+                "vab_days": counts.get("VAB", 0),
+                "leave_days": counts.get("LEAVE", 0),
+                "off_days": counts.get("OFF", 0),
+                "parental_days": counts.get("PARENTAL", 0),
+                "vacation_days": counts.get("VACATION", 0),
+                "brutto_pay": 0.0,
+                "netto_pay": 0.0,
             }
         )
     return summaries
@@ -934,6 +1201,9 @@ def _build_person_day_basic(
                 "hours": 0.0,
                 "start": None,
                 "end": None,
+                # Week-based parental leave renders as LEAVE; flag it so summaries can
+                # count it as parental rather than ordinary leave.
+                "parental_leave": True,
             }
 
     # Check for manual shift override (admin-assigned N1/N2/N3 replacing rotation)
@@ -1246,6 +1516,9 @@ def _populate_parental_day(
             "ot_pay": 0.0,
             "ot_hours": 0.0,
             "ot_details": {},
+            # Week-based parental leave renders as LEAVE; flag it so summaries can
+            # count it as parental rather than ordinary leave.
+            "parental_leave": True,
         }
     )
     return True

--- a/app/core/schedule/summary.py
+++ b/app/core/schedule/summary.py
@@ -292,14 +292,24 @@ def summarize_month_for_person(
         "leave_hours": 0.0,
         "parental_days": 0,
         "parental_hours": 0.0,
+        "vacation_days": 0,
     }
 
     days_out = []
+    week_parental_days = 0
 
     for day in days:
         # Filter to the correct year and month (important when all_work_days spans multiple years)
         if day["date"].year != year or day["date"].month != month:
             continue
+
+        shift = day.get("shift")
+        if shift is not None and getattr(shift, "code", None) == "SEM":
+            totals["vacation_days"] += 1
+        # Week-based parental leave renders as LEAVE but is flagged; count it separately
+        # so it is not lost (day-level parental is counted via absence records below).
+        if day.get("parental_leave"):
+            week_parental_days += 1
 
         day_data = _process_day_for_summary(
             day,
@@ -340,6 +350,9 @@ def summarize_month_for_person(
                 totals["brutto_pay"], base_salary, worked_hours, totals.get("absence_hours", 0.0), actual_hourly_rate
             )
 
+    # Add week-based parental leave (flagged days) on top of day-level parental absences.
+    totals["parental_days"] += week_parental_days
+
     # Calculate net pay using the user's tax table for the payment year
     netto_pay = totals["brutto_pay"] - _calculate_tax(totals["brutto_pay"], tax_table, payment_year=payment_year)
 
@@ -357,6 +370,7 @@ def summarize_month_for_person(
         "oncall_pay": totals["oncall_pay"],
         "oncall_hours": totals["oncall_hours"],
         "ot_pay": totals["ot_pay"],
+        "ot_hours": totals.get("ot_hours", 0.0),
         "absence_deduction": totals["absence_deduction"],
         "absence_hours": totals["absence_hours"],
         "sick_days": totals["sick_days"],
@@ -370,8 +384,11 @@ def summarize_month_for_person(
         "vab_hours": totals.get("vab_hours", 0.0),
         "leave_days": totals["leave_days"],
         "leave_hours": totals.get("leave_hours", 0.0),
+        "off_days": totals.get("off_days", 0),
+        "off_hours": totals.get("off_hours", 0.0),
         "parental_days": totals.get("parental_days", 0),
         "parental_hours": totals.get("parental_hours", 0.0),
+        "vacation_days": totals.get("vacation_days", 0),
         "absence_details": absence_details,
         "brutto_pay": totals["brutto_pay"],
         "netto_pay": netto_pay,
@@ -865,6 +882,72 @@ def summarize_year_for_person(
         "months": months,
         "year_summary": year_summary,
     }
+
+
+def _report_row_from_summary(summary: dict, is_substitute: bool) -> dict:
+    """Flatten a month summary (agent or substitute) into a single report row.
+
+    Pulls the figures the monthly report needs: hours, overtime, on-call, OB total
+    and absence days per type. The report tracks time only, not salary.
+    """
+    ob_hours_map = summary.get("ob_hours", {}) or {}
+
+    def _ob_sum(*codes: str) -> float:
+        return round(sum(float(ob_hours_map.get(c, 0.0) or 0.0) for c in codes), 1)
+
+    return {
+        "person_name": summary.get("person_name", ""),
+        "person_id": summary.get("person_id"),
+        "substitute_id": summary.get("substitute_id"),
+        "is_substitute": is_substitute,
+        "num_shifts": summary.get("num_shifts", 0) or 0,
+        "total_hours": round(summary.get("total_hours", 0.0) or 0.0, 1),
+        "ot_hours": round(summary.get("ot_hours", 0.0) or 0.0, 1),
+        "oncall_hours": round(summary.get("oncall_hours", 0.0) or 0.0, 1),
+        # OB split into pay-code groups: evening, night, weekend, major holiday
+        "ob_kvall": _ob_sum("OB1"),
+        "ob_natt": _ob_sum("OB2"),
+        "ob_helg": _ob_sum("OB3", "OB4"),
+        "ob_storhelg": _ob_sum("OB5"),
+        "sick_days": summary.get("sick_days", 0) or 0,
+        "vab_days": summary.get("vab_days", 0) or 0,
+        "leave_days": summary.get("leave_days", 0) or 0,
+        "off_days": summary.get("off_days", 0) or 0,
+        "parental_days": summary.get("parental_days", 0) or 0,
+        "vacation_days": summary.get("vacation_days", 0) or 0,
+    }
+
+
+def build_month_report(year: int, month: int, session, fetch_tax_table: bool = False) -> list[dict]:
+    """Build one report row per agent (rotation positions 1-10) plus substitutes.
+
+    Reuses summarize_month_for_person for agents and build_substitute_month_summaries
+    for substitutes, returning a flat list of rows ready for the report table / CSV.
+    The report tracks time only, so tax lookups are skipped by default.
+    """
+    from .period import build_substitute_month_summaries
+
+    user_wages = get_all_user_wages(session)
+
+    rows = []
+    for pid in range(1, 11):
+        month_days = generate_month_data(year, month, pid, session=session, user_wages=user_wages)
+        summary = summarize_month_for_person(
+            year,
+            month,
+            pid,
+            session=session,
+            user_wages=user_wages,
+            year_days=month_days,
+            fetch_tax_table=fetch_tax_table,
+            payment_year=year,
+        )
+        rows.append(_report_row_from_summary(summary, is_substitute=False))
+
+    for sub_summary in build_substitute_month_summaries(year, month, session, include_overtime=True):
+        rows.append(_report_row_from_summary(sub_summary, is_substitute=True))
+
+    return rows
 
 
 def _build_year_summary(months: list[dict]) -> dict:

--- a/app/database/database.py
+++ b/app/database/database.py
@@ -177,18 +177,21 @@ class OvertimeShift(Base):
     __tablename__ = "overtime_shifts"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    # Exactly one of user_id / substitute_id is set (enforced at the route layer).
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    substitute_id = Column(Integer, ForeignKey("substitutes.id"), nullable=True)
     date = Column(Date, nullable=False)
     start_time = Column(Time, nullable=False)
     end_time = Column(Time, nullable=False)
     hours = Column(Float, nullable=False)
-    ot_pay = Column(Float, nullable=False)
+    ot_pay = Column(Float, nullable=False)  # Always 0.0 for substitutes (hours tracked, no pay)
     is_extension = Column(Boolean, default=False, nullable=False)
     created_at = Column(DateTime, default=utcnow)
     created_by = Column(Integer, ForeignKey("users.id"))
 
     # Relationships
     user = relationship("User", foreign_keys=[user_id], back_populates="overtime_shifts")
+    substitute = relationship("Substitute", foreign_keys=[substitute_id])
     creator = relationship("User", foreign_keys=[created_by])
 
     def __repr__(self):
@@ -201,7 +204,9 @@ class Absence(Base):
     __tablename__ = "absences"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    # Exactly one of user_id / substitute_id is set (enforced at the route layer).
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    substitute_id = Column(Integer, ForeignKey("substitutes.id"), nullable=True)
     date = Column(Date, nullable=False)
     absence_type = Column(SQLEnum(AbsenceType), nullable=False)
     left_at = Column(String(5), nullable=True)  # "HH:MM" - time they left early (None = full day or on time)
@@ -210,6 +215,7 @@ class Absence(Base):
 
     # Relationships
     user = relationship("User", foreign_keys=[user_id])
+    substitute = relationship("Substitute", foreign_keys=[substitute_id])
 
     @property
     def is_partial_day(self) -> bool:
@@ -228,7 +234,9 @@ class OnCallOverride(Base):
     __tablename__ = "oncall_overrides"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    # Exactly one of user_id / substitute_id is set (enforced at the route layer).
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    substitute_id = Column(Integer, ForeignKey("substitutes.id"), nullable=True)
     date = Column(Date, nullable=False)
     override_type = Column(SQLEnum(OnCallOverrideType), nullable=False)
     reason = Column(String(255), nullable=True)
@@ -237,6 +245,7 @@ class OnCallOverride(Base):
 
     # Relationships
     user = relationship("User", foreign_keys=[user_id])
+    substitute = relationship("Substitute", foreign_keys=[substitute_id])
     creator = relationship("User", foreign_keys=[created_by])
 
     def __repr__(self):

--- a/app/main.py
+++ b/app/main.py
@@ -30,6 +30,7 @@ from app.routes.day_pay_override import router as day_pay_override_router
 from app.routes.oncall import router as oncall_router
 from app.routes.overtime import router as overtime_router
 from app.routes.profile import router as profile_router
+from app.routes.reports import router as reports_router
 from app.routes.schedule_all import router as schedule_all_router
 from app.routes.schedule_api import router as schedule_api_router
 from app.routes.schedule_personal import router as schedule_personal_router
@@ -312,6 +313,7 @@ app.include_router(day_pay_override_router)
 app.include_router(statistics_router)
 app.include_router(auth_router)
 app.include_router(profile_router)
+app.include_router(reports_router)
 app.include_router(admin_users_router)
 app.include_router(admin_router)
 app.include_router(transition_router)

--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -15,6 +15,22 @@ router = APIRouter()
 
 VERSIONS = [
     {
+        "version": "0.26.1",
+        "date": "2026-06-24",
+        "entries": [
+            {
+                "type": "fix",
+                "sv": "Månadsvy (alla): en vikaries frånvaro syns nu i schemat (visas som frånvaropass den dagen), även om vikarien inte har något inlagt arbetspass den månaden",
+                "en": "Month view (all): a substitute's absence now appears in the schedule (shown as an absence shift on that day), even when the substitute has no scheduled shift that month",
+            },
+            {
+                "type": "fix",
+                "sv": "Månadsvy (alla): en vikaries övertidspass visas nu som ÖT i schemat, och beredskap på en jourdag minskas med de timmar som jobbats som övertid under jouren",
+                "en": "Month view (all): a substitute's overtime now appears as OT in the schedule, and on-call standby on an on-call day is reduced by the hours worked as overtime during the on-call period",
+            },
+        ],
+    },
+    {
         "version": "0.26.0",
         "date": "2026-06-02",
         "entries": [

--- a/app/routes/reports.py
+++ b/app/routes/reports.py
@@ -1,0 +1,124 @@
+# app/routes/reports.py
+"""Admin monthly report: one row per agent and substitute with hours, overtime,
+on-call and absence figures, viewable in the browser and exportable as CSV."""
+
+import csv
+import io
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse, StreamingResponse
+from sqlalchemy.orm import Session
+
+from app.auth.auth import get_admin_user
+from app.core.helpers import render_template
+from app.core.schedule import build_month_report, rotation_start_date
+from app.core.utils import get_safe_today
+from app.core.validators import validate_date_params
+from app.database.database import User, get_db
+from app.routes.shared import templates
+
+router = APIRouter(tags=["reports"])
+
+MONTH_NAMES_SV = [
+    "Januari",
+    "Februari",
+    "Mars",
+    "April",
+    "Maj",
+    "Juni",
+    "Juli",
+    "Augusti",
+    "September",
+    "Oktober",
+    "November",
+    "December",
+]
+
+# CSV column order: (dict key, header label)
+CSV_COLUMNS = [
+    ("person_name", "Namn"),
+    ("num_shifts", "Antal pass"),
+    ("total_hours", "Timmar"),
+    ("ot_hours", "Övertid (h)"),
+    ("oncall_hours", "Beredskap (h)"),
+    ("ob_kvall", "Kväll 150 (h)"),
+    ("ob_natt", "Natt 151 (h)"),
+    ("ob_helg", "Helg 152 (h)"),
+    ("ob_storhelg", "Storhelg 153 (h)"),
+    ("sick_days", "Sjuk (dgr)"),
+    ("vab_days", "VAB (dgr)"),
+    ("leave_days", "Ledigt (dgr)"),
+    ("off_days", "Frånvaro övrigt (dgr)"),
+    ("parental_days", "Föräldraledigt (dgr)"),
+    ("vacation_days", "Semester (dgr)"),
+]
+
+
+def _resolve_year_month(year: int | None, month: int | None) -> tuple[int, int]:
+    safe_today = get_safe_today(rotation_start_date)
+    year = year or safe_today.year
+    month = month or safe_today.month
+    validate_date_params(year, month, None)
+    return year, month
+
+
+@router.get("/admin/report", response_class=HTMLResponse, name="admin_report")
+async def admin_report(
+    request: Request,
+    year: int = None,
+    month: int = None,
+    current_user: User = Depends(get_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Monthly report table for all agents and substitutes."""
+    year, month = _resolve_year_month(year, month)
+    rows = build_month_report(year, month, db)
+
+    prev_month = month - 1 or 12
+    prev_year = year - 1 if month == 1 else year
+    next_month = month + 1 if month < 12 else 1
+    next_year = year + 1 if month == 12 else year
+
+    return render_template(
+        templates,
+        "admin_report.html",
+        request,
+        {
+            "year": year,
+            "month": month,
+            "month_name": MONTH_NAMES_SV[month - 1],
+            "rows": rows,
+            "prev_year": prev_year,
+            "prev_month": prev_month,
+            "next_year": next_year,
+            "next_month": next_month,
+        },
+        user=current_user,
+    )
+
+
+@router.get("/admin/report.csv", name="admin_report_csv")
+async def admin_report_csv(
+    year: int = None,
+    month: int = None,
+    current_user: User = Depends(get_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Download the monthly report as a CSV file (UTF-8 with BOM for Excel)."""
+    year, month = _resolve_year_month(year, month)
+    rows = build_month_report(year, month, db)
+
+    buffer = io.StringIO()
+    buffer.write("﻿")  # BOM so Excel reads UTF-8 (åäö) correctly
+    writer = csv.writer(buffer, delimiter=";")
+    writer.writerow([label for _, label in CSV_COLUMNS])
+    for row in rows:
+        writer.writerow([row.get(key, "") for key, _ in CSV_COLUMNS])
+
+    buffer.seek(0)
+    filename = f"rapport-{year}-{month:02d}.csv"
+    return StreamingResponse(
+        iter([buffer.getvalue()]),
+        media_type="text/csv; charset=utf-8",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/app/routes/substitutes.py
+++ b/app/routes/substitutes.py
@@ -17,12 +17,22 @@ from sqlalchemy.orm import Session
 from app.auth.auth import get_admin_user
 from app.core.schedule import clear_schedule_cache
 from app.core.utils import get_today
-from app.database.database import Substitute, SubstituteShift, User, get_db
+from app.database.database import (
+    Absence,
+    AbsenceType,
+    OvertimeShift,
+    Substitute,
+    SubstituteShift,
+    User,
+    get_db,
+)
 from app.routes.shared import render
 
 router = APIRouter(tags=["substitutes"])
 
 _ALLOWED_CODES = {"N1", "N2", "N3", "OC"}
+# Absence types selectable for substitutes (we only track days, no pay).
+_ABSENCE_TYPES = ["SICK", "VAB", "LEAVE", "OFF", "PARENTAL", "VACATION"]
 
 
 @router.get("/admin/substitutes", response_class=HTMLResponse, name="admin_substitutes")
@@ -98,6 +108,28 @@ async def admin_substitute_manage_page(
     )
     shift_by_date = {s.date.isoformat(): s.shift_code for s in shifts}
 
+    # Overtime and absence entries for the displayed month (substitutes track hours/days only)
+    overtime_shifts = (
+        db.query(OvertimeShift)
+        .filter(
+            OvertimeShift.substitute_id == substitute_id,
+            OvertimeShift.date >= first_day,
+            OvertimeShift.date <= last_day,
+        )
+        .order_by(OvertimeShift.date)
+        .all()
+    )
+    absences = (
+        db.query(Absence)
+        .filter(
+            Absence.substitute_id == substitute_id,
+            Absence.date >= first_day,
+            Absence.date <= last_day,
+        )
+        .order_by(Absence.date)
+        .all()
+    )
+
     prev_month = month - 1 or 12
     prev_year = year - 1 if month == 1 else year
     next_month = month + 1 if month < 12 else 1
@@ -111,6 +143,9 @@ async def admin_substitute_manage_page(
             "substitute": substitute,
             "weeks": weeks,
             "shift_by_date": shift_by_date,
+            "overtime_shifts": overtime_shifts,
+            "absences": absences,
+            "absence_types": _ABSENCE_TYPES,
             "year": year,
             "month": month,
             "allowed_codes": ["N1", "N2", "N3", "OC"],
@@ -194,6 +229,127 @@ async def admin_substitute_save(
             db.delete(row)
         current += timedelta(days=1)
 
+    db.commit()
+    clear_schedule_cache()
+
+    return RedirectResponse(url=f"/admin/substitutes/{substitute_id}?year={year}&month={month}", status_code=303)
+
+
+def _require_substitute(db: Session, substitute_id: int) -> Substitute:
+    substitute = db.query(Substitute).filter(Substitute.id == substitute_id).first()
+    if not substitute:
+        raise HTTPException(status_code=404, detail="Substitute not found")
+    return substitute
+
+
+@router.post("/admin/substitutes/{substitute_id}/overtime/add", name="admin_substitute_overtime_add")
+async def admin_substitute_overtime_add(
+    substitute_id: int,
+    date: str = Form(...),
+    start_time: str = Form(...),
+    end_time: str = Form(...),
+    hours: float = Form(...),
+    current_user: User = Depends(get_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Add an overtime entry for a substitute (hours only; ot_pay is always 0)."""
+    _require_substitute(db, substitute_id)
+
+    from datetime import datetime as _dt
+
+    ot_date = _dt.strptime(date, "%Y-%m-%d").date()
+    start_t = _dt.strptime(start_time, "%H:%M").time()
+    end_t = _dt.strptime(end_time, "%H:%M").time()
+
+    db.add(
+        OvertimeShift(
+            substitute_id=substitute_id,
+            date=ot_date,
+            start_time=start_t,
+            end_time=end_t,
+            hours=hours,
+            ot_pay=0.0,
+            is_extension=False,
+            created_by=current_user.id,
+        )
+    )
+    db.commit()
+    clear_schedule_cache()
+
+    return RedirectResponse(
+        url=f"/admin/substitutes/{substitute_id}?year={ot_date.year}&month={ot_date.month}", status_code=303
+    )
+
+
+@router.post("/admin/substitutes/{substitute_id}/overtime/{ot_id}/delete", name="admin_substitute_overtime_delete")
+async def admin_substitute_overtime_delete(
+    substitute_id: int,
+    ot_id: int,
+    current_user: User = Depends(get_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Delete an overtime entry belonging to a substitute."""
+    ot = db.query(OvertimeShift).filter(OvertimeShift.id == ot_id, OvertimeShift.substitute_id == substitute_id).first()
+    if not ot:
+        raise HTTPException(status_code=404, detail="Overtime entry not found")
+    year, month = ot.date.year, ot.date.month
+    db.delete(ot)
+    db.commit()
+    clear_schedule_cache()
+
+    return RedirectResponse(url=f"/admin/substitutes/{substitute_id}?year={year}&month={month}", status_code=303)
+
+
+@router.post("/admin/substitutes/{substitute_id}/absence/add", name="admin_substitute_absence_add")
+async def admin_substitute_absence_add(
+    substitute_id: int,
+    date: str = Form(...),
+    absence_type: str = Form(...),
+    current_user: User = Depends(get_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Add an absence day for a substitute (day tracking only, no deduction)."""
+    _require_substitute(db, substitute_id)
+
+    if absence_type not in _ABSENCE_TYPES:
+        raise HTTPException(status_code=400, detail="Invalid absence type")
+
+    from datetime import datetime as _dt
+
+    abs_date = _dt.strptime(date, "%Y-%m-%d").date()
+
+    existing = db.query(Absence).filter(Absence.substitute_id == substitute_id, Absence.date == abs_date).first()
+    if existing:
+        existing.absence_type = AbsenceType(absence_type)
+    else:
+        db.add(
+            Absence(
+                substitute_id=substitute_id,
+                date=abs_date,
+                absence_type=AbsenceType(absence_type),
+            )
+        )
+    db.commit()
+    clear_schedule_cache()
+
+    return RedirectResponse(
+        url=f"/admin/substitutes/{substitute_id}?year={abs_date.year}&month={abs_date.month}", status_code=303
+    )
+
+
+@router.post("/admin/substitutes/{substitute_id}/absence/{absence_id}/delete", name="admin_substitute_absence_delete")
+async def admin_substitute_absence_delete(
+    substitute_id: int,
+    absence_id: int,
+    current_user: User = Depends(get_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Delete an absence day belonging to a substitute."""
+    absence = db.query(Absence).filter(Absence.id == absence_id, Absence.substitute_id == substitute_id).first()
+    if not absence:
+        raise HTTPException(status_code=404, detail="Absence not found")
+    year, month = absence.date.year, absence.date.month
+    db.delete(absence)
     db.commit()
     clear_schedule_cache()
 

--- a/app/templates/admin_report.html
+++ b/app/templates/admin_report.html
@@ -1,0 +1,85 @@
+{# app/templates/admin_report.html #}
+{% extends "base.html" %}
+
+{% block title %}Periodical – Månadsrapport{% endblock %}
+
+{% block page_content %}
+
+<div class="page-header">
+    <div class="page-header-left">
+        <a href="/admin/users" class="btn secondary">&larr; Tillbaka</a>
+    </div>
+</div>
+
+<h2 class="page-title">Månadsrapport</h2>
+
+<div class="page-header" style="margin-bottom: 1rem;">
+    <div class="page-header-left">
+        <a href="/admin/report?year={{ prev_year }}&month={{ prev_month }}" class="btn secondary">&larr;</a>
+        <strong style="margin: 0 0.75rem;">{{ month_name }} {{ year }}</strong>
+        <a href="/admin/report?year={{ next_year }}&month={{ next_month }}" class="btn secondary">&rarr;</a>
+    </div>
+    <div class="page-header-right">
+        <a href="/admin/report.csv?year={{ year }}&month={{ month }}" class="btn">Exportera CSV</a>
+    </div>
+</div>
+
+<div style="overflow-x: auto;">
+<table class="report-table">
+    <thead>
+        <tr>
+            <th class="name-col">Namn</th>
+            <th>Pass</th>
+            <th>Timmar</th>
+            <th>Övertid</th>
+            <th>Beredskap</th>
+            <th>Kväll</th>
+            <th>Natt</th>
+            <th>Helg</th>
+            <th>Storhelg</th>
+            <th>Sjuk</th>
+            <th>VAB</th>
+            <th>Ledigt</th>
+            <th>Övrigt</th>
+            <th>Föräldra</th>
+            <th>Semester</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for r in rows %}
+            <tr>
+                <td class="name-col">
+                    {{ r.person_name }}
+                    {% if r.is_substitute %}
+                        <span class="badge" style="background: #3b82f6; color: white;">Vikarie</span>
+                    {% endif %}
+                </td>
+                <td>{{ r.num_shifts }}</td>
+                <td>{{ r.total_hours }}</td>
+                <td>{{ r.ot_hours }}</td>
+                <td>{{ r.oncall_hours }}</td>
+                <td>{{ r.ob_kvall }}</td>
+                <td>{{ r.ob_natt }}</td>
+                <td>{{ r.ob_helg }}</td>
+                <td>{{ r.ob_storhelg }}</td>
+                <td>{{ r.sick_days }}</td>
+                <td>{{ r.vab_days }}</td>
+                <td>{{ r.leave_days }}</td>
+                <td>{{ r.off_days }}</td>
+                <td>{{ r.parental_days }}</td>
+                <td>{{ r.vacation_days }}</td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>
+</div>
+
+<style>
+    .report-table { width: 100%; border-collapse: collapse; }
+    .report-table th,
+    .report-table td { padding: 6px; border: 1px solid var(--border); text-align: right; }
+    .report-table th { border-bottom-width: 2px; }
+    .report-table .name-col { text-align: left; }
+</style>
+
+{% endblock %}

--- a/app/templates/admin_substitute_manage.html
+++ b/app/templates/admin_substitute_manage.html
@@ -73,6 +73,77 @@
 
         <button type="submit" class="btn" style="margin-top: 1rem;">{{ t.admin_substitute_save }}</button>
     </form>
+
+    {# Overtime entries (hours only, no pay for substitutes) #}
+    <h3 style="margin-top: 2rem;">Övertid</h3>
+    <form method="POST" action="/admin/substitutes/{{ substitute.id }}/overtime/add"
+          style="display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: end; margin-bottom: 0.75rem;">
+        <label style="display: flex; flex-direction: column; font-size: 0.8rem;">Datum
+            <input type="date" name="date" value="{{ year }}-{{ '%02d'|format(month) }}-01" required>
+        </label>
+        <label style="display: flex; flex-direction: column; font-size: 0.8rem;">Från
+            <input type="time" name="start_time" required>
+        </label>
+        <label style="display: flex; flex-direction: column; font-size: 0.8rem;">Till
+            <input type="time" name="end_time" required>
+        </label>
+        <label style="display: flex; flex-direction: column; font-size: 0.8rem;">Timmar
+            <input type="number" name="hours" step="0.25" min="0" style="width: 6rem;" required>
+        </label>
+        <button type="submit" class="btn">Lägg till</button>
+    </form>
+    {% if overtime_shifts %}
+        <table style="width: 100%; border-collapse: collapse; margin-bottom: 1rem;">
+            <tbody>
+                {% for ot in overtime_shifts %}
+                    <tr style="border-bottom: 1px solid var(--border);">
+                        <td style="padding: 4px;">{{ ot.date }}</td>
+                        <td style="padding: 4px;">{{ '%02d:%02d'|format(ot.start_time.hour, ot.start_time.minute) }}&ndash;{{ '%02d:%02d'|format(ot.end_time.hour, ot.end_time.minute) }}</td>
+                        <td style="padding: 4px;">{{ ot.hours }} h</td>
+                        <td style="padding: 4px; text-align: right;">
+                            <form method="POST" action="/admin/substitutes/{{ substitute.id }}/overtime/{{ ot.id }}/delete" style="display: inline;">
+                                <button type="submit" class="btn secondary" style="padding: 2px 8px;">Ta bort</button>
+                            </form>
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
+
+    {# Absence entries (day tracking only, no deduction for substitutes) #}
+    <h3 style="margin-top: 1.5rem;">Frånvaro</h3>
+    <form method="POST" action="/admin/substitutes/{{ substitute.id }}/absence/add"
+          style="display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: end; margin-bottom: 0.75rem;">
+        <label style="display: flex; flex-direction: column; font-size: 0.8rem;">Datum
+            <input type="date" name="date" value="{{ year }}-{{ '%02d'|format(month) }}-01" required>
+        </label>
+        <label style="display: flex; flex-direction: column; font-size: 0.8rem;">Typ
+            <select name="absence_type" required>
+                {% for at in absence_types %}
+                    <option value="{{ at }}">{{ at }}</option>
+                {% endfor %}
+            </select>
+        </label>
+        <button type="submit" class="btn">Lägg till</button>
+    </form>
+    {% if absences %}
+        <table style="width: 100%; border-collapse: collapse;">
+            <tbody>
+                {% for a in absences %}
+                    <tr style="border-bottom: 1px solid var(--border);">
+                        <td style="padding: 4px;">{{ a.date }}</td>
+                        <td style="padding: 4px;">{{ a.absence_type }}</td>
+                        <td style="padding: 4px; text-align: right;">
+                            <form method="POST" action="/admin/substitutes/{{ substitute.id }}/absence/{{ a.id }}/delete" style="display: inline;">
+                                <button type="submit" class="btn secondary" style="padding: 2px 8px;">Ta bort</button>
+                            </form>
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
 </div>
 
 <style>

--- a/app/templates/admin_users.html
+++ b/app/templates/admin_users.html
@@ -16,6 +16,7 @@
         <h2 class="page-title" style="margin: 0;">{{ t.admin_users_title }}</h2>
     </div>
     <div class="page-header-right">
+        <a href="/admin/report" class="btn secondary">Månadsrapport</a>
         <a href="/admin/substitutes" class="btn secondary">{{ t.admin_substitutes_title }}</a>
         <a href="/admin/users/create" class="btn">{{ t.admin_create_user }}</a>
     </div>

--- a/migrations/migrate_substitute_ot_absence.py
+++ b/migrations/migrate_substitute_ot_absence.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+Migration: allow overtime, absence and on-call rows to reference a substitute.
+
+Adds a nullable ``substitute_id`` column to ``overtime_shifts``, ``absences`` and
+``oncall_overrides`` and makes their ``user_id`` column nullable. SQLite cannot drop a
+NOT NULL constraint in place, so each table is rebuilt (create new, copy data, drop,
+rename). Exactly one of user_id / substitute_id is expected to be set on each row; this
+is enforced at the route layer, not by a DB constraint.
+
+The script is idempotent: a table that already has a substitute_id column is skipped.
+
+Usage:
+    python migrations/migrate_substitute_ot_absence.py
+"""
+
+import sys
+from pathlib import Path
+
+# Add project root to path
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+# ruff: noqa: E402
+from sqlalchemy import text
+
+from app.database.database import engine
+
+# Target schema for each rebuilt table. user_id is nullable and substitute_id is added.
+NEW_TABLES = {
+    "overtime_shifts": """
+        CREATE TABLE overtime_shifts_new (
+            id INTEGER NOT NULL PRIMARY KEY,
+            user_id INTEGER,
+            substitute_id INTEGER,
+            date DATE NOT NULL,
+            start_time TIME NOT NULL,
+            end_time TIME NOT NULL,
+            hours FLOAT NOT NULL,
+            ot_pay FLOAT NOT NULL,
+            is_extension BOOLEAN NOT NULL DEFAULT 0,
+            created_at DATETIME,
+            created_by INTEGER,
+            FOREIGN KEY(user_id) REFERENCES users (id),
+            FOREIGN KEY(substitute_id) REFERENCES substitutes (id),
+            FOREIGN KEY(created_by) REFERENCES users (id)
+        )
+    """,
+    "absences": """
+        CREATE TABLE absences_new (
+            id INTEGER NOT NULL PRIMARY KEY,
+            user_id INTEGER,
+            substitute_id INTEGER,
+            date DATE NOT NULL,
+            absence_type VARCHAR NOT NULL,
+            left_at VARCHAR(5),
+            arrived_at VARCHAR(5),
+            created_at DATETIME,
+            FOREIGN KEY(user_id) REFERENCES users (id),
+            FOREIGN KEY(substitute_id) REFERENCES substitutes (id)
+        )
+    """,
+    "oncall_overrides": """
+        CREATE TABLE oncall_overrides_new (
+            id INTEGER NOT NULL PRIMARY KEY,
+            user_id INTEGER,
+            substitute_id INTEGER,
+            date DATE NOT NULL,
+            override_type VARCHAR NOT NULL,
+            reason VARCHAR(255),
+            created_at DATETIME,
+            created_by INTEGER,
+            FOREIGN KEY(user_id) REFERENCES users (id),
+            FOREIGN KEY(substitute_id) REFERENCES substitutes (id),
+            FOREIGN KEY(created_by) REFERENCES users (id)
+        )
+    """,
+}
+
+
+def _existing_columns(conn, table: str) -> list[str]:
+    result = conn.execute(text(f"PRAGMA table_info({table})"))
+    return [row[1] for row in result]
+
+
+def _rebuild_table(table: str, create_sql: str) -> None:
+    """Rebuild a single table, copying the intersection of old and new columns."""
+    with engine.connect() as conn:
+        columns = _existing_columns(conn, table)
+
+    if not columns:
+        print(f"   Skipping {table}: table not found.")
+        return
+    if "substitute_id" in columns:
+        print(f"   Skipping {table}: substitute_id already present.")
+        return
+
+    # New table columns (excluding the freshly added substitute_id which has no source data)
+    new_table = f"{table}_new"
+
+    # Toggle foreign keys outside the transaction (SQLite requirement for table rebuilds).
+    with engine.connect() as conn:
+        conn.execute(text("PRAGMA foreign_keys=OFF"))
+        conn.commit()
+
+    try:
+        with engine.begin() as conn:
+            conn.execute(text(create_sql))
+            new_columns = _existing_columns(conn, new_table)
+            # Copy only columns present in both old and new (substitute_id stays NULL).
+            shared = [c for c in new_columns if c in columns]
+            col_list = ", ".join(shared)
+            conn.execute(text(f"INSERT INTO {new_table} ({col_list}) SELECT {col_list} FROM {table}"))
+            conn.execute(text(f"DROP TABLE {table}"))
+            conn.execute(text(f"ALTER TABLE {new_table} RENAME TO {table}"))
+        print(f"   Rebuilt {table}: added substitute_id, user_id now nullable.")
+    finally:
+        with engine.connect() as conn:
+            conn.execute(text("PRAGMA foreign_keys=ON"))
+            conn.commit()
+
+
+def migrate() -> None:
+    print("Starting substitute OT/absence/on-call migration...")
+    for table, create_sql in NEW_TABLES.items():
+        _rebuild_table(table, create_sql)
+    print("Migration completed.")
+
+
+if __name__ == "__main__":
+    migrate()

--- a/tests/test_report_and_substitute_ot.py
+++ b/tests/test_report_and_substitute_ot.py
@@ -1,0 +1,160 @@
+"""Tests for the monthly report and overtime/absence on substitutes."""
+
+from app.auth.auth import create_access_token
+from app.core.schedule import build_month_report
+from app.database.database import Absence, OvertimeShift, Substitute
+
+
+def _login_admin(test_client, admin_user):
+    token = create_access_token(data={"sub": str(admin_user.id)})
+    test_client.cookies.set("access_token", token)
+
+
+def test_substitute_ot_and_absence_flow(test_client, test_db, admin_user):
+    _login_admin(test_client, admin_user)
+
+    # Create a substitute
+    test_client.post("/admin/substitutes/create", data={"name": "Vik Sommar"})
+    sub = test_db.query(Substitute).filter(Substitute.name == "Vik Sommar").first()
+    assert sub is not None
+
+    # Add an overtime entry (hours only, no pay)
+    r = test_client.post(
+        f"/admin/substitutes/{sub.id}/overtime/add",
+        data={"date": "2026-07-10", "start_time": "08:00", "end_time": "12:30", "hours": "4.5"},
+    )
+    assert r.status_code == 200  # followed redirect to manage page
+
+    ot = test_db.query(OvertimeShift).filter(OvertimeShift.substitute_id == sub.id).one()
+    assert ot.user_id is None
+    assert ot.hours == 4.5
+    assert ot.ot_pay == 0.0
+
+    # Add an absence day
+    r = test_client.post(
+        f"/admin/substitutes/{sub.id}/absence/add",
+        data={"date": "2026-07-11", "absence_type": "SICK"},
+    )
+    assert r.status_code == 200
+    absence = test_db.query(Absence).filter(Absence.substitute_id == sub.id).one()
+    assert absence.user_id is None
+    assert str(absence.absence_type) == "SICK"
+
+    # Add a vacation day (substitutes can have vacation registered manually too)
+    r = test_client.post(
+        f"/admin/substitutes/{sub.id}/absence/add",
+        data={"date": "2026-07-14", "absence_type": "VACATION"},
+    )
+    assert r.status_code == 200
+
+    # The manage page shows both entries
+    r = test_client.get(f"/admin/substitutes/{sub.id}?year=2026&month=7")
+    assert r.status_code == 200
+    assert "4.5" in r.text
+    assert "SICK" in r.text
+
+    # Report reflects the substitute's hours, sick day and vacation day
+    rows = build_month_report(2026, 7, test_db, fetch_tax_table=False)
+    sub_row = next(row for row in rows if row["substitute_id"] == sub.id)
+    assert sub_row["is_substitute"] is True
+    assert sub_row["ot_hours"] == 4.5
+    assert sub_row["total_hours"] == 4.5
+    assert sub_row["sick_days"] == 1
+    assert sub_row["vacation_days"] == 1
+    assert "brutto_pay" not in sub_row  # report tracks time only, no salary
+
+    # Invalid absence type is rejected
+    r = test_client.post(
+        f"/admin/substitutes/{sub.id}/absence/add",
+        data={"date": "2026-07-12", "absence_type": "BOGUS"},
+    )
+    assert r.status_code == 400
+
+    # Deleting the overtime entry removes it
+    r = test_client.post(f"/admin/substitutes/{sub.id}/overtime/{ot.id}/delete")
+    assert r.status_code == 200
+    assert test_db.query(OvertimeShift).filter(OvertimeShift.substitute_id == sub.id).count() == 0
+
+
+def test_report_page_and_csv(test_client, test_db, admin_user):
+    _login_admin(test_client, admin_user)
+
+    # Add a substitute with a worked day so it appears in the report
+    test_client.post("/admin/substitutes/create", data={"name": "Rapportvik"})
+    sub = test_db.query(Substitute).filter(Substitute.name == "Rapportvik").first()
+    test_client.post(
+        f"/admin/substitutes/{sub.id}/save",
+        data={"year": "2026", "month": "7", "shift_2026-07-06": "N1"},
+    )
+
+    # HTML report renders with the substitute row
+    r = test_client.get("/admin/report?year=2026&month=7")
+    assert r.status_code == 200
+    assert "Månadsrapport" in r.text
+    assert "Rapportvik" in r.text
+
+    # The substitute's worked N1 shift contributes night OB (OB2) to the report
+    rows = build_month_report(2026, 7, test_db)
+    sub_row = next(row for row in rows if row["substitute_id"] == sub.id)
+    assert sub_row["ob_natt"] == 1.0
+    assert sub_row["ob_kvall"] == 0.0
+    assert sub_row["ob_helg"] == 0.0
+    assert sub_row["ob_storhelg"] == 0.0
+
+    # CSV export downloads with the right headers and content
+    r = test_client.get("/admin/report.csv?year=2026&month=7")
+    assert r.status_code == 200
+    assert "text/csv" in r.headers["content-type"]
+    assert "attachment" in r.headers["content-disposition"]
+    assert "rapport-2026-07.csv" in r.headers["content-disposition"]
+    body = r.content.decode("utf-8-sig")
+    assert "Namn;Antal pass" in body
+    assert "Rapportvik" in body
+
+
+def test_substitute_overtime_on_oncall_day(test_client, test_db, admin_user):
+    """Overtime on an on-call day shows as OT in the month view and reduces standby hours."""
+    from datetime import date
+
+    from app.core.schedule.period import build_substitute_month_summaries
+
+    _login_admin(test_client, admin_user)
+
+    test_client.post("/admin/substitutes/create", data={"name": "Beredskapsvik"})
+    sub = test_db.query(Substitute).filter(Substitute.name == "Beredskapsvik").first()
+
+    # On-call (OC) day = 24h standby
+    test_client.post(
+        f"/admin/substitutes/{sub.id}/save",
+        data={"year": "2026", "month": "7", "shift_2026-07-08": "OC"},
+    )
+    # Overtime worked during the on-call day
+    test_client.post(
+        f"/admin/substitutes/{sub.id}/overtime/add",
+        data={"date": "2026-07-08", "start_time": "14:00", "end_time": "22:30", "hours": "8.5"},
+    )
+
+    summaries = build_substitute_month_summaries(2026, 7, test_db)
+    summary = next(s for s in summaries if s["substitute_id"] == sub.id)
+
+    # Standby reduced by the overtime hours: 24 - 8.5 = 15.5
+    assert summary["oncall_hours"] == 15.5
+    assert summary["ot_hours"] == 8.5
+
+    # The on-call day is displayed as OT in the month grid
+    ot_day = next(d for d in summary["days"] if d["date"] == date(2026, 7, 8))
+    assert ot_day["shift"].code == "OT"
+    assert ot_day["hours"] == 8.5
+
+    # Report row reflects the same figures
+    row = next(r for r in build_month_report(2026, 7, test_db) if r["substitute_id"] == sub.id)
+    assert row["oncall_hours"] == 15.5
+    assert row["ot_hours"] == 8.5
+
+
+def test_report_requires_admin(test_client, test_db, test_user):
+    """A non-admin user must not reach the report."""
+    token = create_access_token(data={"sub": str(test_user.id)})
+    test_client.cookies.set("access_token", token)
+    r = test_client.get("/admin/report?year=2026&month=7", follow_redirects=False)
+    assert r.status_code in (302, 303, 401, 403)


### PR DESCRIPTION
## Summary

Adds a consolidated monthly report and extends overtime/absence tracking to substitutes, plus three fixes to how substitute and parental-leave time is counted and shown.

### Monthly report (admin)
- New report at **Admin -> Monthly report** (`/admin/report`) with one row per agent and substitute for a selected month: shifts, hours, overtime, on-call and OB split into evening (OB1), night (OB2), weekend (OB3+OB4) and major holiday (OB5), plus absence and vacation days.
- CSV export (`/admin/report.csv`) with UTF-8 BOM and `;` delimiter so it opens directly in Swedish Excel. OB columns use the payroll codes 150-153.
- The report tracks time only; no salary is shown. Tax-table lookups are skipped.

### Overtime and absence on substitutes (admin)
- Overtime and absence (including vacation) can be registered manually per substitute under **Admin -> Substitutes**.
- New nullable `substitute_id` on `overtime_shifts`, `absences` and `oncall_overrides`; `user_id` is now nullable. Exactly one of `user_id` / `substitute_id` is set, enforced at the route layer. Idempotent migration included (table rebuild, since SQLite cannot drop NOT NULL in place).
- Substitutes have no salary, so overtime pay is always 0; hours and days are tracked.

### Fixes
- **Week-based parental leave** (`User.parental_leave`) was never counted because it renders as a LEAVE shift; it is now flagged and counted (report + summaries).
- **Substitute absences** now appear in the all-persons month view (rendered as a day shift), even for substitutes with no scheduled shift that month.
- **Substitute overtime** now appears as an OT shift in the month view, and on-call standby on an on-call day is reduced by the overtime worked during the on-call period.

### Changelog
- Adds user-facing 0.26.1 entries for the two month-view fixes (the admin-only report/registration is intentionally not listed in the public changelog).

## Testing
- New tests in `tests/test_report_and_substitute_ot.py` cover the report page/CSV, substitute overtime/absence flow, vacation tracking, and overtime-reduces-on-call.
- Full suite green (311 passed); ruff clean.