### PR TITLE
Add Excel export and shared-link access for the monthly report

### DIFF
--- a/app/core/schedule/period.py
+++ b/app/core/schedule/period.py
@@ -712,6 +712,7 @@ def build_substitute_month_summaries(year: int, month: int, session, include_ove
     absence_counts = _fetch_substitute_absence_counts(session, sub_ids, start_date, end_date)
     absence_by_date = _fetch_substitute_absences_by_date(session, sub_ids, start_date, end_date)
     shift_types = get_shift_types()
+    settings = get_settings()
 
     # OB rules for the month (same rules agents use); covers any year in range.
     combined_ob_rules: list = []
@@ -735,21 +736,36 @@ def build_substitute_month_summaries(year: int, month: int, session, include_ove
             absence = absence_by_date.get((sub.id, current))
             entry = shift_map.get((sub.id, current))
             code = entry.shift_code if entry else None
-            day_ot_hours = sum(o.hours or 0.0 for o in ot_by_date.get((sub.id, current), []))
+            ot_entries_today = ot_by_date.get((sub.id, current), [])
+            day_ot_hours = sum(o.hours or 0.0 for o in ot_entries_today)
+
+            # Overtime counts as a worked pass too (in addition to any scheduled shift).
+            num_shifts += len(ot_entries_today)
+
+            # Per-day detail so the day renders like an agent day in the Excel export.
+            day["ob_hours"] = {}
+            day["ot_hours"] = day_ot_hours
 
             if absence is not None:
                 # Absence days are counted via absence_counts below, not as worked shifts.
                 pass
             elif code == "OC":
                 # On-call standby is reduced by overtime worked during the on-call period.
-                oc_hours, _, _ = calculate_shift_hours(current, "OC")
-                oncall_hours += max(oc_hours - day_ot_hours, 0.0)
+                # Reuse the agent on-call calc for the per-code breakdown (hours only; no pay).
+                if ot_entries_today:
+                    _, oc_details = _recalculate_oncall_before_ot(current, ot_entries_today[0], {}, 0, settings, None)
+                else:
+                    oc_shift = next((s for s in shift_types if s.code == "OC"), None)
+                    _, oc_details = _compute_oncall_pay(oc_shift, current, 0, {}, settings, None)
+                day["oncall_details"] = oc_details
+                oncall_hours += oc_details.get("total_hours", 0.0)
             elif code in ("N1", "N2", "N3"):
                 hours, start, end = calculate_shift_hours(current, code)
                 worked_hours += hours
                 num_shifts += 1
                 # OB hours for the worked shift, accumulated per OB code
                 day_ob = calculate_ob_hours(start, end, combined_ob_rules)
+                day["ob_hours"] = day_ob
                 for ob_code, ob_h in day_ob.items():
                     if ob_h:
                         ob_hours[ob_code] = ob_hours.get(ob_code, 0.0) + ob_h

--- a/app/core/schedule/summary.py
+++ b/app/core/schedule/summary.py
@@ -318,6 +318,9 @@ def summarize_month_for_person(
             totals,
             ob_rate_overrides=user_rates.get("ob") if user_rates else None,
         )
+        # Carry the parental-leave marker through so exports can label the day correctly.
+        if day.get("parental_leave"):
+            day_data["parental_leave"] = True
         days_out.append(day_data)
 
     # Aggregate OB/OT hours per calendar day for the per-day breakdown toggle.
@@ -578,7 +581,9 @@ def _process_day_for_summary(
     if shift and shift.code != "OC":
         totals["total_hours"] += hours
 
-    if shift and shift.code not in ("OFF", "OC"):
+    # "Antal pass" counts actual worked shifts only: day/evening/night and overtime.
+    # On-call standby (OC) and all leave/absence days (OFF, SEM, SICK, VAB, LEAVE) are excluded.
+    if shift and shift.code in ("N1", "N2", "N3", "OT"):
         totals["num_shifts"] += 1
 
     for code, h in ob_hours.items():
@@ -895,14 +900,23 @@ def _report_row_from_summary(summary: dict, is_substitute: bool) -> dict:
     def _ob_sum(*codes: str) -> float:
         return round(sum(float(ob_hours_map.get(c, 0.0) or 0.0) for c in codes), 1)
 
+    # Hours = worked shift hours (day/evening/night) plus overtime, each counted once.
+    # summary["total_hours"] cannot be used directly: it double-counts non-extension OT.
+    ot_hours = float(summary.get("ot_hours", 0.0) or 0.0)
+    worked_pass_hours = sum(
+        float(d.get("hours", 0.0) or 0.0)
+        for d in (summary.get("days") or [])
+        if d.get("shift") is not None and getattr(d["shift"], "code", None) in ("N1", "N2", "N3")
+    )
+
     return {
         "person_name": summary.get("person_name", ""),
         "person_id": summary.get("person_id"),
         "substitute_id": summary.get("substitute_id"),
         "is_substitute": is_substitute,
         "num_shifts": summary.get("num_shifts", 0) or 0,
-        "total_hours": round(summary.get("total_hours", 0.0) or 0.0, 1),
-        "ot_hours": round(summary.get("ot_hours", 0.0) or 0.0, 1),
+        "total_hours": round(worked_pass_hours + ot_hours, 1),
+        "ot_hours": round(ot_hours, 1),
         "oncall_hours": round(summary.get("oncall_hours", 0.0) or 0.0, 1),
         # OB split into pay-code groups: evening, night, weekend, major holiday
         "ob_kvall": _ob_sum("OB1"),

--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -15,6 +15,17 @@ router = APIRouter()
 
 VERSIONS = [
     {
+        "version": "0.26.2",
+        "date": "2026-06-24",
+        "entries": [
+            {
+                "type": "fix",
+                "sv": "Antal pass i månads-, års- och statistikvyn räknar nu bara faktiskt arbetade pass (dag/kväll/natt och övertid). Beredskap, semester, sjuk- och frånvarodagar räknas inte längre som pass, så siffran kan vara lägre än tidigare",
+                "en": "The shift count in the month, year and statistics views now counts only actually worked shifts (day/evening/night and overtime). On-call, vacation, sick and absence days no longer count as shifts, so the number may be lower than before",
+            },
+        ],
+    },
+    {
         "version": "0.26.1",
         "date": "2026-06-24",
         "entries": [

--- a/app/routes/excel_shared.py
+++ b/app/routes/excel_shared.py
@@ -1,0 +1,248 @@
+# app/routes/excel_shared.py
+"""Shared Excel helpers for monthly exports.
+
+`populate_month_sheet` renders one agent's month into a worksheet, exactly the layout
+used by the per-person month export (/month/{id}/export-excel). It is reused by the
+admin monthly report so each agent tab looks identical to the single-person export.
+"""
+
+import calendar as _cal
+from datetime import date as _date
+
+from openpyxl.styles import Alignment, Font, PatternFill
+from openpyxl.utils import get_column_letter
+
+# Column layout for an agent's month sheet (index used to decide merge and filter).
+COL_HEADERS = [
+    "Datum",
+    "Veckodag",
+    "Skifttyp",
+    "Start",
+    "Slut",
+    "Vanliga timmar",
+    "OB Vardagskväll(x1,12)",
+    "OB Natt(x1,18)",
+    "OB tillägg helg(x1,24)",  # OB3 + OB4 merged
+    "OB tillägg storhelg(x1,47)",
+    "B.Vardag(75)",
+    "Beredskap Helg(97)",
+    "Beredskap Helgdag(112)",
+    "Beredskap Storhelg(192)",
+    "Övertid(x2)",
+    "Kommentar",
+]
+# First numeric column (0-based, from COL_HEADERS): "Vanliga timmar".
+NUM_START = 5
+
+# Alternative header labels used by the admin monthly report's agent tabs. Same columns
+# and order as COL_HEADERS, but OB uses the payroll codes (150-153) like the summary sheet.
+REPORT_COL_HEADERS = [
+    "Datum",
+    "Veckodag",
+    "Skifttyp",
+    "Start",
+    "Slut",
+    "Vanliga timmar",
+    "Kväll 150",
+    "Natt 151",
+    "Helg 152",
+    "Storhelg 153",
+    "Beredskap Vardag 75",
+    "Beredskap Helg 97",
+    "Beredskap Helgdag 112",
+    "Beredskap Storhelg 192",
+    "Övertid",
+    "Kommentar",
+]
+
+_SV_DAYS = ["Måndag", "Tisdag", "Onsdag", "Torsdag", "Fredag", "Lördag", "Söndag"]
+
+
+def autofit_columns(ws, min_width: int = 4, max_width: int = 40, padding: int = 0) -> None:
+    """Size each column to its widest cell, header included, so headers are never clipped.
+
+    Width is the longest value in the column (header or data), clamped to [min, max].
+    No extra padding is added: Excel's built-in cell margin already prevents clipping, so
+    adding characters here only leaves wasted whitespace on the right.
+    """
+    for col_cells in ws.columns:
+        longest = max((len(str(c.value)) for c in col_cells if c.value is not None), default=0)
+        width = min(max(longest + padding, min_width), max_width)
+        ws.column_dimensions[get_column_letter(col_cells[0].column)].width = width
+
+
+def _fmt_time(t) -> str:
+    if t is None:
+        return ""
+    if hasattr(t, "strftime"):
+        return t.strftime("%H:%M")
+    return str(t)[:5]
+
+
+def _build_month_rows(
+    summary: dict, year: int, month: int, headers: list[str] = COL_HEADERS, split_oncall_overtime: bool = True
+):
+    """Build (final_headers, final_rows, final_totals) for one agent's month.
+
+    Mirrors the per-person export: one row per calendar day and numeric columns with no
+    data dropped (text columns always kept). `headers` selects the displayed labels (same
+    structure as COL_HEADERS). With split_oncall_overtime=True a day with both on-call and
+    overtime is shown as two rows; with False they share one "Beredskap/Övertid" row.
+    """
+    num_days_in_month = _cal.monthrange(year, month)[1]
+    all_dates = [_date(year, month, d) for d in range(1, num_days_in_month + 1)]
+    day_lookup = {d["date"]: d for d in summary.get("days", [])}
+
+    rows = []
+    totals = [0.0] * len(COL_HEADERS)
+
+    for day_date in all_dates:
+        d = day_lookup.get(day_date)
+        shift = d.get("shift") if d else None
+        if d and d.get("parental_leave"):
+            # Week-based parental leave renders as a LEAVE shift; label it as parental.
+            shift_label = "Föräldraledigt"
+        elif not shift or shift.code == "OFF":
+            shift_label = "Ledig"
+        else:
+            shift_label = shift.label if hasattr(shift, "label") and shift.label else shift.code
+
+        partial_absence = d.get("partial_absence") if d else None
+        comment_parts = []
+        if partial_absence:
+            if partial_absence.arrived_at:
+                comment_parts.append(f"Sen ankomst {partial_absence.arrived_at}")
+            if partial_absence.left_at:
+                comment_parts.append(f"Slutade tidigt {partial_absence.left_at}")
+        comment = ", ".join(comment_parts)
+
+        if d and shift and shift.code not in ("OFF",):
+            start_t = d.get("start")
+            end_t = d.get("end")
+            if not start_t and shift and shift.start_time:
+                start_t = shift.start_time
+                end_t = shift.end_time
+            if d.get("ot_details") and d["ot_details"].get("is_extension"):
+                end_t_str = d["ot_details"]["end_time"][:5]
+            else:
+                end_t_str = _fmt_time(end_t)
+            start_str = _fmt_time(start_t)
+
+            ob1 = d["ob_hours"].get("OB1", 0) or 0
+            ob2 = d["ob_hours"].get("OB2", 0) or 0
+            ob3 = (d["ob_hours"].get("OB3", 0) or 0) + (d["ob_hours"].get("OB4", 0) or 0)
+            ob5 = d["ob_hours"].get("OB5", 0) or 0
+
+            ob_sum = ob1 + ob2 + ob3 + ob5
+            is_work = shift.code not in ("OC", "OT")
+            hours = d.get("hours", 0) or 0
+            norm = max((hours - ob_sum), 0) if is_work else 0
+
+            oc_bd = d.get("oncall_details", {}).get("breakdown", {}) if d.get("oncall_details") else {}
+            oc_vardag = oc_bd.get("OC_WEEKDAY", {}).get("hours", 0) or 0
+            oc_helg = (
+                (oc_bd.get("OC_WEEKEND", {}).get("hours", 0) or 0)
+                + (oc_bd.get("OC_WEEKEND_SAT", {}).get("hours", 0) or 0)
+                + (oc_bd.get("OC_WEEKEND_SUN", {}).get("hours", 0) or 0)
+                + (oc_bd.get("OC_WEEKEND_MON", {}).get("hours", 0) or 0)
+            )
+            oc_helgdag = (
+                (oc_bd.get("OC_HOLIDAY", {}).get("hours", 0) or 0)
+                + (oc_bd.get("OC_HOLIDAY_EVE", {}).get("hours", 0) or 0)
+                + (oc_bd.get("OC_NATIONALDAGEN", {}).get("hours", 0) or 0)
+            )
+            oc_storhelg = oc_bd.get("OC_SPECIAL", {}).get("hours", 0) or 0
+            ot = d.get("ot_hours", 0) or 0
+
+            num_vals = [norm, ob1, ob2, ob3, ob5, oc_vardag, oc_helg, oc_helgdag, oc_storhelg, ot, comment]
+
+            oc_total = oc_vardag + oc_helg + oc_helgdag + oc_storhelg
+            if oc_total > 0 and ot > 0 and split_oncall_overtime:
+                # Split into an on-call row and an overtime row
+                oc_vals = [0, 0, 0, 0, 0, oc_vardag, oc_helg, oc_helgdag, oc_storhelg, 0, ""]
+                ot_vals = [norm, ob1, ob2, ob3, ob5, 0, 0, 0, 0, ot, comment]
+                rows.append([str(day_date), _SV_DAYS[day_date.weekday()], "Beredskap", "", ""] + oc_vals)
+                rows.append([str(day_date), _SV_DAYS[day_date.weekday()], shift_label, start_str, end_t_str] + ot_vals)
+            elif oc_total > 0 and ot > 0:
+                # Keep on-call and overtime on a single row
+                rows.append(
+                    [str(day_date), _SV_DAYS[day_date.weekday()], "Beredskap/Övertid", start_str, end_t_str] + num_vals
+                )
+            else:
+                rows.append([str(day_date), _SV_DAYS[day_date.weekday()], shift_label, start_str, end_t_str] + num_vals)
+        else:
+            num_vals = [0.0] * 10 + [comment]
+            rows.append([str(day_date), _SV_DAYS[day_date.weekday()], shift_label, "", ""] + num_vals)
+
+        for i, v in enumerate(num_vals[:-1]):  # exclude comment column
+            totals[NUM_START + i] = totals[NUM_START + i] + v
+
+    # Drop numeric columns with no data anywhere; always keep the fixed text columns.
+    active_num = [any(row[NUM_START + i] for row in rows) for i in range(len(COL_HEADERS) - NUM_START)]
+    keep_cols = list(range(NUM_START)) + [NUM_START + i for i, v in enumerate(active_num) if v]
+
+    final_headers = [headers[i] for i in keep_cols]
+    final_rows = [[row[i] for i in keep_cols] for row in rows]
+    final_totals = [totals[i] for i in keep_cols]
+    return final_headers, final_rows, final_totals
+
+
+def populate_month_sheet(
+    ws,
+    summary: dict,
+    year: int,
+    month: int,
+    headers: list[str] = COL_HEADERS,
+    split_oncall_overtime: bool = True,
+) -> None:
+    """Fill a worksheet with one agent's month, matching the per-person Excel export.
+
+    `headers` overrides the displayed column labels (e.g. REPORT_COL_HEADERS for the
+    monthly report's agent tabs); the column structure is unchanged. With
+    split_oncall_overtime=False, on-call and overtime share one row instead of two.
+    """
+    final_headers, final_rows, final_totals = _build_month_rows(summary, year, month, headers, split_oncall_overtime)
+
+    header_fill = PatternFill("solid", fgColor="2D3748")
+    header_font = Font(bold=True, color="FFFFFF")
+    total_font = Font(bold=True)
+    center_align = Alignment(horizontal="center")
+    right_align = Alignment(horizontal="right")
+
+    ws.append(final_headers)
+    for cell in ws[1]:
+        cell.fill = header_fill
+        cell.font = header_font
+        cell.alignment = center_align
+
+    for row in final_rows:
+        ws.append(row)
+        r = ws.max_row
+        for col_idx, val in enumerate(row, start=1):
+            cell = ws.cell(row=r, column=col_idx)
+            if isinstance(val, (int, float)) and not isinstance(val, bool):
+                cell.number_format = "0.0"
+                cell.alignment = right_align
+                if val == 0:
+                    cell.value = None
+
+    # Total row
+    total_row = []
+    for i, _h in enumerate(final_headers):
+        if i == 0:
+            total_row.append("Total")
+        elif i < NUM_START:
+            total_row.append(None)
+        else:
+            v = final_totals[i]
+            total_row.append(round(v, 1) if v else None)
+
+    ws.append(total_row)
+    r = ws.max_row
+    for cell in ws[r]:
+        cell.font = total_font
+        if isinstance(cell.value, float):
+            cell.number_format = "0.0"
+            cell.alignment = right_align
+
+    autofit_columns(ws)

--- a/app/routes/reports.py
+++ b/app/routes/reports.py
@@ -1,23 +1,42 @@
 # app/routes/reports.py
 """Admin monthly report: one row per agent and substitute with hours, overtime,
-on-call and absence figures, viewable in the browser and exportable as CSV."""
+on-call and absence figures, viewable in the browser and exportable as Excel.
+
+Access is granted to logged-in admins, or via a shared secret link: appending
+?token=<REPORT_TOKEN> lets someone without an account (e.g. a manager) open the report
+and download the Excel. The token is configured via the REPORT_TOKEN environment variable;
+when unset, only admins have access."""
 
 import csv
 import io
+import os
+import secrets
 
-from fastapi import APIRouter, Depends, Request
-from fastapi.responses import HTMLResponse, StreamingResponse
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse, StreamingResponse
 from sqlalchemy.orm import Session
 
-from app.auth.auth import get_admin_user
+from app.auth.auth import get_current_user_optional
 from app.core.helpers import render_template
 from app.core.schedule import build_month_report, rotation_start_date
 from app.core.utils import get_safe_today
 from app.core.validators import validate_date_params
-from app.database.database import User, get_db
+from app.database.database import User, UserRole, get_db
 from app.routes.shared import templates
 
 router = APIRouter(tags=["reports"])
+
+REPORT_TOKEN = os.getenv("REPORT_TOKEN", "")
+
+
+def _has_report_access(current_user: User | None, token: str) -> bool:
+    """Allow logged-in admins, or anyone presenting the configured shared report token."""
+    if current_user is not None and current_user.role == UserRole.ADMIN:
+        return True
+    if REPORT_TOKEN and token and secrets.compare_digest(token, REPORT_TOKEN):
+        return True
+    return False
+
 
 MONTH_NAMES_SV = [
     "Januari",
@@ -83,10 +102,14 @@ async def admin_report(
     request: Request,
     year: int = None,
     month: int = None,
-    current_user: User = Depends(get_admin_user),
+    token: str = "",
+    current_user: User | None = Depends(get_current_user_optional),
     db: Session = Depends(get_db),
 ):
     """Monthly report table for all agents and substitutes."""
+    if not _has_report_access(current_user, token):
+        return RedirectResponse(url=f"/login?next={request.url.path}", status_code=302)
+
     year, month = _resolve_year_month(year, month)
     rows = build_month_report(year, month, db)
 
@@ -108,6 +131,8 @@ async def admin_report(
             "prev_month": prev_month,
             "next_year": next_year,
             "next_month": next_month,
+            # Propagated through page links so shared-token users keep access while navigating.
+            "token": token,
         },
         user=current_user,
     )
@@ -117,10 +142,13 @@ async def admin_report(
 async def admin_report_csv(
     year: int = None,
     month: int = None,
-    current_user: User = Depends(get_admin_user),
+    token: str = "",
+    current_user: User | None = Depends(get_current_user_optional),
     db: Session = Depends(get_db),
 ):
     """Download the monthly report as a CSV file (UTF-8 with BOM for Excel)."""
+    if not _has_report_access(current_user, token):
+        raise HTTPException(status_code=403, detail="Åtkomst nekad")
     year, month = _resolve_year_month(year, month)
     rows = build_month_report(year, month, db)
 
@@ -144,7 +172,8 @@ async def admin_report_csv(
 async def admin_report_xlsx(
     year: int = None,
     month: int = None,
-    current_user: User = Depends(get_admin_user),
+    token: str = "",
+    current_user: User | None = Depends(get_current_user_optional),
     db: Session = Depends(get_db),
 ):
     """Download the monthly report as an Excel workbook.
@@ -153,6 +182,8 @@ async def admin_report_xlsx(
     (rotation positions 1-10) then gets its own sheet, formatted exactly like the
     per-person month export.
     """
+    if not _has_report_access(current_user, token):
+        raise HTTPException(status_code=403, detail="Åtkomst nekad")
     import openpyxl
     from openpyxl.styles import Alignment, Font, PatternFill
 

--- a/app/routes/reports.py
+++ b/app/routes/reports.py
@@ -118,6 +118,11 @@ async def admin_report(
     next_month = month + 1 if month < 12 else 1
     next_year = year + 1 if month == 12 else year
 
+    # Admins see a copyable share link (built from the configured token); token-only
+    # visitors already have the link, so it is not re-exposed to them.
+    is_admin = current_user is not None and current_user.role == UserRole.ADMIN
+    share_token = REPORT_TOKEN if is_admin else ""
+
     return render_template(
         templates,
         "admin_report.html",
@@ -133,6 +138,9 @@ async def admin_report(
             "next_month": next_month,
             # Propagated through page links so shared-token users keep access while navigating.
             "token": token,
+            # The shared report token, shown to admins as a copyable link (empty if unset).
+            "share_token": share_token,
+            "is_admin": is_admin,
         },
         user=current_user,
     )

--- a/app/routes/reports.py
+++ b/app/routes/reports.py
@@ -54,6 +54,22 @@ CSV_COLUMNS = [
 ]
 
 
+# Excel sheet titles cannot contain []:*?/\ and are limited to 31 characters.
+_SHEET_TRANS = str.maketrans({c: " " for c in "[]:*?/\\"})
+
+
+def _safe_sheet_title(name: str, used: set[str]) -> str:
+    """Return a valid, unique Excel sheet title derived from a person's name."""
+    base = (name or "").translate(_SHEET_TRANS).strip()[:31] or "Agent"
+    title = base
+    i = 2
+    while title in used:
+        suffix = f" ({i})"
+        title = f"{base[: 31 - len(suffix)]}{suffix}"
+        i += 1
+    return title
+
+
 def _resolve_year_month(year: int | None, month: int | None) -> tuple[int, int]:
     safe_today = get_safe_today(rotation_start_date)
     year = year or safe_today.year
@@ -120,5 +136,71 @@ async def admin_report_csv(
     return StreamingResponse(
         iter([buffer.getvalue()]),
         media_type="text/csv; charset=utf-8",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@router.get("/admin/report.xlsx", name="admin_report_xlsx")
+async def admin_report_xlsx(
+    year: int = None,
+    month: int = None,
+    current_user: User = Depends(get_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Download the monthly report as an Excel workbook.
+
+    The first sheet is the consolidated report (same columns as the CSV). Each agent
+    (rotation positions 1-10) then gets its own sheet, formatted exactly like the
+    per-person month export.
+    """
+    import openpyxl
+    from openpyxl.styles import Alignment, Font, PatternFill
+
+    from app.core.schedule import build_substitute_month_summaries
+    from app.core.schedule.summary import summarize_month_for_person
+    from app.routes.excel_shared import REPORT_COL_HEADERS, autofit_columns, populate_month_sheet
+
+    year, month = _resolve_year_month(year, month)
+    rows = build_month_report(year, month, db)
+
+    wb = openpyxl.Workbook()
+
+    # Sheet 1: consolidated summary, same layout as the CSV.
+    ws = wb.active
+    ws.title = "Sammanställning"
+    ws.append([label for _, label in CSV_COLUMNS])
+    header_fill = PatternFill("solid", fgColor="2D3748")
+    header_font = Font(bold=True, color="FFFFFF")
+    for cell in ws[1]:
+        cell.fill = header_fill
+        cell.font = header_font
+        cell.alignment = Alignment(horizontal="center")
+    for row in rows:
+        ws.append([row.get(key, "") for key, _ in CSV_COLUMNS])
+    autofit_columns(ws)
+
+    # One sheet per agent (rotation positions 1-10), identical to the /month/{id} export.
+    used_titles = {ws.title}
+    for pid in range(1, 11):
+        summary = summarize_month_for_person(year, month, pid, session=db, payment_year=year)
+        title = _safe_sheet_title(summary.get("person_name") or f"Agent {pid}", used_titles)
+        used_titles.add(title)
+        agent_ws = wb.create_sheet(title=title)
+        populate_month_sheet(agent_ws, summary, year, month, headers=REPORT_COL_HEADERS, split_oncall_overtime=False)
+
+    # One sheet per substitute with activity in the month, same layout as the agent tabs.
+    for sub_summary in build_substitute_month_summaries(year, month, db, include_overtime=True):
+        title = _safe_sheet_title(sub_summary.get("person_name") or "Vikarie", used_titles)
+        used_titles.add(title)
+        sub_ws = wb.create_sheet(title=title)
+        populate_month_sheet(sub_ws, sub_summary, year, month, headers=REPORT_COL_HEADERS, split_oncall_overtime=False)
+
+    buf = io.BytesIO()
+    wb.save(buf)
+    buf.seek(0)
+    filename = f"rapport-{year}-{month:02d}.xlsx"
+    return StreamingResponse(
+        buf,
+        media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )

--- a/app/routes/schedule_personal.py
+++ b/app/routes/schedule_personal.py
@@ -3,7 +3,6 @@
 Personal schedule view routes - day, week, month, and year views for specific persons.
 """
 
-import calendar as _cal
 import io
 from datetime import date, datetime, time, timedelta
 
@@ -998,10 +997,9 @@ async def export_month_excel(
 ):
     """Export monthly data as an Excel file."""
     import openpyxl
-    from openpyxl.styles import Alignment, Font, PatternFill
-    from openpyxl.utils import get_column_letter
 
     from app.core.schedule.summary import summarize_month_for_person
+    from app.routes.excel_shared import populate_month_sheet
 
     if current_user is None:
         return RedirectResponse(url=f"/login?next={request.url.path}", status_code=302)
@@ -1036,198 +1034,11 @@ async def export_month_excel(
 
     days_in_month = summarize_month_for_person(year, month, rotation_position, session=db, payment_year=year)
 
-    # ── Build row data ───────────────────────────────────────────────────
-    # Column definitions (index used to decide merge and filter)
-    COL_HEADERS = [
-        "Datum",
-        "Veckodag",
-        "Skifttyp",
-        "Start",
-        "Slut",
-        "Vanliga timmar",
-        "OB Vardagskväll(x1,12)",
-        "OB Natt(x1,18)",
-        "OB tillägg helg(x1,24)",  # OB3 + OB4 merged
-        "OB tillägg storhelg(x1,47)",
-        "B.Vardag(75)",
-        "Beredskap Helg(97)",
-        "Beredskap Helgdag(112)",
-        "Beredskap Storhelg(192)",
-        "Övertid(x2)",
-        "Kommentar",
-    ]
-    # Indices for numeric columns (0-based, from COL_HEADERS)
-    NUM_START = 5  # "Vanliga timmar" is col index 5
-
-    # Weekday name lookup (Swedish)
-    _SV_DAYS = ["Måndag", "Tisdag", "Onsdag", "Torsdag", "Fredag", "Lördag", "Söndag"]
-
-    def _fmt_time(t):
-        if t is None:
-            return ""
-        if hasattr(t, "strftime"):
-            return t.strftime("%H:%M")
-        return str(t)[:5]
-
-    # Get all days in the calendar month (not just shifts)
-    num_days_in_month = _cal.monthrange(year, month)[1]
-    from datetime import date as _date
-
-    all_dates = {_date(year, month, d): None for d in range(1, num_days_in_month + 1)}
-
-    # Build lookup from days_in_month["days"]
-    day_lookup = {d["date"]: d for d in days_in_month.get("days", [])}
-
-    rows = []
-    totals = [0.0] * len(COL_HEADERS)
-
-    for day_date in sorted(all_dates):
-        d = day_lookup.get(day_date)
-        shift = d.get("shift") if d else None
-        if not shift or shift.code == "OFF":
-            shift_label = "Ledig"
-        else:
-            shift_label = shift.label if hasattr(shift, "label") and shift.label else shift.code
-
-        # Build comment from partial absence (arrived late / left early)
-        partial_absence = d.get("partial_absence") if d else None
-        comment_parts = []
-        if partial_absence:
-            if partial_absence.arrived_at:
-                comment_parts.append(f"Sen ankomst {partial_absence.arrived_at}")
-            if partial_absence.left_at:
-                comment_parts.append(f"Slutade tidigt {partial_absence.left_at}")
-        comment = ", ".join(comment_parts)
-
-        if d and shift and shift.code not in ("OFF",):
-            # Times
-            start_t = d.get("start")
-            end_t = d.get("end")
-            if not start_t and shift and shift.start_time:
-                start_t = shift.start_time
-                end_t = shift.end_time
-            if d.get("ot_details") and d["ot_details"].get("is_extension"):
-                end_t_str = d["ot_details"]["end_time"][:5]
-            else:
-                end_t_str = _fmt_time(end_t)
-            start_str = _fmt_time(start_t)
-
-            ob1 = d["ob_hours"].get("OB1", 0) or 0
-            ob2 = d["ob_hours"].get("OB2", 0) or 0
-            ob3 = (d["ob_hours"].get("OB3", 0) or 0) + (d["ob_hours"].get("OB4", 0) or 0)
-            ob5 = d["ob_hours"].get("OB5", 0) or 0
-
-            ob_sum = ob1 + ob2 + ob3 + ob5
-            is_work = shift.code not in ("OC", "OT")
-            hours = d.get("hours", 0) or 0
-            norm = max((hours - ob_sum), 0) if is_work else 0
-
-            oc_bd = d.get("oncall_details", {}).get("breakdown", {}) if d.get("oncall_details") else {}
-            oc_vardag = oc_bd.get("OC_WEEKDAY", {}).get("hours", 0) or 0
-            oc_helg = (
-                (oc_bd.get("OC_WEEKEND", {}).get("hours", 0) or 0)
-                + (oc_bd.get("OC_WEEKEND_SAT", {}).get("hours", 0) or 0)
-                + (oc_bd.get("OC_WEEKEND_SUN", {}).get("hours", 0) or 0)
-                + (oc_bd.get("OC_WEEKEND_MON", {}).get("hours", 0) or 0)
-            )
-            oc_helgdag = (
-                (oc_bd.get("OC_HOLIDAY", {}).get("hours", 0) or 0)
-                + (oc_bd.get("OC_HOLIDAY_EVE", {}).get("hours", 0) or 0)
-                + (oc_bd.get("OC_NATIONALDAGEN", {}).get("hours", 0) or 0)
-            )
-            oc_storhelg = oc_bd.get("OC_SPECIAL", {}).get("hours", 0) or 0
-            ot = d.get("ot_hours", 0) or 0
-
-            num_vals = [norm, ob1, ob2, ob3, ob5, oc_vardag, oc_helg, oc_helgdag, oc_storhelg, ot, comment]
-
-            oc_total = oc_vardag + oc_helg + oc_helgdag + oc_storhelg
-            if oc_total > 0 and ot > 0:
-                # Split into an on-call row and an overtime row
-                oc_vals = [0, 0, 0, 0, 0, oc_vardag, oc_helg, oc_helgdag, oc_storhelg, 0, ""]
-                ot_vals = [norm, ob1, ob2, ob3, ob5, 0, 0, 0, 0, ot, comment]
-                rows.append([str(day_date), _SV_DAYS[day_date.weekday()], "Beredskap", "", ""] + oc_vals)
-                rows.append([str(day_date), _SV_DAYS[day_date.weekday()], shift_label, start_str, end_t_str] + ot_vals)
-            else:
-                rows.append([str(day_date), _SV_DAYS[day_date.weekday()], shift_label, start_str, end_t_str] + num_vals)
-        else:
-            start_str = ""
-            end_t_str = ""
-            num_vals = [0.0] * 10 + [comment]
-            rows.append([str(day_date), _SV_DAYS[day_date.weekday()], shift_label, start_str, end_t_str] + num_vals)
-
-        for i, v in enumerate(num_vals[:-1]):  # exclude comment column
-            totals[NUM_START + i] = totals[NUM_START + i] + v
-
-    # ── Determine which numeric columns have any data ───────────────────
-    active_num = [any(row[NUM_START + i] for row in rows) for i in range(len(COL_HEADERS) - NUM_START)]
-    # Always keep fixed text columns
-    keep_cols = list(range(NUM_START)) + [NUM_START + i for i, v in enumerate(active_num) if v]
-
-    final_headers = [COL_HEADERS[i] for i in keep_cols]
-    final_rows = [[row[i] for i in keep_cols] for row in rows]
-    final_totals = [totals[i] for i in keep_cols]
-
     # ── Build workbook ───────────────────────────────────────────────────
     wb = openpyxl.Workbook()
     ws = wb.active
     ws.title = f"{year}-{month:02d}"
-
-    header_fill = PatternFill("solid", fgColor="2D3748")
-    header_font = Font(bold=True, color="FFFFFF")
-    total_font = Font(bold=True)
-    center_align = Alignment(horizontal="center")
-    right_align = Alignment(horizontal="right")
-
-    # Header row
-    ws.append(final_headers)
-    for cell in ws[1]:
-        cell.fill = header_fill
-        cell.font = header_font
-        cell.alignment = center_align
-
-    # Data rows
-    for row in final_rows:
-        ws.append(row)
-        r = ws.max_row
-        for col_idx, val in enumerate(row, start=1):
-            cell = ws.cell(row=r, column=col_idx)
-            if isinstance(val, (int, float)) and not isinstance(val, bool):
-                cell.number_format = "0.0"
-                cell.alignment = right_align
-                if val == 0:
-                    cell.value = None
-
-    # Total row
-    total_row = []
-    for i, _h in enumerate(final_headers):
-        if i == 0:
-            total_row.append("Total")
-        elif i < NUM_START:
-            total_row.append(None)
-        else:
-            v = final_totals[i]
-            total_row.append(round(v, 1) if v else None)
-
-    ws.append(total_row)
-    r = ws.max_row
-    for cell in ws[r]:
-        cell.font = total_font
-        if isinstance(cell.value, float):
-            cell.number_format = "0.0"
-            cell.alignment = right_align
-
-    # Column widths
-    col_widths = {
-        "Datum": 12,
-        "Veckodag": 12,
-        "Skifttyp": 14,
-        "Start": 7,
-        "Slut": 7,
-        "Kommentar": 28,
-    }
-    default_num_width = 22
-    for i, h in enumerate(final_headers, start=1):
-        ws.column_dimensions[get_column_letter(i)].width = col_widths.get(h, default_num_width)
+    populate_month_sheet(ws, days_in_month, year, month)
 
     # ── Stream response ──────────────────────────────────────────────────
     buf = io.BytesIO()

--- a/app/templates/admin_report.html
+++ b/app/templates/admin_report.html
@@ -28,6 +28,40 @@
     </div>
 </div>
 
+{% if is_admin %}
+    {% if share_token %}
+    <div style="margin-bottom: 1rem; padding: 0.75rem; border: 1px solid var(--border); border-radius: 6px; background: var(--muted-bg, #1c1c24);">
+        <div style="font-size: 0.85rem; color: var(--muted); margin-bottom: 0.4rem;">
+            Delningslänk (öppnar rapporten utan inloggning, t.ex. för chef):
+        </div>
+        <div style="display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap;">
+            <input id="share-link" type="text" readonly
+                   style="flex: 1; min-width: 280px; padding: 6px; font-size: 0.85rem;">
+            <button type="button" class="btn secondary" onclick="copyShareLink()">Kopiera</button>
+        </div>
+    </div>
+    <script>
+    // Build the link from the browser's actual origin so it is correct on dev and prod.
+    var SHARE_TOKEN = {{ share_token | tojson }};
+    document.getElementById('share-link').value = window.location.origin + '/admin/report?token=' + SHARE_TOKEN;
+    function copyShareLink() {
+        var el = document.getElementById('share-link');
+        el.select();
+        navigator.clipboard.writeText(el.value).then(function () {
+            var btn = event.target;
+            var orig = btn.textContent;
+            btn.textContent = 'Kopierad!';
+            setTimeout(function () { btn.textContent = orig; }, 1500);
+        });
+    }
+    </script>
+    {% else %}
+    <p class="info-text" style="margin-bottom: 1rem;">
+        Delningslänk är inte konfigurerad. Sätt miljövariabeln <code>REPORT_TOKEN</code> för att aktivera en länk som öppnar rapporten utan inloggning.
+    </p>
+    {% endif %}
+{% endif %}
+
 <div style="overflow-x: auto;">
 <table class="report-table">
     <thead>

--- a/app/templates/admin_report.html
+++ b/app/templates/admin_report.html
@@ -20,7 +20,8 @@
         <a href="/admin/report?year={{ next_year }}&month={{ next_month }}" class="btn secondary">&rarr;</a>
     </div>
     <div class="page-header-right">
-        <a href="/admin/report.csv?year={{ year }}&month={{ month }}" class="btn">Exportera CSV</a>
+        <a href="/admin/report.csv?year={{ year }}&month={{ month }}" class="btn secondary">Exportera CSV</a>
+        <a href="/admin/report.xlsx?year={{ year }}&month={{ month }}" class="btn">Exportera Excel</a>
     </div>
 </div>
 

--- a/app/templates/admin_report.html
+++ b/app/templates/admin_report.html
@@ -5,23 +5,26 @@
 
 {% block page_content %}
 
+{% set token_qs = '&token=' ~ token if token else '' %}
+
+{% if not token %}
 <div class="page-header">
     <div class="page-header-left">
         <a href="/admin/users" class="btn secondary">&larr; Tillbaka</a>
     </div>
 </div>
+{% endif %}
 
 <h2 class="page-title">Månadsrapport</h2>
 
 <div class="page-header" style="margin-bottom: 1rem;">
     <div class="page-header-left">
-        <a href="/admin/report?year={{ prev_year }}&month={{ prev_month }}" class="btn secondary">&larr;</a>
+        <a href="/admin/report?year={{ prev_year }}&month={{ prev_month }}{{ token_qs }}" class="btn secondary">&larr;</a>
         <strong style="margin: 0 0.75rem;">{{ month_name }} {{ year }}</strong>
-        <a href="/admin/report?year={{ next_year }}&month={{ next_month }}" class="btn secondary">&rarr;</a>
+        <a href="/admin/report?year={{ next_year }}&month={{ next_month }}{{ token_qs }}" class="btn secondary">&rarr;</a>
     </div>
     <div class="page-header-right">
-        <a href="/admin/report.csv?year={{ year }}&month={{ month }}" class="btn secondary">Exportera CSV</a>
-        <a href="/admin/report.xlsx?year={{ year }}&month={{ month }}" class="btn">Exportera Excel</a>
+        <a href="/admin/report.xlsx?year={{ year }}&month={{ month }}{{ token_qs }}" class="btn">Exportera Excel</a>
     </div>
 </div>
 

--- a/tests/test_report_and_substitute_ot.py
+++ b/tests/test_report_and_substitute_ot.py
@@ -112,6 +112,42 @@ def test_report_page_and_csv(test_client, test_db, admin_user):
     assert "Rapportvik" in body
 
 
+def test_report_xlsx_export(test_client, test_db, admin_user):
+    """The Excel export has a summary sheet plus one sheet per agent with 15x headers."""
+    import io
+
+    import openpyxl
+
+    _login_admin(test_client, admin_user)
+
+    # A substitute with a worked shift so it gets its own tab
+    test_client.post("/admin/substitutes/create", data={"name": "Excelvik"})
+    sub = test_db.query(Substitute).filter(Substitute.name == "Excelvik").first()
+    test_client.post(
+        f"/admin/substitutes/{sub.id}/save",
+        data={"year": "2026", "month": "7", "shift_2026-07-06": "N1"},
+    )
+
+    r = test_client.get("/admin/report.xlsx?year=2026&month=7")
+    assert r.status_code == 200
+    assert "spreadsheetml" in r.headers["content-type"]
+    assert "rapport-2026-07.xlsx" in r.headers["content-disposition"]
+
+    wb = openpyxl.load_workbook(io.BytesIO(r.content))
+    # First sheet is the consolidated summary, same headers as the CSV
+    assert wb.sheetnames[0] == "Sammanställning"
+    summary_headers = [c.value for c in wb["Sammanställning"][1]]
+    assert summary_headers[:3] == ["Namn", "Antal pass", "Timmar"]
+    # One sheet per agent (rotation positions 1-10) plus one per active substitute
+    assert len(wb.sheetnames) == 12
+    assert "Excelvik" in wb.sheetnames
+    # Agent/substitute tabs use the payroll-code (15x) OB headers, not /month multiplier labels
+    agent_headers = [c.value for c in wb[wb.sheetnames[1]][1]]
+    assert "Kväll 150" in agent_headers
+    assert "Natt 151" in agent_headers
+    assert all("x1," not in (h or "") for h in agent_headers)
+
+
 def test_substitute_overtime_on_oncall_day(test_client, test_db, admin_user):
     """Overtime on an on-call day shows as OT in the month view and reduces standby hours."""
     from datetime import date

--- a/tests/test_report_and_substitute_ot.py
+++ b/tests/test_report_and_substitute_ot.py
@@ -141,11 +141,12 @@ def test_report_xlsx_export(test_client, test_db, admin_user):
     # One sheet per agent (rotation positions 1-10) plus one per active substitute
     assert len(wb.sheetnames) == 12
     assert "Excelvik" in wb.sheetnames
-    # Agent/substitute tabs use the payroll-code (15x) OB headers, not /month multiplier labels
-    agent_headers = [c.value for c in wb[wb.sheetnames[1]][1]]
-    assert "Kväll 150" in agent_headers
-    assert "Natt 151" in agent_headers
-    assert all("x1," not in (h or "") for h in agent_headers)
+    # The substitute tab has a worked N1 shift (which yields night OB), so it uses the
+    # payroll-code (15x) OB headers, not the /month multiplier labels. Checked on this
+    # sheet because empty agents drop their (data-less) numeric columns.
+    sub_headers = [c.value for c in wb["Excelvik"][1]]
+    assert "Natt 151" in sub_headers
+    assert all("x1," not in (h or "") for h in sub_headers)
 
 
 def test_substitute_overtime_on_oncall_day(test_client, test_db, admin_user):

--- a/tests/test_report_and_substitute_ot.py
+++ b/tests/test_report_and_substitute_ot.py
@@ -194,3 +194,31 @@ def test_report_requires_admin(test_client, test_db, test_user):
     test_client.cookies.set("access_token", token)
     r = test_client.get("/admin/report?year=2026&month=7", follow_redirects=False)
     assert r.status_code in (302, 303, 401, 403)
+
+
+def test_report_shared_token_access(test_client, test_db, monkeypatch):
+    """A correct shared token grants access to the report and Excel without an account."""
+    from app.routes import reports
+
+    monkeypatch.setattr(reports, "REPORT_TOKEN", "s3cret-report-link")
+    test_client.cookies.clear()
+
+    # No login and no token -> redirected to login
+    r = test_client.get("/admin/report?year=2026&month=7", follow_redirects=False)
+    assert r.status_code == 302
+
+    # Correct token -> report renders without login
+    r = test_client.get("/admin/report?year=2026&month=7&token=s3cret-report-link")
+    assert r.status_code == 200
+    assert "Månadsrapport" in r.text
+
+    # Correct token -> Excel downloads without login
+    r = test_client.get("/admin/report.xlsx?year=2026&month=7&token=s3cret-report-link")
+    assert r.status_code == 200
+    assert "spreadsheetml" in r.headers["content-type"]
+
+    # Wrong token -> rejected
+    r = test_client.get("/admin/report?year=2026&month=7&token=nope", follow_redirects=False)
+    assert r.status_code == 302
+    r = test_client.get("/admin/report.xlsx?year=2026&month=7&token=nope")
+    assert r.status_code == 403


### PR DESCRIPTION
## Summary

Builds on the monthly report (PR #265) with an Excel export, a no-account access path for a manager, and several counting fixes.

### Excel export
- New **Exportera Excel** button on the report producing an `.xlsx` workbook: first sheet is the consolidated summary (same columns as the CSV); each agent and each active substitute then gets its own sheet, laid out like the per-person month export but with payroll-code OB headers (150-153) and on-call/overtime combined onto one row.
- Refactors the per-person month export to share `excel_shared.populate_month_sheet`, so both exports stay in sync; columns are auto-sized to their content.
- Removes the CSV export button (Excel replaces it); the CSV endpoint remains.

### Shared-link access (no account)
- Appending `?token=<REPORT_TOKEN>` grants access to the report page and the Excel download without logging in, so a manager without an account can pull the report. Configured via the `REPORT_TOKEN` environment variable; when unset, only admins have access. The token is compared with `secrets.compare_digest` and propagated through month navigation and the Excel link.
- Admins see a copyable share link (built from the browser origin) on the report page, or a hint to set `REPORT_TOKEN` when it is unset.

### Fixes
- Shift count ("antal pass") counts only worked shifts (day/evening/night and overtime); on-call, vacation, sick and absence days are excluded. Visible in the month, year and statistics views, so it is listed in the changelog (0.26.2).
- Report hours no longer double-count non-extension overtime; hours are worked-shift hours plus overtime, each counted once.
- Substitute overtime now counts as a worked pass.
- Week-based parental leave is labelled "Föräldraledigt" (not "Ledig") in exports.

## Testing
- New/updated tests in `tests/test_report_and_substitute_ot.py` cover the Excel export (summary + per-agent/substitute sheets, 15x headers), shared-token access (report + Excel, wrong token rejected), substitute overtime on an on-call day, and vacation tracking.
- Full suite green (313 passed); ruff clean.
