### PR TITLE
Harden templates: extract inline styles into CSS classes

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,88 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+A single rotating team of about ten people working day, evening, and night
+shifts plus on-call (Beredskap) in Sweden. They are not power users of software;
+they open Periodical to settle one practical question, often on a phone, often
+between or around shifts, sometimes late at night.
+
+Two roles share the surface:
+
+- **Team members** check their own schedule and their own pay (OB, on-call,
+  overtime, vacation balance). They see only their own salary figures.
+- **Admins** manage users, wages, rotation eras, substitutes, and settings, and
+  can see everyone's figures.
+
+The job to be done is the same for both, phrased from the member's seat:
+*"When do I work, and what will I earn?"* with complete trust in the numbers.
+
+## Product Purpose
+
+Periodical turns a 10-week shift rotation and Swedish labour-law OB rules into a
+clear schedule and a correct paycheck preview. It calculates inconvenient-hours
+pay (OB1-OB5), on-call compensation, overtime, holiday handling, and vacation
+balances under Handelns tjänstemannaavtal, then presents them so a team member
+can read off the answer without doing their own math.
+
+Success is the user getting the answer at a glance and not feeling the need to
+double-check it by hand. The schedule matrix and the pay readout are the
+product; everything else is in service of trusting those two.
+
+## Brand Personality
+
+An operations board, not a SaaS dashboard. Calm, exact, and instrument-like. The
+voice is plain and factual, in Swedish, with no marketing tone and no cleverness
+that competes with the data.
+
+Three words: **precise, legible, trustworthy.**
+
+The guiding emotional goal is **fast overview**: the answer to "when do I work /
+what will I earn" should be visible immediately, not hunted for. Colour belongs
+to the data (the shift pills); the chrome stays near-colourless so the numbers
+read as the only chromatic event on the screen.
+
+## Anti-references
+
+- **Generic SaaS dashboard.** Dark background plus a single loud accent,
+  hero-metric template cards, Ant Design default blue. This is the primary thing
+  to avoid; the design deliberately inverts it by removing the loud accent and
+  letting the data carry the colour.
+- **Cream + serif + terracotta "warm editorial."** The wrong tone entirely for
+  an operations tool; warmth is not the brand.
+- **Overdesigned / decorative chrome.** Decorative motion, glassmorphism, and
+  ornamental surfaces that compete with the schedule data for attention. Motion
+  conveys state only.
+- **Playful consumer-app styling.** Gradients, mascots, rounded bubble shapes;
+  anything that undermines confidence in the figures.
+
+## Design Principles
+
+1. **Colour belongs to the data.** The shift pills own the spectrum; the chrome
+   recedes. Never add another saturated accent next to the matrix.
+2. **Numbers are instrument readouts.** Hard data (hours, pay, dates, shift
+   codes) uses tabular monospace so columns align and figures read as
+   measurements, not prose.
+3. **Answer first.** Lead each surface with the question it answers (next shift,
+   net pay) before any supporting detail. Fast overview beats completeness.
+4. **Trust over flourish.** Consistency, legibility, and correctness outrank
+   delight. The tool should disappear into the task.
+5. **One meaning per colour.** Semantic colours do not collide (danger is money
+   out, not also a role; the admin role has its own colour).
+
+## Accessibility & Inclusion
+
+- **WCAG AA contrast.** Body text at least 4.5:1, large text at least 3:1,
+  against its background. Muted greys must still clear the bar.
+- **Colour-blind safe.** Shift and status meaning is never carried by colour
+  alone. Each shift pill shows its code, and status is reinforced by label or
+  position, so the board is readable without colour discrimination.
+- **Reduced motion.** Honour `prefers-reduced-motion`; every animation has a
+  crossfade or instant fallback.
+- **Keyboard and focus.** Clear focus rings and full keyboard navigation across
+  tables and forms; the focus state uses the interaction accent, not the data
+  palette.

--- a/app/static/css/base.css
+++ b/app/static/css/base.css
@@ -13,8 +13,12 @@
   --ink: #0e1216;            /* neutral graphite so the rainbow pills read true */
   --bg: var(--ink);
   --panel: #141b22;
+  --bg-depth: #071018;
   --panel-2: #19222b;
+  --surface: var(--panel-2);
+  --card-bg: var(--panel);
   --table-border: rgba(255,255,255,0.06);
+  --border: var(--table-border);
   --line: var(--table-border);
   --line-strong: rgba(255,255,255,0.14);
   --text: #e6eef6;
@@ -35,12 +39,14 @@
   --danger: #ef4444;
   --danger-hover: #dc2626;
   --success: #7bd389;        /* money in / positive */
+  --up: var(--success);
   --warning: #ffa500;
   --role: #a78bfa;           /* admin role, its own violet (not --danger, not --ob5) */
 
   /* Schedule / absence categories (data colours referenced by templates) */
   --sem: #c7c700;            /* vacation (SEM) */
-  --blue: #3b82f6;           /* secondary blue: substitutes, parental, overrides */
+  --blue: #2563eb;           /* secondary blue: substitutes, parental, overrides */
+  --blue-hover: #1d4ed8;
   --ob-sick: #f97316;        /* OB lost on sick days */
   --ob5: #a855f7;            /* highest OB level / absence purple */
 
@@ -50,6 +56,13 @@
   --font-mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
 
   --radius: 0.5rem;
+
+  /* Layering */
+  --z-local: 1;
+  --z-dropdown: 30;
+  --z-sticky: 40;
+  --z-modal: 100;
+  --z-tooltip: 120;
 
   /* Back-compat aliases (existing names kept, same resolved values) */
   --background: var(--bg);
@@ -68,7 +81,7 @@ html, body {
   height: 100%;
   margin: 0;
   font-family: var(--font-body);
-  background: linear-gradient(180deg, var(--bg), #071018 120%);
+  background: linear-gradient(180deg, var(--bg), var(--bg-depth) 120%);
   color: var(--text);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -104,4 +117,15 @@ a:hover { text-decoration: underline; }
   h1 { font-size: 1.25rem; }
   h2, .page-title { font-size: 1.125rem; }
   h3 { font-size: 0.9375rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/app/static/css/calendar.css
+++ b/app/static/css/calendar.css
@@ -121,3 +121,5 @@ a.rotation-week-small:hover { color: var(--text); }
 .week-grid-all .shift-link { color: var(--text); }
 .shift-name { font-size: 0.85rem; font-weight: 500; }
 .shift-name--off { font-weight: 400; color: var(--muted); }
+
+.calendar-grid .calendar-day { border-top: 4px solid #333; }

--- a/app/static/css/calendar.css
+++ b/app/static/css/calendar.css
@@ -114,3 +114,10 @@ a.rotation-week-small:hover { color: var(--text); }
   .week-grid-all .person-name-cell { min-width: 80px; font-size: 0.8rem; padding: 8px; }
   .week-grid-all .shift-cell { padding: 6px 4px; }
 }
+/* Hardening: data-driven shift colours applied via static/js/shift-colors.js.
+   These provide stable fallbacks before the script runs (and for OFF cells). */
+.week-grid-single .calendar-day { border-top: 4px solid #333; }
+.week-grid-all .shift-cell { border-left: 4px solid transparent; }
+.week-grid-all .shift-link { color: var(--text); }
+.shift-name { font-size: 0.85rem; font-weight: 500; }
+.shift-name--off { font-weight: 400; color: var(--muted); }

--- a/app/static/css/calendar.css
+++ b/app/static/css/calendar.css
@@ -68,14 +68,14 @@ a.rotation-week-small:hover { color: var(--text); }
 .week-grid-wrapper { overflow-x: auto; margin-top: 1.25rem; }
 .week-grid-all { width: 100%; border-collapse: collapse; min-width: 800px; }
 /* Header is the board's destination rail: a stronger hairline underlines it. */
-.week-grid-all thead th { background: var(--panel); padding: 0.75rem 0.5rem; border: 1px solid var(--line); border-bottom: 2px solid var(--line-strong); position: sticky; top: 0; z-index: 10; }
-.week-grid-all .person-header-column { position: sticky; left: 0; z-index: 20; min-width: 120px; background: var(--panel); border-right: 2px solid var(--line-strong); }
+.week-grid-all thead th { background: var(--panel); padding: 0.75rem 0.5rem; border: 1px solid var(--line); border-bottom: 2px solid var(--line-strong); position: sticky; top: 0; z-index: var(--z-sticky); }
+.week-grid-all .person-header-column { position: sticky; left: 0; z-index: var(--z-sticky); min-width: 120px; background: var(--panel); border-right: 2px solid var(--line-strong); }
 .week-grid-all .day-column { min-width: 100px; }
 /* "Now" flag: today's column header carries an accent underline and label colour. */
 .week-grid-all .day-column.today-column { background: rgb(var(--accent-rgb) / 0.18); color: var(--accent); box-shadow: inset 0 -3px 0 var(--accent); }
 .week-grid-all .date-small { font-family: var(--font-mono); font-size: 0.75rem; color: var(--muted); font-weight: normal; margin-top: 2px; }
 .week-grid-all .person-row { border-bottom: 1px solid var(--line); }
-.week-grid-all .person-name-cell { position: sticky; left: 0; background: var(--panel); padding: 6px 0.75rem; text-align: left; font-weight: 500; border-right: 2px solid var(--line-strong); z-index: 10; }
+.week-grid-all .person-name-cell { position: sticky; left: 0; background: var(--panel); padding: 6px 0.75rem; text-align: left; font-weight: 500; border-right: 2px solid var(--line-strong); z-index: var(--z-sticky); }
 .week-grid-all .person-name-cell a { color: var(--text); }
 .week-grid-all .person-name-cell a:hover { color: var(--accent); }
 .week-grid-all .person-name-cell small { color: var(--muted); font-size: 0.75rem; font-family: var(--font-mono); }
@@ -83,7 +83,7 @@ a.rotation-week-small:hover { color: var(--text); }
 /* "Now" line: today's column runs a teal rail down its trailing edge. */
 .week-grid-all .shift-cell.today-cell { background: rgb(var(--accent-rgb) / 0.08); box-shadow: inset -2px 0 0 var(--accent); }
 .week-grid-all .shift-link { text-decoration: none; display: inline-block; }
-.week-grid-all .shift-link:hover .badge { opacity: 0.9; transform: scale(1.05); transition: all 0.15s ease; }
+.week-grid-all .shift-link:hover .badge { opacity: 0.9; transform: scale(1.05); transition: opacity 0.15s ease, transform 0.15s ease; }
 
 /* Calendar Export */
 .calendar-export { margin-top: 2rem; padding-top: 2rem; border-top: 1px solid var(--table-border); }

--- a/app/static/css/components.css
+++ b/app/static/css/components.css
@@ -104,7 +104,7 @@
 .badge-blue { background: var(--blue); color: #fff; }
 .badge-warning { background: var(--warning); color: #000; }
 .badge-sem { box-shadow: 0 0 0 2px rgba(250, 250, 210, 0.7); }
-.orig-asterisk { font-size: 1em; color: var(--muted); margin-left: 4px; }
+.orig-asterisk { font-size: 1em; color: var(--muted); margin-left: 4px; display: none; }
 .badge-ob4 {
   background: var(--warning);
   color: var(--bg);
@@ -264,6 +264,14 @@ input, select {
 .inline-form { display: inline; }
 .badge-archived { background: var(--muted-bg); color: var(--text); }
 .text-muted { color: var(--muted); }
+.text-danger { color: var(--danger); }
+.text-ob-sick { color: var(--ob-sick); }
+.text-success { color: var(--success); }
+.text-accent { color: var(--accent); }
+.text-accent2 { color: var(--accent-2); }
+.text-ob5 { color: var(--ob5); }
+.text-blue { color: var(--blue); }
+.text-gray { color: #888; }
 .empty-state-text { color: var(--muted); text-align: center; padding: 1.25rem; }
 .badge-calendar-marker { font-size: 0.6rem; padding: 1px 4px; }
 .calendar-day--empty { background: transparent; border: 0; }
@@ -291,6 +299,22 @@ input, select {
 @media (max-width: 520px) { .form-grid-2 { grid-template-columns: 1fr; } }
 .heading-danger { color: var(--danger); }
 .heading-success { color: var(--success); }
+.title-inline { margin: 0; }
+.btn-compact { padding: 0.25rem 0.75rem; font-size: 0.85rem; }
+.btn-sm { font-size: 0.85rem; }
+.btn-warning { background: var(--warning); border-color: var(--warning); color: #000; }
+.btn-warning:hover { background: var(--warning); }
+.badge-role { background: var(--role); }
+.badge-marker-xs { font-size: 0.55rem; padding: 1px 3px; }
+.inline-form-mr { display: inline-block; margin-left: 0.5rem; }
+.week-shift-time { color: var(--muted); font-size: 0.7rem; margin-top: 2px; }
+.col-toggle-bar { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.75rem; padding: 0.5rem 0.75rem; background: var(--panel); border-radius: var(--radius); border: 1px solid var(--border); align-items: center; }
+.col-toggle-label { display: flex; align-items: center; gap: 0.3rem; cursor: pointer; font-size: 0.85rem; user-select: none; }
+.col-sep { color: var(--border); margin: 0 0.25rem; }
+.btn-xs { font-size: 0.8rem; padding: 2px 8px; }
+.cursor-pointer { cursor: pointer; }
+.plain-link { text-decoration: none; }
+.month-shift-cell { border-left: 6px solid transparent; padding-left: 8px; }
 
 .range-controls { position: relative; align-items: center; }
 .range-select { min-height: 44px; cursor: pointer; color-scheme: dark; }
@@ -1067,3 +1091,5 @@ textarea {
 /* Year view: transition row highlight */
 .transition-year-row { border-left: 3px solid var(--warning); }
 
+.loading-spinner { color: #999; font-size: 0.9em; }
+.scroll-x { overflow-x: auto; }

--- a/app/static/css/components.css
+++ b/app/static/css/components.css
@@ -6,7 +6,7 @@
   border: 1px solid var(--table-border);
   border-radius: var(--radius);
   padding: 1rem;
-  box-shadow: 0 6px 18px rgba(2,8,23,0.5);
+  box-shadow: 0 4px 8px rgba(2,8,23,0.42);
 }
 
 /* Login: the empty void becomes a faint slice of the schedule board, so the
@@ -56,7 +56,7 @@
 }
 .login-card {
   position: relative;
-  z-index: 1;
+  z-index: var(--z-local);
   width: 100%;
   max-width: 380px;
   background: var(--panel);
@@ -89,7 +89,20 @@
   background: var(--accent);
   font-weight: 600;
 }
-.badge-off { background: var(--muted-bg); color: var(--muted-text); }
+.badge-off { background: var(--muted-bg); color: var(--text); }
+/* Semantic absence / status badges (day view, schedules) */
+.badge-sick { background: var(--danger); color: #fff; }
+.badge-vab { background: var(--ob-sick); color: #fff; }
+.badge-leave { background: var(--ob5); color: #fff; }
+.badge-off-gray { background: #888; color: #fff; }
+.badge-vacation { background: var(--sem); color: #000; }
+.badge-parental { background: var(--blue); color: #fff; }
+.badge-partial { background: #0ea5e9; color: #fff; }
+.badge-karens { background: var(--danger-hover); color: #fff; }
+.badge-added { background: #22c55e; color: #fff; }
+.badge-danger { background: var(--danger); color: #fff; }
+.badge-blue { background: var(--blue); color: #fff; }
+.badge-warning { background: var(--warning); color: #000; }
 .badge-sem { box-shadow: 0 0 0 2px rgba(250, 250, 210, 0.7); }
 .orig-asterisk { font-size: 1em; color: var(--muted); margin-left: 4px; }
 .badge-ob4 {
@@ -116,10 +129,36 @@ button, .btn {
   padding: 0.5rem 0.75rem;
   border-radius: 6px;
   cursor: pointer;
-  transition: background 0.2s ease;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 button:hover, .btn:hover {
   background: var(--primary-dark);
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: var(--bg);
+}
+.btn-primary:hover { background: var(--primary-dark); }
+
+button:focus-visible,
+.btn:focus-visible,
+a:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+[tabindex]:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+button:disabled,
+.btn[aria-disabled="true"],
+input:disabled,
+select:disabled,
+textarea:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
 }
 
 /* Date Picker */
@@ -131,7 +170,7 @@ button:hover, .btn:hover {
   cursor: pointer;
   background: var(--panel);
   color: var(--text);
-  transition: all 0.2s ease;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .date-picker-input:hover {
@@ -156,14 +195,14 @@ button.secondary, .btn.secondary, .btn-secondary {
   text-decoration: none;
   font-size: 1rem;
   font-weight: 500;
-  transition: all 0.2s ease;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
 }
 button.secondary:hover, .btn.secondary:hover, .btn-secondary:hover {
   background-color: var(--table-border);
   border-color: var(--muted);
 }
 
-.btn-danger {
+.btn-danger, .btn.danger {
   background-color: var(--danger);
   color: white;
   padding: 0.25rem 0.5rem;
@@ -171,7 +210,7 @@ button.secondary:hover, .btn.secondary:hover, .btn-secondary:hover {
   border-radius: 4px;
   border: none;
 }
-.btn-danger:hover { background-color: var(--danger-hover); }
+.btn-danger:hover, .btn.danger:hover { background-color: var(--danger-hover); }
 
 /* Person Toggle Buttons */
 .day-button-row { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 1rem; }
@@ -199,12 +238,458 @@ input, select {
   border-radius: 6px;
 }
 
+
+.form-shell { width: 100%; max-width: 500px; }
+.form-shell--md { max-width: 700px; }
+.form-shell--center { margin: 3.75rem auto; }
+.form-stack { display: grid; gap: 1rem; }
+.form-stack .form-group { margin-bottom: 0; }
+.form-group { min-width: 0; }
+.form-label { display: block; margin-bottom: 0.375rem; color: var(--muted); }
+.form-input { width: 100%; box-sizing: border-box; }
+.form-hint { color: var(--muted); font-size: 0.85em; }
+.form-actions { display: flex; gap: 0.75rem; align-items: center; flex-wrap: wrap; margin-top: 1.5rem; }
+.form-actions--stack { display: grid; gap: 0.75rem; }
+.form-actions--stack .btn { width: 100%; justify-content: center; text-align: center; }
+.form-row-inline { display: flex; gap: 0.75rem; align-items: flex-end; flex-wrap: wrap; }
+.form-row-inline .form-group { flex: 1 1 16rem; margin-bottom: 0; }
+.form-card-title { margin-top: 0; }
+.form-note { margin-top: 1.25rem; padding-top: 1.25rem; border-top: 1px solid var(--border); color: var(--muted); font-size: 0.9em; }
+.form-note ul { margin: 0.5rem 0 0; padding-left: 1.25rem; }
+
+.form-card-block { margin-bottom: 1.5rem; }
+.admin-table-card { margin-bottom: 1.5rem; }
+.admin-table { width: 100%; }
+.table-action { text-align: right; }
+.inline-form { display: inline; }
+.badge-archived { background: var(--muted-bg); color: var(--text); }
+.text-muted { color: var(--muted); }
+.empty-state-text { color: var(--muted); text-align: center; padding: 1.25rem; }
+.badge-calendar-marker { font-size: 0.6rem; padding: 1px 4px; }
+.calendar-day--empty { background: transparent; border: 0; }
+.range-day-cell { border-top: 4px solid var(--line-strong); }
+
+/* Shared helpers for profile / admin edit / day surfaces */
+.card-mt { margin-top: 1rem; }
+.section-mt { margin-top: 2rem; }
+.split-cols { display: flex; gap: 1.5rem; flex-wrap: wrap; align-items: flex-start; }
+.split-col { flex: 1; min-width: 300px; }
+.input-mono { font-family: var(--font-mono); }
+.cell-strong { font-weight: 500; }
+.text-italic-muted { color: var(--muted); font-style: italic; }
+.status-pos { color: var(--success); font-weight: 500; }
+.status-warn { color: var(--warning); font-weight: 500; }
+.history-table { width: 100%; border-collapse: collapse; }
+.history-table thead tr,
+.history-table tbody tr { border-bottom: 1px solid var(--border); }
+.history-table th { text-align: left; padding: 0.5rem; color: var(--muted); font-weight: 500; }
+.history-table td { padding: 0.5rem; }
+.history-table .table-action { text-align: center; }
+.form-textarea { resize: vertical; }
+.form-label--mt { margin-top: 0.4rem; }
+.form-grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; margin-bottom: 1rem; }
+@media (max-width: 520px) { .form-grid-2 { grid-template-columns: 1fr; } }
+.heading-danger { color: var(--danger); }
+.heading-success { color: var(--success); }
+
+.range-controls { position: relative; align-items: center; }
+.range-select { min-height: 44px; cursor: pointer; color-scheme: dark; }
+.range-filter-toggle { min-height: 44px; }
+.range-date-panel { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; position: absolute; right: 0; top: calc(100% + 4px); background: var(--panel); border: 1px solid var(--table-border); border-radius: 6px; padding: 0.5rem; z-index: var(--z-dropdown); box-shadow: 0 4px 8px rgba(2,8,23,0.42); }
+.range-date-panel[hidden] { display: none; }
+.range-date-panel label { color: var(--muted); font-size: 0.85rem; }
+.range-date-panel input { min-height: 44px; }
+
 .ot-form .form-row { display: flex; gap: 1rem; margin-bottom: 1rem; }
 .ot-form .form-group { flex: 1; }
 .ot-form label { display: block; margin-bottom: 0.5rem; font-weight: bold; }
 .ot-form input { width: 100%; padding: 0.5rem; border: 1px solid var(--table-border); border-radius: 4px; }
 .ot-display { margin-top: 1rem; }
 .info-text { font-size: 0.9em; color: var(--muted); margin-top: 0.5rem; font-style: italic; }
+
+
+
+/* Admin/data-entry surfaces */
+textarea {
+  background: var(--panel);
+  color: var(--text);
+  border: 1px solid var(--table-border);
+  padding: 0.5rem 0.625rem;
+  border-radius: 6px;
+}
+.pattern-textarea {
+  width: 100%;
+  max-width: 600px;
+  min-height: 10rem;
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  resize: vertical;
+}
+.pattern-textarea.is-readonly-preview {
+  background: var(--panel-2);
+  color: var(--muted);
+}
+.dialog-backdrop {
+  display: none;
+  position: fixed;
+  inset: 0;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(0,0,0,0.55);
+  z-index: var(--z-modal);
+}
+.dialog-backdrop[aria-hidden="false"] { display: flex; }
+.dialog-surface {
+  display: flex;
+  flex-direction: column;
+  width: min(90vw, 700px);
+  max-height: 85vh;
+  min-width: 0;
+  padding: 1.5rem;
+  background: var(--panel);
+  border: 1px solid var(--table-border);
+  border-radius: var(--radius);
+}
+.dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+.dialog-close {
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0;
+  background: transparent;
+  color: var(--muted);
+  border: 0;
+  font-size: 1.25rem;
+  line-height: 1;
+}
+.dialog-close:hover { background: var(--table-border); color: var(--text); }
+.dialog-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: auto;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--table-border);
+}
+.dialog-code {
+  flex: 1;
+  min-height: 0;
+  margin: 0;
+  overflow: auto;
+  padding: 1rem;
+  background: var(--bg);
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  white-space: pre;
+}
+
+
+.alert--info h3,
+.alert--danger h3 { margin-top: 0; }
+.alert ul { margin-bottom: 0; }
+.admin-era-form { max-width: 720px; }
+.form-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1rem;
+  margin-bottom: 0.5rem;
+}
+.form-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--text);
+}
+.form-input--sm { width: min(100%, 7rem); }
+.form-input--md { width: min(100%, 13rem); }
+.admin-inline-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+.link-button {
+  min-height: 36px;
+  padding: 0.25rem 0.5rem;
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid transparent;
+  border-radius: 4px;
+  text-decoration: underline;
+}
+.link-button:hover {
+  background: rgb(var(--accent-rgb) / 0.08);
+  border-color: rgb(var(--accent-rgb) / 0.25);
+}
+.link-button--danger { color: var(--danger); }
+.link-button--danger:hover {
+  background: rgba(239, 68, 68, 0.1);
+  border-color: rgba(239, 68, 68, 0.3);
+}
+.status-current,
+.status-ongoing { color: var(--success); font-weight: 600; }
+.status-future { color: var(--accent); font-weight: 600; }
+.status-historical { color: var(--muted); }
+.dialog-form {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+.dialog-form-grid {
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  gap: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  align-items: start;
+}
+.dialog-form-grid .form-label { padding-top: 0.5rem; font-weight: 600; }
+@media (max-width: 640px) {
+  .dialog-form-grid { grid-template-columns: 1fr; }
+  .dialog-form-grid .form-label { padding-top: 0; }
+  .dialog-actions .btn { width: 100%; justify-content: center; }
+}
+
+/* Vacation controls */
+.vacation-year-label {
+  padding: 0.5rem 1rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+.vacation-layout {
+  display: flex;
+  gap: 1.5rem;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+.vacation-main {
+  flex: 2 1 28rem;
+  min-width: 0;
+}
+.vacation-side {
+  flex: 1 1 18rem;
+  min-width: 0;
+}
+.vacation-section { margin-bottom: 1rem; }
+.vacation-section-title { margin-top: 0; }
+.vacation-copy { color: var(--muted); margin-bottom: 1rem; }
+.vacation-divider {
+  border: 0;
+  border-top: 1px solid var(--table-border);
+  margin: 1.25rem 0;
+}
+.vacation-subtitle {
+  margin: 0 0 0.5rem;
+  color: var(--blue);
+}
+.vacation-week-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+.vacation-week-grid--compact { margin-bottom: 1rem; }
+.vacation-week-btn {
+  min-height: 44px;
+  padding: 0.75rem 0.5rem;
+  background: var(--panel);
+  color: var(--text);
+  border: 1px solid var(--table-border);
+  border-radius: var(--radius);
+  font-weight: 400;
+  transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+.vacation-week-btn.selected,
+.vacation-week-btn[aria-pressed="true"] {
+  background: var(--accent);
+  color: var(--bg);
+  border-color: var(--accent);
+  font-weight: 600;
+}
+.vacation-week-btn--parental.selected,
+.vacation-week-btn--parental[aria-pressed="true"] {
+  background: var(--blue);
+  color: white;
+  border-color: var(--blue);
+}
+.btn-blue { background: var(--blue); color: white; }
+.btn-blue:hover { background: var(--blue-hover); }
+.vacation-mode-group {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+.vacation-mode-btn { flex: 1 1 0; }
+.vacation-mode-btn.is-active {
+  background: var(--accent);
+  color: var(--bg);
+  border-color: var(--accent);
+}
+.vacation-mode-btn[data-mode="parental"].is-active {
+  background: var(--blue);
+  color: white;
+  border-color: var(--blue);
+}
+.vacation-day-calendar {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+.vacation-form-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+.vacation-day-count { color: var(--muted); font-size: 0.85rem; }
+.vacation-metric-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0.375rem;
+}
+.vacation-metric { text-align: center; min-width: 0; }
+.vacation-metric-label { color: var(--muted); font-size: 0.7rem; margin-bottom: 0.25rem; }
+.vacation-metric-value { font-size: 1.2rem; font-weight: 700; overflow-wrap: anywhere; }
+.vacation-muted { color: var(--muted); }
+.vacation-small-note { margin-top: 0.5rem; font-size: 0.75rem; color: var(--muted); text-align: center; }
+.vacation-summary-text { color: var(--muted); overflow-wrap: anywhere; }
+
+.vacation-value-positive { color: var(--accent); }
+.vacation-value-success { color: var(--accent-2); }
+.vacation-value-warning { color: var(--warning); }
+.vacation-value-danger { color: var(--danger); }
+.vacation-value-muted { color: var(--muted); }
+.vacation-detail-label { color: var(--muted); }
+.vacation-detail-value { font-weight: 600; overflow-wrap: anywhere; }
+.vacation-detail-value--success { color: var(--accent-2); }
+.vacation-card-title-sm { font-size: 0.95rem; }
+.vacation-formula-note { margin-top: 0.5rem; font-size: 0.75rem; color: var(--muted); }
+.vacation-supplement-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.375rem;
+  margin-bottom: 0.75rem;
+}
+.vacation-supplement-label { color: var(--muted); font-size: 0.7rem; margin-bottom: 0.25rem; }
+.vacation-supplement-value { font-size: 1rem; font-weight: 700; overflow-wrap: anywhere; }
+.vacation-supplement-note { color: var(--muted); font-size: 0.75rem; }
+.vacation-supplement-total-label { color: var(--muted); font-size: 0.7rem; margin-bottom: 0.125rem; }
+.vacation-supplement-total-value { font-size: 1.3rem; font-weight: 700; color: var(--accent-2); }
+.vacation-supplement-breakdown { font-size: 0.75rem; color: var(--muted); }
+.vacation-supplement-breakdown-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.125rem 0.5rem;
+}
+.vacation-supplement-breakdown-value { text-align: right; }
+.vacation-supplement-sum {
+  margin-top: 0.25rem;
+  padding-top: 0.25rem;
+  border-top: 1px solid var(--table-border);
+}
+.vacation-callout {
+  margin-bottom: 1rem;
+  border: 1px solid var(--accent);
+  background: rgb(var(--accent-rgb) / 0.08);
+}
+.vacation-detail-grid {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.25rem 0.75rem;
+  font-size: 0.85rem;
+}
+.vacation-detail-grid > span { min-width: 0; overflow-wrap: anywhere; }
+.vacation-supplement-total {
+  text-align: center;
+  padding: 0.5rem;
+  background: var(--glass);
+  border-radius: var(--radius);
+  margin-bottom: 0.75rem;
+}
+.vacation-day-month {
+  background: var(--panel);
+  border-radius: var(--radius);
+  padding: 0.5rem;
+  border: 1px solid var(--table-border);
+}
+.vacation-day-month-title {
+  text-align: center;
+  font-weight: 600;
+  font-size: 0.85rem;
+  margin-bottom: 0.375rem;
+}
+.vacation-day-grid {
+  display: grid;
+  grid-template-columns: auto repeat(7, 1fr);
+  gap: 2px;
+  font-size: 0.75rem;
+}
+.vacation-day-grid-header,
+.vacation-week-number {
+  color: var(--muted);
+  font-size: 0.65rem;
+  opacity: 0.65;
+}
+.vacation-day-grid-header { text-align: center; padding: 2px 0; }
+.vacation-week-number { text-align: right; padding: 3px 4px 0 0; }
+.vacation-day-cell {
+  min-width: 0;
+  min-height: 24px;
+  padding: 3px 1px;
+  background: transparent;
+  color: var(--text);
+  border: 0;
+  border-radius: 3px;
+  font-size: 0.75rem;
+  text-align: center;
+  user-select: none;
+  transition: background-color 0.1s ease, color 0.1s ease, opacity 0.1s ease;
+}
+.vacation-day-cell.is-weekend { opacity: 0.5; color: var(--muted); }
+.vacation-day-cell.is-vacation { background: var(--accent); color: var(--bg); font-weight: 600; opacity: 1; }
+.vacation-day-cell.is-parental { background: var(--blue); color: white; font-weight: 600; opacity: 1; }
+.vacation-day-cell:disabled {
+  cursor: not-allowed;
+  opacity: 0.35;
+  text-decoration: line-through;
+}
+
+
+@media (pointer: coarse), (max-width: 760px) {
+  .vacation-day-calendar { overflow-x: auto; }
+  .vacation-day-month { min-width: 360px; }
+  .vacation-day-cell {
+    min-width: 44px;
+    min-height: 44px;
+    font-size: 0.9rem;
+  }
+  .vacation-day-grid { gap: 4px; }
+}
+
+@media (max-width: 760px) {
+  .vacation-layout { display: grid; grid-template-columns: 1fr; gap: 1rem; }
+  .vacation-main,
+  .vacation-side { flex: none; width: 100%; }
+  .vacation-metric-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .vacation-mode-group { flex-direction: column; }
+  .vacation-form-footer { align-items: stretch; }
+  .vacation-form-footer .btn { width: 100%; justify-content: center; }
+}
+
+@media (max-width: 420px) {
+  .vacation-week-grid { grid-template-columns: repeat(auto-fill, minmax(52px, 1fr)); }
+  .vacation-day-calendar { grid-template-columns: 1fr; }
+}
 
 /* Responsive Components */
 @media (max-width: 800px) {
@@ -215,6 +700,9 @@ input, select {
 
 @media (max-width: 700px) {
   .day-buttons-bar { flex-direction: column; align-items: flex-start; }
+  .range-controls { width: 100%; align-items: stretch; }
+  .range-controls .range-select, .range-controls .range-filter-toggle { width: 100%; }
+  .range-date-panel { position: static; width: 100%; margin-top: 0.5rem; }
   .page-header-left .btn, .page-header-right .btn { flex: 1; }
   .badge { font-size: 0.75rem; padding: 3px 7px; }
 }
@@ -515,7 +1003,7 @@ input, select {
 .alert--danger  { background: rgba(239,68,68,0.12);  border-color: var(--danger); }
 .alert--success { background: rgba(123,211,137,0.09); border-color: var(--accent-2); }
 .alert--warning { background: rgba(255,165,0,0.09);  border-color: var(--warning); }
-.alert--info    { background: rgb(var(--accent-rgb) / 0.08); border-color: var(--accent); }
+.alert--info    { background: rgb(var(--accent-rgb) / 0.08); border-color: var(--accent); color: var(--text); }
 
 /* ===== Anställningsövergång ===== */
 .transition-employer {

--- a/app/static/css/components.css
+++ b/app/static/css/components.css
@@ -1093,3 +1093,51 @@ textarea {
 
 .loading-spinner { color: #999; font-size: 0.9em; }
 .scroll-x { overflow-x: auto; }
+.h-mb { margin-bottom: 0.75rem; }
+.table-empty { text-align: center; color: var(--muted); padding: 1rem; }
+.month-actions { margin-top: 1.5rem; text-align: center; display: flex; gap: 0.5rem; justify-content: center; flex-wrap: wrap; }
+.flex-between { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.75rem; flex-wrap: wrap; gap: 0.5rem; }
+.text-right { text-align: right; }
+.text-center { text-align: center; }
+.year-cell { font-size: 0.8rem; padding: 4px; }
+.year-th-group { border-bottom: 1px solid var(--border); font-size: 0.8rem; color: var(--muted); }
+.year-th-sm { font-size: 0.7rem; padding: 2px 4px; }
+.year-type-cell { padding-left: 1.5rem; font-size: 0.85rem; }
+.year-note { font-size: 0.75rem; color: var(--muted); margin-top: 6px; }
+.year-foot-note { margin-top: 8px; font-size: 0.8rem; color: var(--muted); }
+.year-cowork-link { font-size: 0.8em; margin-left: 0.75rem; }
+.year-intro { font-style: italic; color: var(--muted); margin-bottom: 16px; }
+.stat-card { text-align: center; }
+.stat-label { color: var(--muted); font-size: 0.85rem; }
+.stat-value { font-size: 1.4rem; font-weight: bold; }
+.stat-header { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 0.5rem; }
+.stat-header-controls { display: flex; gap: 0.5rem; align-items: center; }
+.stat-select { padding: 0.4rem; border-radius: 4px; background: var(--card-bg); color: var(--text); border: 1px solid var(--muted-bg); }
+.stat-grid-1 { display: grid; grid-template-columns: 1fr; gap: 1.5rem; margin-top: 1.5rem; }
+.stat-grid-auto { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1.5rem; }
+.stat-grid-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 1rem; margin-top: 1.5rem; }
+.chart-tall { min-height: 300px; }
+.chart-med { min-height: 280px; }
+.mb-1 { margin-bottom: 1rem; }
+.mb-3 { margin-bottom: 1.5rem; }
+.mt-3 { margin-top: 1.5rem; }
+.mx-2 { margin: 0 0.75rem; }
+.ml-2 { margin-left: 0.75rem; }
+.inline-block { display: inline-block; }
+.flex-row-wrap { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; }
+.cell-head { font-weight: 600; color: var(--muted); }
+.text-sm-muted { font-size: 0.85rem; color: var(--muted); }
+.accent-link { color: var(--accent); text-decoration: none; }
+.text-warning { color: var(--warning); }
+.num-bold { font-weight: 600; }
+.badge-accent2 { background: var(--accent-2); color: #000; }
+.border-warning { border-color: var(--warning); }
+.ml-auto { margin-left: auto; }
+.ml-1 { margin-left: 0.25rem; }
+.btn-fs-sm { font-size: 0.8rem; }
+.btn-swap { font-size: 0.8rem; padding: 0.3rem 0.6rem; }
+.badge-muted { background: var(--muted); color: var(--bg); }
+.mt-1 { margin-top: 1rem; }
+.mb-sm { margin-bottom: 0.75rem; }
+.w-6 { width: 6rem; }
+.text-xs-muted { font-size: 0.75rem; color: var(--muted); }

--- a/app/static/css/layout.css
+++ b/app/static/css/layout.css
@@ -44,6 +44,23 @@ footer {
   padding: 1rem;
 }
 
+
+.app-header-row { justify-content: space-between; }
+.app-brand { flex: none; }
+.app-title { margin: 0; font-size: 1.375rem; }
+.app-subtitle { color: var(--muted); font-size: 0.8125rem; margin-top: 2px; }
+.app-footer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  padding: 1.5rem 1rem 1rem;
+  color: var(--muted);
+  font-size: 0.78rem;
+  text-align: center;
+}
+.app-footer-link { color: var(--muted); text-decoration: none; }
+
 /* Page Headers */
 .page-header {
   display: flex;

--- a/app/static/css/navigation.css
+++ b/app/static/css/navigation.css
@@ -5,6 +5,17 @@
 .nav-personal { padding-left: 0.75rem; border-left: 2px solid var(--accent); font-size: 0.85rem; }
 .nav-divider { border-left: 1px solid var(--table-border); height: 20px; margin: 0 0.5rem; }
 
+.nav-inline-form { display: inline; }
+.nav-link-button {
+  background: none;
+  border: 0;
+  cursor: pointer;
+  padding: 0;
+  font: inherit;
+  color: var(--muted);
+}
+
+
 .nav-link {
   color: var(--muted);
   padding: 6px 0.625rem;
@@ -29,21 +40,21 @@
   display: none;
   flex-direction: column;
   justify-content: space-around;
-  width: 30px;
-  height: 24px;
+  width: 44px;
+  height: 44px;
   background: transparent;
   border: none;
   cursor: pointer;
   padding: 0;
-  z-index: 100;
+  z-index: var(--z-tooltip);
 }
 
 .hamburger span {
-  width: 30px;
+  width: 24px;
   height: 3px;
   background: var(--text);
   border-radius: 3px;
-  transition: all 0.3s ease;
+  transition: transform 0.3s ease, opacity 0.3s ease;
   transform-origin: center;
 }
 
@@ -67,7 +78,7 @@
     border-left: 1px solid var(--table-border);
     padding: 4px;
     transition: right 0.3s ease;
-    z-index: 99;
+    z-index: var(--z-modal);
     gap: 0;
     justify-content: flex-start;
     align-items: stretch;
@@ -79,12 +90,12 @@
     width: 100%;
     padding: 0.5rem 0.75rem;
     margin: 0;
-    display: block;
+    display: flex;
+    align-items: center;
     font-size: 0.95rem;
     line-height: 1.2;
     border: none;
-    outline: none;
-    min-height: auto;
+    min-height: 44px;
     height: auto;
     flex: 0 0 auto; /* Override for small screens */
   }

--- a/app/static/css/tables.css
+++ b/app/static/css/tables.css
@@ -38,8 +38,8 @@ td.num, th.num { font-family: var(--font-mono); }
 /* Sticky tables */
 .table-sticky { border-collapse: separate; border-spacing: 0; }
 /* The header row is a structural rail: a stronger hairline anchors it. */
-.table-sticky thead th { position: sticky; top: 0; z-index: 5; background: var(--panel); border-bottom: 2px solid var(--line-strong); }
-.table-sticky .sticky-col { position: sticky; left: 0; z-index: 4; background: var(--panel); border-right: 2px solid var(--line-strong); }
+.table-sticky thead th { position: sticky; top: 0; z-index: var(--z-sticky); background: var(--panel); border-bottom: 2px solid var(--line-strong); }
+.table-sticky .sticky-col { position: sticky; left: 0; z-index: var(--z-sticky); background: var(--panel); border-right: 2px solid var(--line-strong); }
 
 /* "Now" line: in the day-per-row matrices (month/year), today reads as a
    horizontal teal rule running across the whole board. */

--- a/app/static/js/shift-colors.js
+++ b/app/static/js/shift-colors.js
@@ -1,0 +1,34 @@
+// Apply data-driven colours without inline style attributes.
+//
+// Shift colours are admin-configured in the database, so they cannot live in
+// static CSS. Templates emit the colour in data attributes and this script
+// copies it onto the element's style at runtime (which is CSP-safe, unlike an
+// inline style attribute):
+//
+//   data-bg          -> background-color   (shift pills / badges)
+//   data-fg          -> color              (text tinted with the shift colour)
+//   data-border-top  -> border-top-color   (calendar day cells)
+//   data-border-left -> border-left-color  (per-person schedule rows)
+(function () {
+    function apply() {
+        document.querySelectorAll('[data-bg]').forEach(function (el) {
+            el.style.backgroundColor = el.getAttribute('data-bg');
+            var fg = el.getAttribute('data-fg');
+            if (fg) el.style.color = fg;
+        });
+        document.querySelectorAll('[data-fg]:not([data-bg])').forEach(function (el) {
+            el.style.color = el.getAttribute('data-fg');
+        });
+        document.querySelectorAll('[data-border-top]').forEach(function (el) {
+            el.style.borderTopColor = el.getAttribute('data-border-top');
+        });
+        document.querySelectorAll('[data-border-left]').forEach(function (el) {
+            el.style.borderLeftColor = el.getAttribute('data-border-left');
+        });
+    }
+    if (document.readyState !== 'loading') {
+        apply();
+    } else {
+        document.addEventListener('DOMContentLoaded', apply);
+    }
+})();

--- a/app/templates/admin_report.html
+++ b/app/templates/admin_report.html
@@ -17,10 +17,10 @@
 
 <h2 class="page-title">Månadsrapport</h2>
 
-<div class="page-header" style="margin-bottom: 1rem;">
+<div class="page-header mb-1">
     <div class="page-header-left">
         <a href="/admin/report?year={{ prev_year }}&month={{ prev_month }}{{ token_qs }}" class="btn secondary">&larr;</a>
-        <strong style="margin: 0 0.75rem;">{{ month_name }} {{ year }}</strong>
+        <strong class="mx-2">{{ month_name }} {{ year }}</strong>
         <a href="/admin/report?year={{ next_year }}&month={{ next_month }}{{ token_qs }}" class="btn secondary">&rarr;</a>
     </div>
     <div class="page-header-right">
@@ -30,13 +30,12 @@
 
 {% if is_admin %}
     {% if share_token %}
-    <div style="margin-bottom: 1rem; padding: 0.75rem; border: 1px solid var(--border); border-radius: 6px; background: var(--muted-bg, #1c1c24);">
-        <div style="font-size: 0.85rem; color: var(--muted); margin-bottom: 0.4rem;">
+    <div class="share-box">
+        <div class="share-label">
             Delningslänk (öppnar rapporten utan inloggning, t.ex. för chef):
         </div>
-        <div style="display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap;">
-            <input id="share-link" type="text" readonly
-                   style="flex: 1; min-width: 280px; padding: 6px; font-size: 0.85rem;">
+        <div class="flex-row-wrap">
+            <input id="share-link" type="text" readonly class="share-input">
             <button type="button" class="btn secondary" onclick="copyShareLink()">Kopiera</button>
         </div>
     </div>
@@ -56,13 +55,13 @@
     }
     </script>
     {% else %}
-    <p class="info-text" style="margin-bottom: 1rem;">
+    <p class="info-text mb-1">
         Delningslänk är inte konfigurerad. Sätt miljövariabeln <code>REPORT_TOKEN</code> för att aktivera en länk som öppnar rapporten utan inloggning.
     </p>
     {% endif %}
 {% endif %}
 
-<div style="overflow-x: auto;">
+<div class="scroll-x">
 <table class="report-table">
     <thead>
         <tr>
@@ -89,7 +88,7 @@
                 <td class="name-col">
                     {{ r.person_name }}
                     {% if r.is_substitute %}
-                        <span class="badge" style="background: var(--blue); color: white;">Vikarie</span>
+                        <span class="badge badge-blue">Vikarie</span>
                     {% endif %}
                 </td>
                 <td>{{ r.num_shifts }}</td>
@@ -118,6 +117,13 @@
     .report-table td { padding: 6px; border: 1px solid var(--border); text-align: right; }
     .report-table th { border-bottom-width: 2px; }
     .report-table .name-col { text-align: left; }
+</style>
+
+
+<style>
+.share-box { margin-bottom: 1rem; padding: 0.75rem; border: 1px solid var(--border); border-radius: 6px; background: var(--panel); }
+.share-label { font-size: 0.85rem; color: var(--muted); margin-bottom: 0.4rem; }
+.share-input { flex: 1; min-width: 280px; padding: 6px; font-size: 0.85rem; }
 </style>
 
 {% endblock %}

--- a/app/templates/admin_rotation_eras.html
+++ b/app/templates/admin_rotation_eras.html
@@ -7,12 +7,12 @@
 
 <h2 class="page-title">{{ t.admin_eras_title }}</h2>
 
-<div class="card" style="margin-bottom: 24px; background-color: #e8f4fd; border-left: 4px solid #2196F3;">
-    <h3 style="margin-top: 0; color: #1976D2;">ℹ️ {{ t.admin_eras_about_title }}</h3>
-    <p style="color: #424242; line-height: 1.6;">
+<div class="alert alert--info">
+    <h3>{{ t.admin_eras_about_title }}</h3>
+    <p>
         <strong>{{ t.admin_eras_about_title }}</strong> {{ t.admin_eras_about_p }}
     </p>
-    <ul style="color: #424242; line-height: 1.6; margin-bottom: 0;">
+    <ul>
         <li>{{ t.admin_eras_about_li1 }}</li>
         <li>{{ t.admin_eras_about_li2 }}</li>
         <li>{{ t.admin_eras_about_li3 }}</li>
@@ -20,12 +20,12 @@
 </div>
 
 {% if error %}
-<div class="card" style="margin-bottom: 24px; background-color: #ffebee; border-left: 4px solid var(--danger);">
-    <p style="color: #c62828; margin: 0;"><strong>{{ t.admin_eras_error_label }}</strong> {{ error }}</p>
+<div class="alert alert--danger">
+    <p><strong>{{ t.admin_eras_error_label }}</strong> {{ error }}</p>
 </div>
 {% endif %}
 
-<div class="card" style="margin-bottom: 24px;">
+<div class="card admin-table-card">
     <h3>{{ t.admin_eras_current_historical }}</h3>
 
     {% if eras %}
@@ -48,21 +48,21 @@
                     {% if era.end_date %}
                         {{ era.end_date }}
                     {% else %}
-                        <span style="color: var(--success); font-weight: 600;">{{ t.admin_eras_ongoing }}</span>
+                        <span class="status-ongoing">{{ t.admin_eras_ongoing }}</span>
                     {% endif %}
                 </td>
                 <td class="num" data-label="{{ t.admin_eras_col_length }}">{{ era.rotation_length }} {{ t.admin_eras_weeks }}</td>
                 <td data-label="{{ t.admin_eras_col_status }}">
                     {% if era.start_date > now %}
-                        <span style="color: #1976D2; font-weight: 600;">⏵ {{ t.admin_eras_future }}</span>
+                        <span class="status-future">{{ t.admin_eras_future }}</span>
                     {% elif era.end_date and era.end_date <= now %}
-                        <span style="color: var(--muted);">{{ t.admin_eras_historical }}</span>
+                        <span class="status-historical">{{ t.admin_eras_historical }}</span>
                     {% else %}
-                        <span style="color: var(--success); font-weight: 600;">{{ t.admin_eras_current }}</span>
+                        <span class="status-current">{{ t.admin_eras_current }}</span>
                     {% endif %}
                 </td>
                 <td data-label="{{ t.admin_eras_col_created }}">
-                    <small style="color: var(--muted);">{{ era.created_at | date_format }} {{ era.created_at | time_format }}</small>
+                    <small class="text-muted">{{ era.created_at | date_format }} {{ era.created_at | time_format }}</small>
                 </td>
                 <td data-label="{{ t.admin_eras_col_actions }}">
                     {% set era_json = {
@@ -73,116 +73,113 @@
                         "weeks_pattern": era.weeks_pattern,
                         "created_at": era.created_at | string
                     } %}
-                    <button type="button"
-                            onclick="showEraJson(this)"
-                            data-era="{{ era_json | tojson | forceescape }}"
-                            style="background: none; border: none; color: var(--primary); cursor: pointer; padding: 4px 8px; font-size: 0.9rem; text-decoration: underline; margin-right: 8px;">
-                        { } JSON
-                    </button>
-                    <form method="POST" action="/admin/rotation-eras/delete/{{ era.id }}"
-                          style="display: inline;"
-                          onsubmit="return confirm('{{ t.admin_eras_delete_confirm }}');">
-                        <button type="submit"
-                                style="background: none; border: none; color: #d32f2f; cursor: pointer; padding: 4px 8px; font-size: 0.9rem; text-decoration: underline;">
-                            🗑️ {{ t.admin_eras_delete }}
+                    <div class="admin-inline-actions">
+                        <button type="button"
+                                class="link-button"
+                                onclick="showEraJson(this)"
+                                data-era="{{ era_json | tojson | forceescape }}">
+                            { } JSON
                         </button>
-                    </form>
-                    {% if era.start_date > now %}
-                    <button type="button"
-                            onclick="showEditEra(this)"
-                            data-era="{{ era_json | tojson | forceescape }}"
-                            style="background: none; border: none; color: var(--accent, #f0a500); cursor: pointer; padding: 4px 8px; font-size: 0.9rem; text-decoration: underline; margin-left: 8px;">
-                        ✏️ {{ t.admin_eras_edit }}
-                    </button>
-                    {% endif %}
+                        <form method="POST" action="/admin/rotation-eras/delete/{{ era.id }}"
+                              onsubmit="return confirm('{{ t.admin_eras_delete_confirm }}');">
+                            <button type="submit" class="link-button link-button--danger">
+                                {{ t.admin_eras_delete }}
+                            </button>
+                        </form>
+                        {% if era.start_date > now %}
+                        <button type="button"
+                                class="link-button"
+                                onclick="showEditEra(this)"
+                                data-era="{{ era_json | tojson | forceescape }}">
+                            {{ t.admin_eras_edit }}
+                        </button>
+                        {% endif %}
+                    </div>
                 </td>
             </tr>
             {% endfor %}
         </tbody>
     </table>
     {% else %}
-    <p style="color: var(--muted); text-align: center; padding: 20px;">
+    <p class="empty-state-text">
         {{ t.admin_eras_no_eras }}
     </p>
     {% endif %}
 </div>
 
-<div class="card">
-    <h3>{{ t.admin_eras_create_title }}</h3>
-    <p style="color: var(--muted); margin-bottom: 16px;">
+<div class="card admin-era-form">
+    <h3 class="form-card-title">{{ t.admin_eras_create_title }}</h3>
+    <p class="vacation-copy">
         {{ t.admin_eras_create_desc }}
     </p>
 
-    <form method="POST" action="/admin/rotation-eras/create" id="create-era-form">
-        <table style="width: auto;">
-            <tbody>
-                <tr>
-                    <td style="font-weight: 600; color: var(--muted); padding-right: 16px;">{{ t.admin_eras_field_start }}</td>
-                    <td>
-                        <input
-                            type="date"
-                            name="start_date"
-                            required
-                            style="width: 200px;"
-                        />
-                        <small style="color: var(--muted); display: block; margin-top: 4px;">
-                            {{ t.admin_eras_field_start_hint }}
-                        </small>
-                    </td>
-                </tr>
-                <tr>
-                    <td style="font-weight: 600; color: var(--muted); padding-right: 16px;">{{ t.admin_eras_field_length }}</td>
-                    <td>
-                        <input
-                            type="number"
-                            name="rotation_length"
-                            id="rotation_length"
-                            min="1"
-                            max="52"
-                            value="11"
-                            required
-                            style="width: 100px;"
-                            onchange="updateWeeksPattern()"
-                        /> {{ t.admin_eras_weeks }}
-                        <small style="color: var(--muted); display: block; margin-top: 4px;">
-                            {{ t.admin_eras_field_length_hint }}
-                        </small>
-                    </td>
-                </tr>
-                <tr>
-                    <td style="font-weight: 600; color: var(--muted); padding-right: 16px; vertical-align: top;">{{ t.admin_eras_field_pattern }}</td>
-                    <td>
-                        <div style="margin-bottom: 8px;">
-                            <label style="display: inline-flex; align-items: center; margin-right: 16px;">
-                                <input type="radio" name="pattern_option" value="copy_current" checked onchange="updateWeeksPattern()" style="margin-right: 6px;">
-                                {{ t.admin_eras_pattern_copy }}
-                            </label>
-                            <label style="display: inline-flex; align-items: center;">
-                                <input type="radio" name="pattern_option" value="custom" onchange="updateWeeksPattern()" style="margin-right: 6px;">
-                                {{ t.admin_eras_pattern_custom }}
-                            </label>
-                        </div>
-                        <textarea
-                            name="weeks_pattern"
-                            id="weeks_pattern"
-                            rows="8"
-                            required
-                            style="width: 100%; max-width: 600px; font-family: monospace; font-size: 0.9rem;"
-                            placeholder='{"1": ["OFF", "OFF", "OFF", "N3", "N3", "N3", "N3"], ...}'
-                        ></textarea>
-                        <small style="color: var(--muted); display: block; margin-top: 4px;">
-                            {{ t.admin_eras_pattern_hint.replace('{n}', rotation_length | string) }}
-                        </small>
-                    </td>
-                </tr>
-            </tbody>
-        </table>
+    <form method="POST" action="/admin/rotation-eras/create" id="create-era-form" class="form-stack">
+        <div class="form-group">
+            <label for="era-start-date" class="form-label">{{ t.admin_eras_field_start }}</label>
+            <input
+                type="date"
+                id="era-start-date"
+                name="start_date"
+                required
+                class="form-input form-input--md"
+                aria-describedby="era-start-date-hint"
+            />
+            <small id="era-start-date-hint" class="form-hint">
+                {{ t.admin_eras_field_start_hint }}
+            </small>
+        </div>
 
-        <div style="margin-top: 24px;">
-            <button type="submit" class="btn" style="padding: 10px 24px;">
+        <div class="form-group">
+            <label for="rotation_length" class="form-label">{{ t.admin_eras_field_length }}</label>
+            <input
+                type="number"
+                name="rotation_length"
+                id="rotation_length"
+                min="1"
+                max="52"
+                value="11"
+                required
+                class="form-input form-input--sm"
+                onchange="updateWeeksPattern()"
+                aria-describedby="rotation-length-hint"
+            />
+            <span class="form-hint">{{ t.admin_eras_weeks }}</span>
+            <small id="rotation-length-hint" class="form-hint">
+                {{ t.admin_eras_field_length_hint }}
+            </small>
+        </div>
+
+        <fieldset class="form-group">
+            <legend class="form-label">{{ t.admin_eras_field_pattern }}</legend>
+            <div class="form-options">
+                <label class="form-option">
+                    <input type="radio" name="pattern_option" value="copy_current" checked onchange="updateWeeksPattern()">
+                    {{ t.admin_eras_pattern_copy }}
+                </label>
+                <label class="form-option">
+                    <input type="radio" name="pattern_option" value="custom" onchange="updateWeeksPattern()">
+                    {{ t.admin_eras_pattern_custom }}
+                </label>
+            </div>
+            <textarea
+                name="weeks_pattern"
+                id="weeks_pattern"
+                rows="8"
+                required
+                class="pattern-textarea"
+                aria-describedby="weeks-pattern-hint"
+                placeholder='{"1": ["OFF", "OFF", "OFF", "N3", "N3", "N3", "N3"], ...}'
+            ></textarea>
+            <small id="weeks-pattern-hint" class="form-hint">
+                {{ t.admin_eras_pattern_hint.replace('{n}', rotation_length | string) }}
+            </small>
+        </fieldset>
+
+        <div class="form-actions">
+            <button type="submit" class="btn btn-primary">
                 {{ t.admin_eras_create_button }}
             </button>
-            <a href="/admin/settings" class="btn secondary" style="margin-left: 12px;">
+            <a href="/admin/settings" class="btn secondary">
                 {{ t.admin_eras_back_settings }}
             </a>
         </div>
@@ -230,10 +227,10 @@ function updateWeeksPattern() {
 
         textarea.value = formatWeeksPattern(pattern);
         textarea.readOnly = true;
-        textarea.style.backgroundColor = '#f5f5f5';
+        textarea.classList.add('is-readonly-preview');
     } else {
         textarea.readOnly = false;
-        textarea.style.backgroundColor = 'white';
+        textarea.classList.remove('is-readonly-preview');
         if (textarea.value === '' || textarea.value === '{}') {
             // Provide a template
             const pattern = {};
@@ -250,90 +247,129 @@ document.addEventListener('DOMContentLoaded', function() {
     updateWeeksPattern();
 });
 
+let activeDialogTrigger = null;
+
+function getDialogControls(dialog) {
+    return Array.from(dialog.querySelectorAll('input, textarea, select, button, [href], [tabindex]:not([tabindex="-1"])'))
+        .filter(el => !el.disabled && el.offsetParent !== null);
+}
+
+function focusFirstDialogControl(dialog) {
+    const target = getDialogControls(dialog)[0];
+    (target || dialog).focus();
+}
+
+function openDialog(dialog, trigger) {
+    activeDialogTrigger = trigger || document.activeElement;
+    dialog.setAttribute('aria-hidden', 'false');
+    focusFirstDialogControl(dialog);
+}
+
+function closeDialog(dialog) {
+    if (!dialog || dialog.getAttribute('aria-hidden') === 'true') return;
+    dialog.setAttribute('aria-hidden', 'true');
+    if (activeDialogTrigger && typeof activeDialogTrigger.focus === 'function') {
+        activeDialogTrigger.focus();
+    }
+    activeDialogTrigger = null;
+}
+
 function showEraJson(btn) {
     const era = JSON.parse(btn.getAttribute('data-era'));
+    const dialog = document.getElementById('era-json-modal');
     document.getElementById('era-json-content').textContent = JSON.stringify(era, null, 2);
-    document.getElementById('era-json-modal').style.display = 'flex';
+    openDialog(dialog, btn);
 }
 
 function closeEraJson() {
-    document.getElementById('era-json-modal').style.display = 'none';
+    closeDialog(document.getElementById('era-json-modal'));
 }
 
 function showEditEra(btn) {
     const era = JSON.parse(btn.getAttribute('data-era'));
+    const dialog = document.getElementById('edit-era-modal');
     document.getElementById('edit-era-id').value = era.id;
     document.getElementById('edit-era-form').action = '/admin/rotation-eras/edit/' + era.id;
     document.getElementById('edit-era-start-date').value = era.start_date;
     document.getElementById('edit-era-rotation-length').textContent = era.rotation_length + ' veckor';
     document.getElementById('edit-era-pattern').value = formatWeeksPattern(era.weeks_pattern);
-    document.getElementById('edit-era-modal').style.display = 'flex';
+    openDialog(dialog, btn);
 }
 
 function closeEditEra() {
-    document.getElementById('edit-era-modal').style.display = 'none';
+    closeDialog(document.getElementById('edit-era-modal'));
 }
 
 document.addEventListener('keydown', function(e) {
+    const openDialogEl = document.querySelector('[role="dialog"][aria-hidden="false"]');
     if (e.key === 'Escape') { closeEraJson(); closeEditEra(); }
+    if (e.key !== 'Tab' || !openDialogEl) return;
+
+    const controls = getDialogControls(openDialogEl);
+    if (!controls.length) return;
+    const first = controls[0];
+    const last = controls[controls.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+    }
 });
 </script>
 
 <div id="edit-era-modal"
-     style="display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.55); z-index: 1000; align-items: center; justify-content: center;"
+     class="dialog-backdrop"
+     role="dialog"
+     aria-modal="true"
+     aria-hidden="true"
+     aria-labelledby="edit-era-title"
+     tabindex="-1"
      onclick="if(event.target===this) closeEditEra()">
-    <div style="background: var(--card-bg, #1e1e1e); border: 1px solid var(--border, #333); border-radius: 8px; padding: 24px; max-width: 680px; width: 90%; max-height: 85vh; display: flex; flex-direction: column;">
-        <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px;">
-            <strong>{{ t.admin_eras_edit_title }}</strong>
-            <button type="button" onclick="closeEditEra()"
-                    style="background: none; border: none; color: var(--muted); cursor: pointer; font-size: 1.2rem; padding: 0 4px; line-height: 1;">&times;</button>
+    <div class="dialog-surface">
+        <div class="dialog-header">
+            <strong id="edit-era-title">{{ t.admin_eras_edit_title }}</strong>
+            <button type="button" class="dialog-close" onclick="closeEditEra()" aria-label="{{ t.admin_eras_edit_cancel }}">&times;</button>
         </div>
-        <form id="edit-era-form" method="POST" style="display: flex; flex-direction: column; flex: 1; overflow: hidden;">
+        <form id="edit-era-form" method="POST" class="dialog-form">
             <input type="hidden" id="edit-era-id" name="era_id">
-            <table style="width: auto; margin-bottom: 16px;">
-                <tbody>
-                    <tr>
-                        <td style="font-weight: 600; color: var(--muted); padding-right: 16px; white-space: nowrap;">{{ t.admin_eras_field_start }}</td>
-                        <td>
-                            <input type="date" id="edit-era-start-date" name="start_date" required style="width: 200px;">
-                            <small style="color: var(--muted); display: block; margin-top: 4px;">{{ t.admin_eras_edit_start_hint }}</small>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td style="font-weight: 600; color: var(--muted); padding-right: 16px; white-space: nowrap;">{{ t.admin_eras_col_length }}</td>
-                        <td>
-                            <span id="edit-era-rotation-length" style="color: var(--muted);"></span>
-                            <small style="color: var(--muted); display: block; margin-top: 4px;">{{ t.admin_eras_edit_length_hint }}</small>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td style="font-weight: 600; color: var(--muted); padding-right: 16px; vertical-align: top; padding-top: 8px; white-space: nowrap;">{{ t.admin_eras_field_pattern }}</td>
-                        <td>
-                            <textarea id="edit-era-pattern" name="weeks_pattern" rows="10" required
-                                      style="width: 100%; max-width: 520px; font-family: monospace; font-size: 0.85rem;"></textarea>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-            <div style="margin-top: auto; padding-top: 12px; border-top: 1px solid var(--border, #333); display: flex; gap: 12px;">
-                <button type="submit" class="btn" style="padding: 8px 20px;">{{ t.admin_eras_edit_save }}</button>
-                <button type="button" onclick="closeEditEra()" class="btn secondary" style="padding: 8px 20px;">{{ t.admin_eras_edit_cancel }}</button>
+            <div class="dialog-form-grid">
+                <label for="edit-era-start-date" class="form-label">{{ t.admin_eras_field_start }}</label>
+                <div>
+                    <input type="date" id="edit-era-start-date" name="start_date" required class="form-input form-input--md">
+                    <small class="form-hint">{{ t.admin_eras_edit_start_hint }}</small>
+                </div>
+                <span class="form-label">{{ t.admin_eras_col_length }}</span>
+                <div>
+                    <span id="edit-era-rotation-length" class="form-hint"></span>
+                    <small class="form-hint">{{ t.admin_eras_edit_length_hint }}</small>
+                </div>
+                <label for="edit-era-pattern" class="form-label">{{ t.admin_eras_field_pattern }}</label>
+                <textarea id="edit-era-pattern" name="weeks_pattern" rows="10" required class="pattern-textarea"></textarea>
+            </div>
+            <div class="dialog-actions">
+                <button type="submit" class="btn btn-primary">{{ t.admin_eras_edit_save }}</button>
+                <button type="button" onclick="closeEditEra()" class="btn secondary">{{ t.admin_eras_edit_cancel }}</button>
             </div>
         </form>
     </div>
 </div>
 
 <div id="era-json-modal"
-     style="display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.55); z-index: 1000; align-items: center; justify-content: center;"
+     class="dialog-backdrop"
+     role="dialog"
+     aria-modal="true"
+     aria-hidden="true"
+     aria-labelledby="era-json-title"
+     tabindex="-1"
      onclick="if(event.target===this) closeEraJson()">
-    <div style="background: var(--card-bg, #1e1e1e); border: 1px solid var(--border, #333); border-radius: 8px; padding: 24px; max-width: 700px; width: 90%; max-height: 80vh; display: flex; flex-direction: column;">
-        <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px;">
-            <strong>Era JSON</strong>
-            <button type="button" onclick="closeEraJson()"
-                    style="background: none; border: none; color: var(--muted); cursor: pointer; font-size: 1.2rem; padding: 0 4px; line-height: 1;">&times;</button>
+    <div class="dialog-surface">
+        <div class="dialog-header">
+            <strong id="era-json-title">Era JSON</strong>
+            <button type="button" class="dialog-close" onclick="closeEraJson()" aria-label="{{ t.admin_eras_edit_cancel }}">&times;</button>
         </div>
-        <pre id="era-json-content"
-             style="margin: 0; overflow: auto; font-family: monospace; font-size: 0.85rem; white-space: pre; background: var(--bg, #121212); padding: 16px; border-radius: 4px; flex: 1;"></pre>
+        <pre id="era-json-content" class="dialog-code"></pre>
     </div>
 </div>
 

--- a/app/templates/admin_settings.html
+++ b/app/templates/admin_settings.html
@@ -7,23 +7,23 @@
 
 <h2 class="page-title">{{ t.admin_settings_title }}</h2>
 
-<div style="margin-bottom: 20px;">
-    <a href="/admin/rotation-eras" class="btn secondary" style="display: inline-block;">
+<div class="mb-3">
+    <a href="/admin/rotation-eras" class="btn secondary inline-block">
         📅 {{ t.admin_settings_manage_eras }}
     </a>
 </div>
 
 <form method="POST" action="/admin/settings" id="settings-form" onsubmit="return prepareFormSubmit()">
-    <div class="card" style="margin-bottom: 24px;">
+    <div class="card mb-3">
         <h3>{{ t.admin_settings_global_config }}</h3>
-        <table style="width: auto;">
+        <table class="table-auto">
             <tbody>
                 <tr>
-                    <td style="font-weight: 600; color: var(--muted);">{{ t.admin_settings_rotation_start }}</td>
-                    <td>{{ settings.rotation_start_date }} <span style="color: var(--muted); font-size: 0.85rem;">{{ t.admin_settings_read_only }}</span></td>
+                    <td class="cell-head">{{ t.admin_settings_rotation_start }}</td>
+                    <td>{{ settings.rotation_start_date }} <span class="text-sm-muted">{{ t.admin_settings_read_only }}</span></td>
                 </tr>
                 <tr>
-                    <td style="font-weight: 600; color: var(--muted);">{{ t.admin_settings_default_salary }}</td>
+                    <td class="cell-head">{{ t.admin_settings_default_salary }}</td>
                     <td>
                         <input
                             type="number"
@@ -32,7 +32,7 @@
                             min="0"
                             step="1000"
                             required
-                            style="width: 150px;"
+                            class="w-150"
                         /> SEK
                     </td>
                 </tr>
@@ -40,7 +40,7 @@
         </table>
     </div>
 
-    <div class="card" style="margin-bottom: 24px;">
+    <div class="card mb-3">
         <h3>{{ t.admin_settings_persons }}</h3>
         <table>
             <thead>
@@ -58,13 +58,12 @@
                     <td class="num" data-label="{{ t.admin_settings_col_wage }}">
                         <input
                             type="number"
-                            class="person-wage"
+                            class="person-wage w-120-right"
                             data-person-id="{{ person.id }}"
                             value="{{ person.wage }}"
                             min="0"
                             step="500"
                             required
-                            style="width: 120px; text-align: right;"
                         />
                     </td>
                 </tr>
@@ -73,11 +72,11 @@
         </table>
     </div>
     {# Submit button #}
-    <div style="margin-top: 24px; padding: 0 8px;">
-        <button type="submit" class="btn" style="padding: 10px 24px;">
+    <div class="settings-actions">
+        <button type="submit" class="btn btn-lg">
             {{ t.admin_settings_save }}
         </button>
-        <a href="/admin/settings" class="btn secondary" style="margin-left: 12px;">
+        <a href="/admin/settings" class="btn secondary ml-2">
             {{ t.admin_settings_cancel }}
         </a>
     </div>
@@ -104,5 +103,14 @@ function prepareFormSubmit() {
     return true; // Allow form submission
 }
 </script>
+
+
+<style>
+.table-auto { width: auto; }
+.w-150 { width: 150px; }
+.w-120-right { width: 120px; text-align: right; }
+.settings-actions { margin-top: 1.5rem; padding: 0 8px; }
+.btn-lg { padding: 10px 24px; }
+</style>
 
 {% endblock %}

--- a/app/templates/admin_substitute_manage.html
+++ b/app/templates/admin_substitute_manage.html
@@ -13,9 +13,9 @@
 
 <h2 class="page-title">
     {{ substitute.name }}
-    <span class="badge" style="background: var(--blue); color: white;">{{ t.substitute_tag }}</span>
+    <span class="badge badge-blue">{{ t.substitute_tag }}</span>
     {% if not substitute.is_active %}
-        <span class="badge" style="background: var(--muted); color: var(--bg);">{{ t.admin_substitutes_archived }}</span>
+        <span class="badge badge-muted">{{ t.admin_substitutes_archived }}</span>
     {% endif %}
 </h2>
 
@@ -23,11 +23,11 @@
 
 {% set weekday_names_short = t.week_day_names | from_json %}
 
-<div style="max-width: 760px;">
-    <div class="page-header" style="margin-bottom: 0.75rem;">
+<div class="shell-760">
+    <div class="page-header mb-sm">
         <div class="page-header-left">
             <a href="/admin/substitutes/{{ substitute.id }}?year={{ prev_year }}&month={{ prev_month }}" class="btn secondary">&larr;</a>
-            <strong style="margin: 0 0.75rem;">{{ year }}-{{ '%02d'|format(month) }}</strong>
+            <strong class="mx-2">{{ year }}-{{ '%02d'|format(month) }}</strong>
             <a href="/admin/substitutes/{{ substitute.id }}?year={{ next_year }}&month={{ next_month }}" class="btn secondary">&rarr;</a>
         </div>
     </div>
@@ -36,11 +36,11 @@
         <input type="hidden" name="year" value="{{ year }}">
         <input type="hidden" name="month" value="{{ month }}">
 
-        <table class="sub-calendar" style="width: 100%; border-collapse: collapse;">
+        <table class="sub-calendar">
             <thead>
                 <tr>
                     {% for d in range(7) %}
-                        <th style="padding: 4px; text-align: center; color: var(--muted); font-size: 0.8rem;">{{ weekday_names_short[d] }}</th>
+                        <th class="sub-th">{{ weekday_names_short[d] }}</th>
                     {% endfor %}
                 </tr>
             </thead>
@@ -51,11 +51,9 @@
                             {% if day.month == month %}
                                 {% set iso = day.isoformat() %}
                                 {% set current_code = shift_by_date.get(iso, '') %}
-                                <td class="sub-cal-cell {% if current_code %}has-shift{% endif %}"
-                                    style="border: 1px solid var(--border); padding: 4px; vertical-align: top; height: 56px;">
-                                    <div style="font-size: 0.75rem; color: var(--muted);">{{ day.day }}</div>
-                                    <select name="shift_{{ iso }}" onchange="markCell(this)"
-                                            style="width: 100%; font-size: 0.8rem; box-sizing: border-box;">
+                                <td class="sub-cal-cell {% if current_code %}has-shift{% endif %}">
+                                    <div class="text-xs-muted">{{ day.day }}</div>
+                                    <select name="shift_{{ iso }}" onchange="markCell(this)" class="sub-select">
                                         <option value="">&ndash;</option>
                                         {% for code in allowed_codes %}
                                             <option value="{{ code }}" {% if current_code == code %}selected{% endif %}>{{ code }}</option>
@@ -63,7 +61,7 @@
                                     </select>
                                 </td>
                             {% else %}
-                                <td style="border: 1px solid var(--border); padding: 4px; background: var(--muted-bg, #1c1c24);"></td>
+                                <td class="sub-cell-filled"></td>
                             {% endif %}
                         {% endfor %}
                     </tr>
@@ -71,38 +69,38 @@
             </tbody>
         </table>
 
-        <button type="submit" class="btn" style="margin-top: 1rem;">{{ t.admin_substitute_save }}</button>
+        <button type="submit" class="btn mt-1">{{ t.admin_substitute_save }}</button>
     </form>
 
     {# Overtime entries (hours only, no pay for substitutes) #}
-    <h3 style="margin-top: 2rem;">Övertid</h3>
+    <h3 class="section-mt">Övertid</h3>
     <form method="POST" action="/admin/substitutes/{{ substitute.id }}/overtime/add"
-          style="display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: end; margin-bottom: 0.75rem;">
-        <label style="display: flex; flex-direction: column; font-size: 0.8rem;">Datum
+          class="sub-form-row">
+        <label class="sub-field">Datum
             <input type="date" name="date" value="{{ year }}-{{ '%02d'|format(month) }}-01" required>
         </label>
-        <label style="display: flex; flex-direction: column; font-size: 0.8rem;">Från
+        <label class="sub-field">Från
             <input type="time" name="start_time" required>
         </label>
-        <label style="display: flex; flex-direction: column; font-size: 0.8rem;">Till
+        <label class="sub-field">Till
             <input type="time" name="end_time" required>
         </label>
-        <label style="display: flex; flex-direction: column; font-size: 0.8rem;">Timmar
-            <input type="number" name="hours" step="0.25" min="0" style="width: 6rem;" required>
+        <label class="sub-field">Timmar
+            <input type="number" name="hours" step="0.25" min="0" class="w-6" required>
         </label>
         <button type="submit" class="btn">Lägg till</button>
     </form>
     {% if overtime_shifts %}
-        <table style="width: 100%; border-collapse: collapse; margin-bottom: 1rem;">
+        <table class="sub-list-table">
             <tbody>
                 {% for ot in overtime_shifts %}
-                    <tr style="border-bottom: 1px solid var(--border);">
-                        <td style="padding: 4px;">{{ ot.date }}</td>
-                        <td style="padding: 4px;">{{ '%02d:%02d'|format(ot.start_time.hour, ot.start_time.minute) }}&ndash;{{ '%02d:%02d'|format(ot.end_time.hour, ot.end_time.minute) }}</td>
-                        <td style="padding: 4px;">{{ ot.hours }} h</td>
-                        <td style="padding: 4px; text-align: right;">
-                            <form method="POST" action="/admin/substitutes/{{ substitute.id }}/overtime/{{ ot.id }}/delete" style="display: inline;">
-                                <button type="submit" class="btn secondary" style="padding: 2px 8px;">Ta bort</button>
+                    <tr class="sub-tr">
+                        <td class="sub-td">{{ ot.date }}</td>
+                        <td class="sub-td">{{ '%02d:%02d'|format(ot.start_time.hour, ot.start_time.minute) }}&ndash;{{ '%02d:%02d'|format(ot.end_time.hour, ot.end_time.minute) }}</td>
+                        <td class="sub-td">{{ ot.hours }} h</td>
+                        <td class="sub-td sub-td-right">
+                            <form method="POST" action="/admin/substitutes/{{ substitute.id }}/overtime/{{ ot.id }}/delete" class="inline-form">
+                                <button type="submit" class="btn secondary btn-xs">Ta bort</button>
                             </form>
                         </td>
                     </tr>
@@ -112,13 +110,13 @@
     {% endif %}
 
     {# Absence entries (day tracking only, no deduction for substitutes) #}
-    <h3 style="margin-top: 1.5rem;">Frånvaro</h3>
+    <h3 class="mt-3">Frånvaro</h3>
     <form method="POST" action="/admin/substitutes/{{ substitute.id }}/absence/add"
-          style="display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: end; margin-bottom: 0.75rem;">
-        <label style="display: flex; flex-direction: column; font-size: 0.8rem;">Datum
+          class="sub-form-row">
+        <label class="sub-field">Datum
             <input type="date" name="date" value="{{ year }}-{{ '%02d'|format(month) }}-01" required>
         </label>
-        <label style="display: flex; flex-direction: column; font-size: 0.8rem;">Typ
+        <label class="sub-field">Typ
             <select name="absence_type" required>
                 {% for at in absence_types %}
                     <option value="{{ at }}">{{ at }}</option>
@@ -128,15 +126,15 @@
         <button type="submit" class="btn">Lägg till</button>
     </form>
     {% if absences %}
-        <table style="width: 100%; border-collapse: collapse;">
+        <table class="sub-list-table sub-list-table--flush">
             <tbody>
                 {% for a in absences %}
-                    <tr style="border-bottom: 1px solid var(--border);">
-                        <td style="padding: 4px;">{{ a.date }}</td>
-                        <td style="padding: 4px;">{{ a.absence_type }}</td>
-                        <td style="padding: 4px; text-align: right;">
-                            <form method="POST" action="/admin/substitutes/{{ substitute.id }}/absence/{{ a.id }}/delete" style="display: inline;">
-                                <button type="submit" class="btn secondary" style="padding: 2px 8px;">Ta bort</button>
+                    <tr class="sub-tr">
+                        <td class="sub-td">{{ a.date }}</td>
+                        <td class="sub-td">{{ a.absence_type }}</td>
+                        <td class="sub-td sub-td-right">
+                            <form method="POST" action="/admin/substitutes/{{ substitute.id }}/absence/{{ a.id }}/delete" class="inline-form">
+                                <button type="submit" class="btn secondary btn-xs">Ta bort</button>
                             </form>
                         </td>
                     </tr>
@@ -159,5 +157,22 @@ function markCell(sel) {
     }
 }
 </script>
+
+
+<style>
+.shell-760 { max-width: 760px; }
+.sub-calendar { width: 100%; border-collapse: collapse; }
+.sub-th { padding: 4px; text-align: center; color: var(--muted); font-size: 0.8rem; }
+.sub-cal-cell { border: 1px solid var(--border); padding: 4px; vertical-align: top; height: 56px; }
+.sub-cell-filled { border: 1px solid var(--border); padding: 4px; background: var(--panel); }
+.sub-select { width: 100%; font-size: 0.8rem; box-sizing: border-box; }
+.sub-form-row { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: end; margin-bottom: 0.75rem; }
+.sub-field { display: flex; flex-direction: column; font-size: 0.8rem; }
+.sub-list-table { width: 100%; border-collapse: collapse; margin-bottom: 1rem; }
+.sub-list-table--flush { margin-bottom: 0; }
+.sub-tr { border-bottom: 1px solid var(--border); }
+.sub-td { padding: 4px; }
+.sub-td-right { text-align: right; }
+</style>
 
 {% endblock %}

--- a/app/templates/admin_substitutes.html
+++ b/app/templates/admin_substitutes.html
@@ -13,26 +13,26 @@
 
 <h2 class="page-title">{{ t.admin_substitutes_title }}</h2>
 
-<div style="max-width: 700px;">
-    <div class="card" style="margin-bottom: 1.5rem;">
-        <h3 style="margin-top: 0;">{{ t.admin_substitutes_new }}</h3>
+<div class="form-shell form-shell--md">
+    <div class="card form-card-block">
+        <h3 class="form-card-title">{{ t.admin_substitutes_new }}</h3>
         {% if error %}
-            <div style="background: rgba(255,100,100,0.2); border: 1px solid var(--danger); padding: 12px; border-radius: var(--radius); margin-bottom: 16px;">
+            <div class="alert alert--danger">
                 {{ error }}
             </div>
         {% endif %}
-        <form method="POST" action="/admin/substitutes/create" style="display: flex; gap: 8px; align-items: flex-end;">
-            <div style="flex: 1;">
-                <label for="name" style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.admin_substitutes_name }}</label>
-                <input type="text" id="name" name="name" required style="width: 100%; box-sizing: border-box;">
+        <form method="POST" action="/admin/substitutes/create" class="form-row-inline">
+            <div class="form-group">
+                <label for="name" class="form-label">{{ t.admin_substitutes_name }}</label>
+                <input type="text" id="name" name="name" required class="form-input">
             </div>
-            <button type="submit" class="btn">{{ t.admin_substitutes_create }}</button>
+            <button type="submit" class="btn btn-primary">{{ t.admin_substitutes_create }}</button>
         </form>
     </div>
 
     <div class="card">
         {% if substitutes and substitutes|length > 0 %}
-            <table style="width: 100%;">
+            <table class="admin-table">
                 <thead>
                     <tr>
                         <th>{{ t.admin_substitutes_name }}</th>
@@ -46,14 +46,14 @@
                         <td>
                             {{ s.name }}
                             {% if not s.is_active %}
-                                <span class="badge" style="background: var(--muted); color: var(--bg);">{{ t.admin_substitutes_archived }}</span>
+                                <span class="badge badge-archived">{{ t.admin_substitutes_archived }}</span>
                             {% endif %}
                         </td>
-                        <td style="text-align: right;">
+                        <td class="table-action">
                             <a href="/admin/substitutes/{{ s.id }}" class="btn secondary">{{ t.admin_substitutes_manage }}</a>
                         </td>
-                        <td style="text-align: right;">
-                            <form method="POST" action="/admin/substitutes/{{ s.id }}/toggle" style="display: inline;">
+                        <td class="table-action">
+                            <form method="POST" action="/admin/substitutes/{{ s.id }}/toggle" class="inline-form">
                                 <button type="submit" class="btn secondary">
                                     {% if s.is_active %}{{ t.admin_substitutes_archive }}{% else %}{{ t.admin_substitutes_restore }}{% endif %}
                                 </button>

--- a/app/templates/admin_user_create.html
+++ b/app/templates/admin_user_create.html
@@ -13,39 +13,39 @@
 
 <h2 class="page-title">{{ t.admin_user_create_title }}</h2>
 
-<div style="max-width: 500px;">
+<div class="form-shell">
     <div class="card">
         {% if error %}
-            <div style="background: rgba(255,100,100,0.2); border: 1px solid var(--danger); padding: 12px; border-radius: var(--radius); margin-bottom: 16px;">
+            <div class="alert alert--danger">
                 {{ error }}
             </div>
         {% endif %}
 
-        <form method="POST" action="/admin/users/create">
-            <div style="margin-bottom: 16px;">
-                <label for="username" style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.admin_user_create_username }}</label>
-                <input type="text" id="username" name="username" required style="width: 100%; box-sizing: border-box;">
+        <form method="POST" action="/admin/users/create" class="form-stack">
+            <div class="form-group">
+                <label for="username" class="form-label">{{ t.admin_user_create_username }}</label>
+                <input type="text" id="username" name="username" required class="form-input">
             </div>
 
-            <div style="margin-bottom: 16px;">
-                <label for="password" style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.admin_user_create_password }}</label>
-                <input type="password" id="password" name="password" required minlength="6" style="width: 100%; box-sizing: border-box;">
+            <div class="form-group">
+                <label for="password" class="form-label">{{ t.admin_user_create_password }}</label>
+                <input type="password" id="password" name="password" required minlength="6" class="form-input">
             </div>
 
-            <div style="margin-bottom: 16px;">
-                <label for="name" style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.admin_user_create_name }}</label>
-                <input type="text" id="name" name="name" required style="width: 100%; box-sizing: border-box;">
+            <div class="form-group">
+                <label for="name" class="form-label">{{ t.admin_user_create_name }}</label>
+                <input type="text" id="name" name="name" required class="form-input">
             </div>
 
-            <div style="margin-bottom: 24px;">
-                <label for="role" style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.admin_user_create_role }}</label>
-                <select id="role" name="role" style="width: 100%; box-sizing: border-box;">
+            <div class="form-group">
+                <label for="role" class="form-label">{{ t.admin_user_create_role }}</label>
+                <select id="role" name="role" class="form-input">
                     <option value="user">User</option>
                     <option value="admin">Admin</option>
                 </select>
             </div>
 
-            <button type="submit" class="btn">{{ t.admin_user_create_button }}</button>
+            <button type="submit" class="btn btn-primary">{{ t.admin_user_create_button }}</button>
         </form>
     </div>
 </div>

--- a/app/templates/admin_user_edit.html
+++ b/app/templates/admin_user_edit.html
@@ -13,117 +13,117 @@
 
 <h2 class="page-title">{{ t.admin_edit_title.replace('{name}', edit_user.name) }}</h2>
 
-<div style="max-width: 500px;">
+<div class="form-shell">
     <div class="card">
         {% if error %}
-            <div style="background: rgba(255,100,100,0.2); border: 1px solid var(--danger); padding: 12px; border-radius: var(--radius); margin-bottom: 16px;">
+            <div class="alert alert--danger">
                 {{ error }}
             </div>
         {% endif %}
 
-        <form method="POST" action="/admin/users/{{ edit_user.id }}">
-            <div style="margin-bottom: 16px;">
-                <label style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.admin_field_id }}</label>
-                <input type="text" value="{{ edit_user.id }}" disabled style="width: 100%; box-sizing: border-box; opacity: 0.6;">
+        <form method="POST" action="/admin/users/{{ edit_user.id }}" class="form-stack">
+            <div class="form-group">
+                <label class="form-label">{{ t.admin_field_id }}</label>
+                <input type="text" value="{{ edit_user.id }}" disabled class="form-input">
             </div>
 
-            <div style="margin-bottom: 16px;">
-                <label style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.admin_field_username }}</label>
-                <input type="text" value="{{ edit_user.username }}" disabled style="width: 100%; box-sizing: border-box; opacity: 0.6;">
-                <small style="color: var(--muted);">{{ t.admin_field_username_hint }}</small>
+            <div class="form-group">
+                <label class="form-label">{{ t.admin_field_username }}</label>
+                <input type="text" value="{{ edit_user.username }}" disabled class="form-input">
+                <small class="form-hint">{{ t.admin_field_username_hint }}</small>
             </div>
 
-            <div style="margin-bottom: 16px;">
-                <label for="name" style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.admin_field_name }}</label>
-                <input type="text" id="name" name="name" value="{{ edit_user.name }}" required style="width: 100%; box-sizing: border-box;">
+            <div class="form-group">
+                <label for="name" class="form-label">{{ t.admin_field_name }}</label>
+                <input type="text" id="name" name="name" value="{{ edit_user.name }}" required class="form-input">
             </div>
 
-            <div style="margin-bottom: 16px;">
-                <label style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.admin_field_wage }}</label>
+            <div class="form-group">
+                <label class="form-label">{{ t.admin_field_wage }}</label>
                 {% set wage_unit = t.admin_wage_unit_hourly if edit_user.wage_type and edit_user.wage_type.value == 'hourly' else t.admin_wage_unit_monthly %}
-                <input type="text" value="{{ '{:,}'.format(edit_user.wage).replace(',', ' ') }} {{ wage_unit }}" disabled style="width: 100%; box-sizing: border-box; opacity: 0.6;">
-                <small style="color: var(--muted);">{{ t.admin_field_wage_hint }}</small>
+                <input type="text" value="{{ '{:,}'.format(edit_user.wage).replace(',', ' ') }} {{ wage_unit }}" disabled class="form-input">
+                <small class="form-hint">{{ t.admin_field_wage_hint }}</small>
             </div>
 
-            <div style="margin-bottom: 16px;">
-                <label for="tax_table" style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.admin_field_tax }}</label>
-                <select id="tax_table" name="tax_table" style="width: 100%; box-sizing: border-box; padding: 8px; border: 1px solid var(--border); border-radius: var(--radius); background: var(--bg); color: var(--text);">
+            <div class="form-group">
+                <label for="tax_table" class="form-label">{{ t.admin_field_tax }}</label>
+                <select id="tax_table" name="tax_table" class="form-input">
                     {% for table in available_tax_tables %}
                     <option value="{{ table }}" {% if edit_user.tax_table == table %}selected{% endif %}>Tabell {{ table }}</option>
                     {% endfor %}
                 </select>
-                <small style="color: var(--muted);">{{ t.admin_field_tax_hint }}</small>
+                <small class="form-hint">{{ t.admin_field_tax_hint }}</small>
             </div>
 
-            <div style="margin-bottom: 16px;">
-                <label for="role" style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.admin_field_role }}</label>
-                <select id="role" name="role" style="width: 100%; box-sizing: border-box;">
+            <div class="form-group">
+                <label for="role" class="form-label">{{ t.admin_field_role }}</label>
+                <select id="role" name="role" class="form-input">
                     <option value="user" {% if edit_user.role.value == 'user' %}selected{% endif %}>User</option>
                     <option value="admin" {% if edit_user.role.value == 'admin' %}selected{% endif %}>Admin</option>
                 </select>
             </div>
 
-            <div style="margin-bottom: 16px;">
-                <label for="person_id" style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.admin_field_person_id }}</label>
+            <div class="form-group">
+                <label for="person_id" class="form-label">{{ t.admin_field_person_id }}</label>
                 <input type="number" id="person_id" name="person_id"
                        value="{{ edit_user.person_id if edit_user.person_id is not none else '' }}"
                        min="1" max="10"
                        placeholder="1-10 eller tomt"
-                       style="width: 100%; box-sizing: border-box;">
-                <small style="color: var(--muted);">{{ t.admin_field_person_id_hint }}</small>
+                       class="form-input">
+                <small class="form-hint">{{ t.admin_field_person_id_hint }}</small>
             </div>
 
-            <div style="margin-bottom: 24px;">
-                <label for="new_password" style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.admin_field_new_password }}</label>
-                <input type="password" id="new_password" name="new_password" minlength="6" style="width: 100%; box-sizing: border-box;">
-                <small style="color: var(--muted);">{{ t.admin_field_new_password_hint }}</small>
+            <div class="form-group">
+                <label for="new_password" class="form-label">{{ t.admin_field_new_password }}</label>
+                <input type="password" id="new_password" name="new_password" minlength="6" class="form-input">
+                <small class="form-hint">{{ t.admin_field_new_password_hint }}</small>
             </div>
 
-            <button type="submit" class="btn">{{ t.admin_save }}</button>
+            <button type="submit" class="btn btn-primary">{{ t.admin_save }}</button>
         </form>
     </div>
 
     <!-- Wage History -->
-    <div class="card" style="margin-top: 16px;">
-        <h3 style="margin-top: 0;">{{ t.admin_wage_history }}</h3>
+    <div class="card card-mt">
+        <h3 class="form-card-title">{{ t.admin_wage_history }}</h3>
 
         {% if wage_history %}
-            <table style="width: 100%; border-collapse: collapse;">
+            <table class="history-table">
                 <thead>
-                    <tr style="border-bottom: 1px solid var(--border);">
-                        <th style="text-align: left; padding: 8px; color: var(--muted); font-weight: 500;">{{ t.profile_wage_col }}</th>
-                        <th style="text-align: left; padding: 8px; color: var(--muted); font-weight: 500;">{{ t.profile_from_date }}</th>
-                        <th style="text-align: left; padding: 8px; color: var(--muted); font-weight: 500;">{{ t.profile_to_date }}</th>
-                        <th style="text-align: left; padding: 8px; color: var(--muted); font-weight: 500;">{{ t.profile_status }}</th>
-                        <th style="text-align: left; padding: 8px; color: var(--muted); font-weight: 500;">{{ t.profile_action }}</th>
+                    <tr>
+                        <th>{{ t.profile_wage_col }}</th>
+                        <th>{{ t.profile_from_date }}</th>
+                        <th>{{ t.profile_to_date }}</th>
+                        <th>{{ t.profile_status }}</th>
+                        <th>{{ t.profile_action }}</th>
                     </tr>
                 </thead>
                 <tbody>
                     {% for record in wage_history %}
-                    <tr style="border-bottom: 1px solid var(--border);">
-                        <td style="padding: 8px; font-weight: 500;">{{ "{:,}".format(record.wage).replace(',', ' ') }} {{ wage_unit }}</td>
-                        <td style="padding: 8px;">{{ record.effective_from }}</td>
-                        <td style="padding: 8px;">
+                    <tr>
+                        <td class="cell-strong">{{ "{:,}".format(record.wage).replace(',', ' ') }} {{ wage_unit }}</td>
+                        <td>{{ record.effective_from }}</td>
+                        <td>
                             {% if record.effective_to %}
                                 {{ record.effective_to }}
                             {% else %}
-                                <span style="color: var(--muted); font-style: italic;">{{ t.profile_ongoing }}</span>
+                                <span class="text-italic-muted">{{ t.profile_ongoing }}</span>
                             {% endif %}
                         </td>
-                        <td style="padding: 8px;">
+                        <td>
                             {% if record.is_current %}
-                                <span style="color: var(--success); font-weight: 500;">{{ t.profile_current }}</span>
+                                <span class="status-pos">{{ t.profile_current }}</span>
                             {% else %}
-                                <span style="color: var(--muted);">{{ t.profile_historical }}</span>
+                                <span class="text-muted">{{ t.profile_historical }}</span>
                             {% endif %}
                         </td>
-                        <td style="padding: 8px;">
+                        <td>
                             {% if wage_history | length > 1 %}
-                                <form method="POST" action="/admin/users/{{ edit_user.id }}/delete-wage/{{ record.id }}" style="display: inline;" onsubmit="return confirm('{{ t.admin_delete_wage_confirm }}');">
-                                    <button type="submit" class="btn danger" style="padding: 4px 8px; font-size: 0.875rem;">{{ t.profile_delete }}</button>
+                                <form method="POST" action="/admin/users/{{ edit_user.id }}/delete-wage/{{ record.id }}" class="inline-form" onsubmit="return confirm('{{ t.admin_delete_wage_confirm }}');">
+                                    <button type="submit" class="btn danger">{{ t.profile_delete }}</button>
                                 </form>
                             {% else %}
-                                <span style="color: var(--muted); font-size: 0.875rem;">-</span>
+                                <span class="text-muted rates-sm">-</span>
                             {% endif %}
                         </td>
                     </tr>
@@ -131,28 +131,28 @@
                 </tbody>
             </table>
         {% else %}
-            <p style="color: var(--muted);">{{ t.admin_no_wage_history }}</p>
+            <p class="text-muted">{{ t.admin_no_wage_history }}</p>
         {% endif %}
     </div>
 
     <!-- Add New Wage -->
-    <div class="card" style="margin-top: 16px;">
-        <h3 style="margin-top: 0;">{{ t.admin_add_wage }}</h3>
-        <p style="color: var(--muted); margin-bottom: 16px;">
+    <div class="card card-mt">
+        <h3 class="form-card-title">{{ t.admin_add_wage }}</h3>
+        <p class="text-muted ue-desc">
             {{ t.admin_add_wage_desc }}
         </p>
 
         <form method="POST" action="/admin/users/{{ edit_user.id }}/add-wage" id="admin-add-wage-form">
-            <div style="margin-bottom: 16px;">
-                <label style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.admin_wage_type_label }}</label>
-                <div style="display: flex; gap: 1.5rem;">
-                    <label style="display: flex; align-items: center; gap: 0.4rem; cursor: pointer;">
+            <div class="form-group ue-field-block">
+                <label class="form-label">{{ t.admin_wage_type_label }}</label>
+                <div class="form-options">
+                    <label class="form-option">
                         <input type="radio" name="wage_type" value="monthly"
                             {% if not edit_user.wage_type or edit_user.wage_type.value == 'monthly' %}checked{% endif %}
                             onchange="updateAdminWageUnit(this.value)">
                         {{ t.admin_wage_type_monthly }}
                     </label>
-                    <label style="display: flex; align-items: center; gap: 0.4rem; cursor: pointer;">
+                    <label class="form-option">
                         <input type="radio" name="wage_type" value="hourly"
                             {% if edit_user.wage_type and edit_user.wage_type.value == 'hourly' %}checked{% endif %}
                             onchange="updateAdminWageUnit(this.value)">
@@ -161,9 +161,9 @@
                 </div>
             </div>
 
-            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 16px;">
+            <div class="form-grid-2">
                 <div>
-                    <label for="new_wage" style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.admin_new_wage }} (<span id="admin-wage-unit">{{ wage_unit }}</span>)</label>
+                    <label for="new_wage" class="form-label">{{ t.admin_new_wage }} (<span id="admin-wage-unit">{{ wage_unit }}</span>)</label>
                     <input
                         type="number"
                         id="new_wage"
@@ -172,23 +172,23 @@
                         min="0"
                         step="1"
                         placeholder="{{ '300' if edit_user.wage_type and edit_user.wage_type.value == 'hourly' else '35000' }}"
-                        style="width: 100%; box-sizing: border-box;"
+                        class="form-input"
                     >
                 </div>
 
                 <div>
-                    <label for="effective_from" style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.profile_from_date }}</label>
+                    <label for="effective_from" class="form-label">{{ t.profile_from_date }}</label>
                     <input
                         type="date"
                         id="effective_from"
                         name="effective_from"
                         required
-                        style="width: 100%; box-sizing: border-box;"
+                        class="form-input"
                     >
                 </div>
             </div>
 
-            <button type="submit" class="btn">{{ t.admin_add_wage_button }}</button>
+            <button type="submit" class="btn btn-primary">{{ t.admin_add_wage_button }}</button>
         </form>
         <script>
         function updateAdminWageUnit(type) {
@@ -202,47 +202,47 @@
     </div>
 
     <!-- Person History (Employment Periods) -->
-    <div class="card" style="margin-top: 16px;">
-        <h3 style="margin-top: 0;">{{ t.admin_employment_history }}</h3>
-        <p style="color: var(--muted); margin-bottom: 16px;">
+    <div class="card card-mt">
+        <h3 class="form-card-title">{{ t.admin_employment_history }}</h3>
+        <p class="text-muted ue-desc">
             {{ t.admin_employment_history_desc }}
         </p>
 
         {% if person_history %}
-            <table style="width: 100%; border-collapse: collapse;">
+            <table class="history-table">
                 <thead>
-                    <tr style="border-bottom: 1px solid var(--border);">
-                        <th style="text-align: left; padding: 8px; color: var(--muted); font-weight: 500;">{{ t.admin_col_position }}</th>
-                        <th style="text-align: left; padding: 8px; color: var(--muted); font-weight: 500;">{{ t.admin_col_name }}</th>
-                        <th style="text-align: left; padding: 8px; color: var(--muted); font-weight: 500;">{{ t.admin_col_from }}</th>
-                        <th style="text-align: left; padding: 8px; color: var(--muted); font-weight: 500;">{{ t.admin_col_to }}</th>
-                        <th style="text-align: left; padding: 8px; color: var(--muted); font-weight: 500;">{{ t.admin_col_status }}</th>
-                        <th style="text-align: center; padding: 8px; color: var(--muted); font-weight: 500;">{{ t.admin_col_delete }}</th>
+                    <tr>
+                        <th>{{ t.admin_col_position }}</th>
+                        <th>{{ t.admin_col_name }}</th>
+                        <th>{{ t.admin_col_from }}</th>
+                        <th>{{ t.admin_col_to }}</th>
+                        <th>{{ t.admin_col_status }}</th>
+                        <th class="table-action">{{ t.admin_col_delete }}</th>
                     </tr>
                 </thead>
                 <tbody>
                     {% for record in person_history %}
-                    <tr style="border-bottom: 1px solid var(--border);">
-                        <td style="padding: 8px; font-weight: 500;">{{ record.person_id }}</td>
-                        <td style="padding: 8px;">{{ record.name }}</td>
-                        <td style="padding: 8px;">{{ record.effective_from }}</td>
-                        <td style="padding: 8px;">
+                    <tr>
+                        <td class="cell-strong">{{ record.person_id }}</td>
+                        <td>{{ record.name }}</td>
+                        <td>{{ record.effective_from }}</td>
+                        <td>
                             {% if record.effective_to %}
                                 {{ record.effective_to }}
                             {% else %}
-                                <span style="color: var(--muted); font-style: italic;">{{ t.profile_ongoing }}</span>
+                                <span class="text-italic-muted">{{ t.profile_ongoing }}</span>
                             {% endif %}
                         </td>
-                        <td style="padding: 8px;">
+                        <td>
                             {% if record.is_current %}
-                                <span style="color: var(--success); font-weight: 500;">{{ t.admin_col_active }}</span>
+                                <span class="status-pos">{{ t.admin_col_active }}</span>
                             {% else %}
-                                <span style="color: var(--muted);">{{ t.profile_historical }}</span>
+                                <span class="text-muted">{{ t.profile_historical }}</span>
                             {% endif %}
                         </td>
-                        <td style="padding: 8px; text-align: center;">
-                            <form method="POST" action="/admin/users/{{ edit_user.id }}/delete-employment/{{ record.id }}" style="display: inline;" onsubmit="return confirm('Ta bort anställningsrecord för position {{ record.person_id }} ({{ record.effective_from }})?');">
-                                <button type="submit" class="btn danger" style="padding: 4px 8px; font-size: 12px;">🗑️</button>
+                        <td class="table-action">
+                            <form method="POST" action="/admin/users/{{ edit_user.id }}/delete-employment/{{ record.id }}" class="inline-form" onsubmit="return confirm('Ta bort anställningsrecord för position {{ record.person_id }} ({{ record.effective_from }})?');">
+                                <button type="submit" class="btn danger ue-icon-btn">🗑️</button>
                             </form>
                         </td>
                     </tr>
@@ -250,15 +250,15 @@
                 </tbody>
             </table>
         {% else %}
-            <p style="color: var(--muted);">{{ t.admin_no_employment }}</p>
+            <p class="text-muted">{{ t.admin_no_employment }}</p>
         {% endif %}
     </div>
 
     <!-- End Employment -->
     {% if person_history and person_history | selectattr('is_current') | list %}
-    <div class="card" style="margin-top: 16px;">
-        <h3 style="margin-top: 0; color: var(--danger);">{{ t.admin_end_employment }}</h3>
-        <p style="color: var(--muted); margin-bottom: 16px;">
+    <div class="card card-mt">
+        <h3 class="form-card-title heading-danger">{{ t.admin_end_employment }}</h3>
+        <p class="text-muted ue-desc">
             {{ t.admin_end_employment_desc }}
         </p>
 
@@ -266,14 +266,14 @@
             {% if record.is_current %}
                 <form method="POST" action="/admin/users/{{ edit_user.id }}/end-employment" onsubmit="return confirm('{% if t.html_lang == "en" %}Are you sure you want to end {{ edit_user.name }}\'s employment at position {{ record.person_id }}?{% else %}Är du säker på att du vill avsluta {{ edit_user.name }}s anställning på position {{ record.person_id }}?{% endif %}');">
                     <input type="hidden" name="person_id" value="{{ record.person_id }}">
-                    <div style="margin-bottom: 16px;">
-                        <label for="end_date" style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.admin_last_day }}</label>
+                    <div class="form-group">
+                        <label for="end_date" class="form-label">{{ t.admin_last_day }}</label>
                         <input
                             type="date"
                             id="end_date"
                             name="end_date"
                             required
-                            style="width: 100%; box-sizing: border-box;"
+                            class="form-input"
                         >
                     </div>
                     <button type="submit" class="btn danger">{{ t.admin_end_employment_button.replace('{n}', record.person_id|string) }}</button>
@@ -286,16 +286,16 @@
     <!-- Start Employment (if inactive or no current employment) -->
     {% set has_current_employment = person_history and (person_history | selectattr('is_current') | list | length > 0) %}
     {% if edit_user.is_active == 0 or not has_current_employment %}
-    <div class="card" style="margin-top: 16px;">
-        <h3 style="margin-top: 0; color: var(--success);">{{ t.admin_start_employment }}</h3>
-        <p style="color: var(--muted); margin-bottom: 16px;">
+    <div class="card card-mt">
+        <h3 class="form-card-title heading-success">{{ t.admin_start_employment }}</h3>
+        <p class="text-muted ue-desc">
             {{ t.admin_start_employment_desc }}
         </p>
 
         <form method="POST" action="/admin/users/{{ edit_user.id }}/start-employment">
-            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 16px;">
+            <div class="form-grid-2">
                 <div>
-                    <label for="person_id" style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.admin_position }}</label>
+                    <label for="person_id" class="form-label">{{ t.admin_position }}</label>
                     <input
                         type="number"
                         id="person_id"
@@ -304,51 +304,51 @@
                         min="1"
                         max="10"
                         placeholder="t.ex. 6"
-                        style="width: 100%; box-sizing: border-box;"
+                        class="form-input"
                     >
                 </div>
 
                 <div>
-                    <label for="start_date" style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.admin_first_day }}</label>
+                    <label for="start_date" class="form-label">{{ t.admin_first_day }}</label>
                     <input
                         type="date"
                         id="start_date"
                         name="start_date"
                         required
-                        style="width: 100%; box-sizing: border-box;"
+                        class="form-input"
                     >
                 </div>
             </div>
 
-            <button type="submit" class="btn">{{ t.admin_start_employment_button }}</button>
+            <button type="submit" class="btn btn-primary">{{ t.admin_start_employment_button }}</button>
         </form>
     </div>
     {% endif %}
 
     <!-- Semester -->
-    <div class="card" style="margin-top: 16px;">
-        <h3 style="margin-top: 0;">{{ t.admin_vacation_section }}</h3>
+    <div class="card card-mt">
+        <h3 class="form-card-title">{{ t.admin_vacation_section }}</h3>
 
         {% if vacation_balance %}
-        <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-bottom: 16px;">
-            <div style="text-align: center;">
-                <div style="color: var(--muted); font-size: 0.8rem; margin-bottom: 4px;">{{ t.admin_vacation_entitled }}</div>
-                <div style="font-size: 1.3rem; font-weight: 700;">{{ vacation_balance.entitled_days }}</div>
+        <div class="ue-vac-grid">
+            <div class="ue-vac-metric">
+                <div class="ue-vac-label">{{ t.admin_vacation_entitled }}</div>
+                <div class="ue-vac-value">{{ vacation_balance.entitled_days }}</div>
             </div>
-            <div style="text-align: center;">
-                <div style="color: var(--muted); font-size: 0.8rem; margin-bottom: 4px;">{{ t.admin_vacation_used }}</div>
-                <div style="font-size: 1.3rem; font-weight: 700;">{{ vacation_balance.used_days }}</div>
+            <div class="ue-vac-metric">
+                <div class="ue-vac-label">{{ t.admin_vacation_used }}</div>
+                <div class="ue-vac-value">{{ vacation_balance.used_days }}</div>
             </div>
-            <div style="text-align: center;">
-                <div style="color: var(--muted); font-size: 0.8rem; margin-bottom: 4px;">{{ t.admin_vacation_remaining }}</div>
-                <div style="font-size: 1.3rem; font-weight: 700; color: {% if vacation_balance.remaining_days > 5 %}var(--accent-2){% elif vacation_balance.remaining_days > 0 %}var(--warning){% else %}var(--danger){% endif %};">
+            <div class="ue-vac-metric">
+                <div class="ue-vac-label">{{ t.admin_vacation_remaining }}</div>
+                <div class="ue-vac-value {% if vacation_balance.remaining_days > 5 %}ue-vac-value--good{% elif vacation_balance.remaining_days > 0 %}ue-vac-value--warn{% else %}ue-vac-value--danger{% endif %}">
                     {{ vacation_balance.remaining_days }}
                 </div>
             </div>
         </div>
-        <div style="font-size: 0.8rem; color: var(--muted); margin-bottom: 12px;">
+        <div class="ue-vac-period">
             Semester&aring;r: {{ vacation_balance.year_start | date_format }} &mdash; {{ vacation_balance.year_end | date_format }}
-            {% if vacation_balance.is_first_year %}<span style="color: var(--warning);"> (proportionellt)</span>{% endif %}
+            {% if vacation_balance.is_first_year %}<span class="status-warn">(proportionellt)</span>{% endif %}
         </div>
         {% endif %}
 
@@ -356,12 +356,12 @@
         {% if vacation %}
             {% for year, weeks in vacation.items() %}
                 {% if weeks %}
-                    <p style="font-size: 0.85rem;"><strong>{{ year }}:</strong> v{{ weeks | join(', v') }}</p>
+                    <p class="ue-vac-weeks"><strong>{{ year }}:</strong> v{{ weeks | join(', v') }}</p>
                 {% endif %}
             {% endfor %}
         {% endif %}
 
-        <a href="/admin/vacation/{{ edit_user.id }}" class="btn secondary" style="margin-top: 8px;">
+        <a href="/admin/vacation/{{ edit_user.id }}" class="btn secondary card-mt">
             {{ t.admin_manage_vacation }}
         </a>
     </div>
@@ -372,7 +372,7 @@
     {% include "rates_form.html" with context %}
 
     <!-- Övertag -->
-    <div class="card" style="margin-top: 16px;">
+    <div class="card card-mt">
         <h3>{{ t.adm_transition_title }}</h3>
 
         {% if edit_transition %}
@@ -421,7 +421,7 @@
                     {{ t.adm_transition_cannot_calculate }} {{ edit_transition.consultant_vacation_days }} {{ t.adm_transition_days }}.
                 </div>
                 {% endif %}
-                <label class="form-label" style="margin-top: 0.4rem;">
+                <label class="form-label form-label--mt">
                     {{ t.adm_transition_manual_override }}
                 </label>
                 <input type="number" id="adm_vacation_days" name="consultant_vacation_days" class="form-input"
@@ -459,8 +459,7 @@
 
             <div class="form-group">
                 <label for="adm_notes" class="form-label">{{ t.adm_transition_notes_label }}</label>
-                <textarea id="adm_notes" name="notes" rows="2" class="form-input"
-                          style="padding: 0.5rem; resize: vertical;">{{ edit_transition.notes if edit_transition and edit_transition.notes else '' }}</textarea>
+                <textarea id="adm_notes" name="notes" rows="2" class="form-input form-textarea">{{ edit_transition.notes if edit_transition and edit_transition.notes else '' }}</textarea>
             </div>
 
             <hr class="form-section-divider">
@@ -502,5 +501,21 @@
         {% endif %}
     </div>
 </div>
+
+<style>
+.ue-desc { margin-bottom: 1rem; }
+.ue-field-block { margin-bottom: 1rem; }
+.ue-vac-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.75rem; margin-bottom: 1rem; }
+.ue-vac-metric { text-align: center; }
+.ue-vac-label { color: var(--muted); font-size: 0.8rem; margin-bottom: 4px; }
+.ue-vac-value { font-size: 1.3rem; font-weight: 700; }
+.ue-vac-value--good { color: var(--accent-2); }
+.ue-vac-value--warn { color: var(--warning); }
+.ue-vac-value--danger { color: var(--danger); }
+.ue-vac-period { font-size: 0.8rem; color: var(--muted); margin-bottom: 0.75rem; }
+.ue-vac-period .status-warn { margin-left: 0.25rem; }
+.ue-vac-weeks { font-size: 0.85rem; }
+.ue-icon-btn { padding: 0.25rem 0.5rem; font-size: 12px; }
+</style>
 
 {% endblock %}

--- a/app/templates/admin_users.html
+++ b/app/templates/admin_users.html
@@ -6,14 +6,14 @@
 {% block page_content %}
 
 {% if success %}
-<div style="background: rgba(100,255,100,0.2); border: 1px solid var(--success); padding: 12px; border-radius: var(--radius); margin-bottom: 16px;">
+<div class="alert alert--success">
     {{ success }}
 </div>
 {% endif %}
 
 <div class="page-header">
     <div class="page-header-left">
-        <h2 class="page-title" style="margin: 0;">{{ t.admin_users_title }}</h2>
+        <h2 class="page-title title-inline">{{ t.admin_users_title }}</h2>
     </div>
     <div class="page-header-right">
         <a href="/admin/report" class="btn secondary">Månadsrapport</a>
@@ -42,16 +42,16 @@
                 <td data-label="{{ t.admin_col_name }}">{{ u.name }}</td>
                 <td data-label="{{ t.admin_col_role }}">
                     {% if u.role.value == 'admin' %}
-                        <span class="badge" style="background: var(--role);">Admin</span>
+                        <span class="badge badge-role">Admin</span>
                     {% else %}
                         <span class="badge badge-off">User</span>
                     {% endif %}
                 </td>
                 <td data-label="{{ t.admin_col_wage }}" class="td_right num">{{ "{:,}".format(u.wage) }} SEK</td>
                 <td>
-                    <a href="/admin/users/{{ u.id }}" class="btn secondary" style="padding: 4px 12px; font-size: 0.85rem;">{{ t.admin_edit }}</a>
-                    <form method="POST" action="/admin/users/{{ u.id }}/reset-password" style="display: inline-block; margin-left: 8px;" onsubmit="return confirm('{{ t.admin_reset_password_confirm.replace('{name}', u.name) }}');">
-                        <button type="submit" class="btn" style="padding: 4px 12px; font-size: 0.85rem; background: var(--warning); border-color: var(--warning);">{{ t.admin_reset_password }}</button>
+                    <a href="/admin/users/{{ u.id }}" class="btn secondary btn-compact">{{ t.admin_edit }}</a>
+                    <form method="POST" action="/admin/users/{{ u.id }}/reset-password" class="inline-form-mr" onsubmit="return confirm('{{ t.admin_reset_password_confirm.replace('{name}', u.name) }}');">
+                        <button type="submit" class="btn btn-warning btn-compact">{{ t.admin_reset_password }}</button>
                     </form>
                 </td>
             </tr>

--- a/app/templates/admin_vacation.html
+++ b/app/templates/admin_vacation.html
@@ -8,7 +8,7 @@
 <div class="page-header">
     <div class="page-header-left">
         <a href="/admin/vacation?year={{ year - 1 }}" class="btn secondary">{{ year - 1 }}</a>
-        <span style="padding: 8px 16px; font-weight: 600;">{{ year }}</span>
+        <span class="vacation-year-label">{{ year }}</span>
         <a href="/admin/vacation?year={{ year + 1 }}" class="btn secondary">{{ year + 1 }}</a>
     </div>
     <div class="page-header-right">
@@ -19,49 +19,49 @@
 <h2 class="page-title">{{ t.admin_vacation_title.replace('{year}', year|string) }}</h2>
 
 <!-- Heatmap Grid -->
-<div class="card" style="overflow-x: auto; margin-bottom: 24px;">
-    <h3 style="margin-top: 0;">{{ t.admin_vacation_weeks_title }}</h3>
-    <table style="min-width: 900px;">
+<div class="card scroll-x mb-3">
+    <h3 class="form-card-title">{{ t.admin_vacation_weeks_title }}</h3>
+    <table class="vac-matrix-table">
         <thead>
             <tr>
-                <th style="position: sticky; left: 0; background: var(--panel); z-index: 1; min-width: 120px;">{{ t.admin_vacation_col_name }}</th>
+                <th class="vac-sticky-col">{{ t.admin_vacation_col_name }}</th>
                 {% for w in weeks_range %}
-                    <th style="text-align: center; padding: 4px 2px; font-size: 0.7rem; min-width: 22px;">{{ w }}</th>
+                    <th class="vac-week-head">{{ w }}</th>
                 {% endfor %}
             </tr>
         </thead>
         <tbody>
             {% for entry in team_data %}
             <tr>
-                <td style="position: sticky; left: 0; background: var(--panel); z-index: 1;">
-                    <a href="/admin/vacation/{{ entry.user.id }}?year={{ year }}" style="color: var(--accent); text-decoration: none;">
+                <td class="vac-sticky-cell">
+                    <a href="/admin/vacation/{{ entry.user.id }}?year={{ year }}" class="accent-link">
                         {{ entry.user.name }}
                     </a>
                 </td>
                 {% for w in weeks_range %}
                     {% if w in entry.vacation_weeks and w in entry.day_vacation_weeks %}
-                        <td style="background: linear-gradient(135deg, var(--accent) 50%, var(--accent-2) 50%); padding: 2px;" title="v{{ w }}: vecka + dag"></td>
+                        <td class="vac-cell-both" title="v{{ w }}: vecka + dag"></td>
                     {% elif w in entry.vacation_weeks %}
-                        <td style="background: var(--accent); padding: 2px;" title="v{{ w }}: semestervecka"></td>
+                        <td class="vac-cell-week" title="v{{ w }}: semestervecka"></td>
                     {% elif w in entry.day_vacation_weeks %}
-                        <td style="background: var(--accent-2); padding: 2px;" title="v{{ w }}: enskild dag"></td>
+                        <td class="vac-cell-day" title="v{{ w }}: enskild dag"></td>
                     {% else %}
-                        <td style="padding: 2px;"></td>
+                        <td class="vac-cell-empty"></td>
                     {% endif %}
                 {% endfor %}
             </tr>
             {% endfor %}
         </tbody>
     </table>
-    <div style="margin-top: 12px; display: flex; gap: 16px; font-size: 0.8rem; color: var(--muted);">
-        <span><span style="display: inline-block; width: 12px; height: 12px; background: var(--accent); border-radius: 2px; vertical-align: middle;"></span> {{ t.admin_vacation_week_label }}</span>
-        <span><span style="display: inline-block; width: 12px; height: 12px; background: var(--accent-2); border-radius: 2px; vertical-align: middle;"></span> {{ t.admin_vacation_day_label }}</span>
+    <div class="vac-legend">
+        <span><span class="vac-swatch vac-swatch-week"></span> {{ t.admin_vacation_week_label }}</span>
+        <span><span class="vac-swatch vac-swatch-day"></span> {{ t.admin_vacation_day_label }}</span>
     </div>
 </div>
 
 <!-- Balance Table -->
 <div class="card">
-    <h3 style="margin-top: 0;">{{ t.admin_vacation_balance }}</h3>
+    <h3 class="form-card-title">{{ t.admin_vacation_balance }}</h3>
     <table>
         <thead>
             <tr>
@@ -79,25 +79,25 @@
             {% for entry in team_data %}
             <tr>
                 <td>
-                    <a href="/admin/vacation/{{ entry.user.id }}?year={{ year }}" style="color: var(--accent); text-decoration: none;">
+                    <a href="/admin/vacation/{{ entry.user.id }}?year={{ year }}" class="accent-link">
                         {{ entry.user.name }}
                     </a>
                 </td>
                 <td class="num">{{ entry.balance.entitled_days }}</td>
-                <td class="num" style="color: {% if entry.balance.saved_from_previous > 0 %}var(--accent){% else %}var(--muted){% endif %};">{{ entry.balance.saved_from_previous }}</td>
-                <td class="num" style="font-weight: 600;">{{ entry.balance.total_available }}</td>
+                <td class="num {% if entry.balance.saved_from_previous > 0 %}text-accent{% else %}text-muted{% endif %}">{{ entry.balance.saved_from_previous }}</td>
+                <td class="num num-bold">{{ entry.balance.total_available }}</td>
                 <td class="num">{{ entry.balance.used_days }}</td>
-                <td class="num" style="font-weight: 600; color: {% if entry.balance.remaining_days > 5 %}var(--accent-2){% elif entry.balance.remaining_days > 0 %}var(--warning){% else %}var(--danger){% endif %};">
+                <td class="num num-bold {% if entry.balance.remaining_days > 5 %}text-accent2{% elif entry.balance.remaining_days > 0 %}text-warning{% else %}text-danger{% endif %}">
                     {{ entry.balance.remaining_days }}
                 </td>
-                <td style="font-size: 0.85rem; color: var(--muted);">
+                <td class="text-sm-muted">
                     {{ entry.balance.year_start | date_format }} &mdash; {{ entry.balance.year_end | date_format }}
                 </td>
-                <td style="font-size: 0.85rem; color: var(--muted);">
+                <td class="text-sm-muted">
                     {% if entry.user.employment_start_date %}
                         {{ entry.user.employment_start_date | date_format }}
                     {% else %}
-                        <span style="color: var(--warning);">{{ t.admin_vacation_not_set }}</span>
+                        <span class="text-warning">{{ t.admin_vacation_not_set }}</span>
                     {% endif %}
                 </td>
             </tr>
@@ -105,5 +105,21 @@
         </tbody>
     </table>
 </div>
+
+
+<style>
+.vac-matrix-table { min-width: 900px; }
+.vac-sticky-col { position: sticky; left: 0; background: var(--panel); z-index: 1; min-width: 120px; }
+.vac-sticky-cell { position: sticky; left: 0; background: var(--panel); z-index: 1; }
+.vac-week-head { text-align: center; padding: 4px 2px; font-size: 0.7rem; min-width: 22px; }
+.vac-cell-both { background: linear-gradient(135deg, var(--accent) 50%, var(--accent-2) 50%); padding: 2px; }
+.vac-cell-week { background: var(--accent); padding: 2px; }
+.vac-cell-day { background: var(--accent-2); padding: 2px; }
+.vac-cell-empty { padding: 2px; }
+.vac-legend { margin-top: 12px; display: flex; gap: 16px; font-size: 0.8rem; color: var(--muted); }
+.vac-swatch { display: inline-block; width: 12px; height: 12px; border-radius: 2px; vertical-align: middle; }
+.vac-swatch-week { background: var(--accent); }
+.vac-swatch-day { background: var(--accent-2); }
+</style>
 
 {% endblock %}

--- a/app/templates/admin_vacation_user.html
+++ b/app/templates/admin_vacation_user.html
@@ -8,7 +8,7 @@
 <div class="page-header">
     <div class="page-header-left">
         <a href="/admin/vacation/{{ edit_user.id }}?year={{ year - 1 }}" class="btn secondary">{{ year - 1 }}</a>
-        <span style="padding: 8px 16px; font-weight: 600;">{{ year }}</span>
+        <span class="vacation-year-label">{{ year }}</span>
         <a href="/admin/vacation/{{ edit_user.id }}?year={{ year + 1 }}" class="btn secondary">{{ year + 1 }}</a>
     </div>
     <div class="page-header-right">
@@ -19,54 +19,54 @@
 <h2 class="page-title">{{ t.admin_vac_user_title.replace('{name}', edit_user.name).replace('{year}', year | string) }}</h2>
 
 {% if success %}
-<div style="background: rgba(100,255,100,0.2); border: 1px solid var(--success); padding: 12px; border-radius: var(--radius); margin-bottom: 16px;">
+<div class="alert alert--success">
     {{ success }}
 </div>
 {% endif %}
 
-<div class="row" style="gap: 24px; flex-wrap: wrap; align-items: flex-start;">
+<div class="vacation-layout">
 
     <!-- Left column: week grid + day-level -->
-    <div class="col" style="min-width: 400px; flex: 2;">
+    <div class="vacation-main">
 
         <!-- Balance Card -->
-        <div class="card" style="margin-bottom: 16px;">
-            <h3 style="margin-top: 0;">{{ t.admin_vac_user_balance }}</h3>
-            <div style="display: grid; grid-template-columns: repeat(5, 1fr); gap: 8px;">
-                <div style="text-align: center;">
-                    <div style="color: var(--muted); font-size: 0.75rem; margin-bottom: 4px;">{{ t.admin_vac_user_entitled }}</div>
-                    <div style="font-size: 1.3rem; font-weight: 700;">{{ balance.entitled_days }}</div>
+        <div class="card vacation-section">
+            <h3 class="vacation-section-title">{{ t.admin_vac_user_balance }}</h3>
+            <div class="vacation-metric-grid">
+                <div class="vacation-metric">
+                    <div class="vacation-metric-label">{{ t.admin_vac_user_entitled }}</div>
+                    <div class="vacation-metric-value">{{ balance.entitled_days }}</div>
                 </div>
-                <div style="text-align: center;">
-                    <div style="color: var(--muted); font-size: 0.75rem; margin-bottom: 4px;">{{ t.admin_vac_user_saved }}</div>
-                    <div style="font-size: 1.3rem; font-weight: 700; color: {% if balance.saved_from_previous > 0 %}var(--accent){% else %}var(--muted){% endif %};">{{ balance.saved_from_previous }}</div>
+                <div class="vacation-metric">
+                    <div class="vacation-metric-label">{{ t.admin_vac_user_saved }}</div>
+                    <div class="vacation-metric-value {% if balance.saved_from_previous > 0 %}vacation-value-positive{% else %}vacation-value-muted{% endif %}">{{ balance.saved_from_previous }}</div>
                 </div>
-                <div style="text-align: center;">
-                    <div style="color: var(--muted); font-size: 0.75rem; margin-bottom: 4px;">{{ t.admin_vac_user_total }}</div>
-                    <div style="font-size: 1.3rem; font-weight: 700;">{{ balance.total_available }}</div>
+                <div class="vacation-metric">
+                    <div class="vacation-metric-label">{{ t.admin_vac_user_total }}</div>
+                    <div class="vacation-metric-value">{{ balance.total_available }}</div>
                 </div>
-                <div style="text-align: center;">
-                    <div style="color: var(--muted); font-size: 0.75rem; margin-bottom: 4px;">{{ t.admin_vac_user_used }}</div>
-                    <div style="font-size: 1.3rem; font-weight: 700;">{{ balance.used_days }}</div>
+                <div class="vacation-metric">
+                    <div class="vacation-metric-label">{{ t.admin_vac_user_used }}</div>
+                    <div class="vacation-metric-value">{{ balance.used_days }}</div>
                 </div>
-                <div style="text-align: center;">
-                    <div style="color: var(--muted); font-size: 0.75rem; margin-bottom: 4px;">{{ t.admin_vac_user_remaining }}</div>
-                    <div style="font-size: 1.3rem; font-weight: 700; color: {% if balance.remaining_days > 5 %}var(--accent-2){% elif balance.remaining_days > 0 %}var(--warning){% else %}var(--danger){% endif %};">
+                <div class="vacation-metric">
+                    <div class="vacation-metric-label">{{ t.admin_vac_user_remaining }}</div>
+                    <div class="vacation-metric-value {% if balance.remaining_days > 5 %}vacation-value-success{% elif balance.remaining_days > 0 %}vacation-value-warning{% else %}vacation-value-danger{% endif %}">
                         {{ balance.remaining_days }}
                     </div>
                 </div>
             </div>
             {% if balance.saved_breakdown %}
-            <div style="margin-top: 8px; font-size: 0.75rem; color: var(--muted); text-align: center;">
+            <div class="vacation-small-note">
                 {{ t.admin_vac_user_saved_from }} {% for s in balance.saved_breakdown %}{{ s.year }} ({{ s.days }}d){% if not loop.last %}, {% endif %}{% endfor %}
             </div>
             {% endif %}
-            <div style="margin-top: 8px; font-size: 0.8rem; color: var(--muted); text-align: center;">
+            <div class="vacation-small-note">
                 {{ t.admin_vac_user_year_range }} {{ balance.year_start | date_format }} &mdash; {{ balance.year_end | date_format }}
-                {% if balance.is_first_year %}<span style="color: var(--warning);"> {{ t.admin_vac_user_first_year }}</span>{% endif %}
+                {% if balance.is_first_year %}<span class="vacation-value-warning">{{ t.admin_vac_user_first_year }}</span>{% endif %}
             </div>
             {% if balance.week_based_used > 0 or balance.day_level_used > 0 %}
-            <div style="margin-top: 6px; font-size: 0.8rem; color: var(--muted); text-align: center;">
+            <div class="vacation-small-note">
                 {{ t.admin_vac_user_week_based }} {{ balance.week_based_used }}d | {{ t.admin_vac_user_day_level_used }} {{ balance.day_level_used }}d
             </div>
             {% endif %}
@@ -74,22 +74,22 @@
 
         <!-- Projection Card (open years) -->
         {% if balance.projection %}
-        <div class="card" style="margin-bottom: 16px; border: 1px solid var(--accent); border-left: 4px solid var(--accent);">
-            <h3 style="margin-top: 0; font-size: 0.95rem;">{{ t.admin_vac_user_projection_title.replace('{date}', balance.year_end | date_format) }}</h3>
-            <div style="display: grid; grid-template-columns: auto 1fr; gap: 4px 12px; font-size: 0.85rem;">
-                <span style="color: var(--muted);">{{ t.admin_vac_user_remaining_at_break }}</span>
-                <span style="font-weight: 600;">{{ balance.remaining_days }} {{ t.admin_vac_user_days_projection }}</span>
-                <span style="color: var(--muted);">{{ t.admin_vac_user_days_to_save }}</span>
-                <span style="font-weight: 600; color: var(--accent-2);">{{ balance.projection.days_to_save }} {{ t.admin_vac_user_days_next_year }}</span>
+        <div class="card vacation-callout">
+            <h3 class="vacation-section-title vacation-card-title-sm">{{ t.admin_vac_user_projection_title.replace('{date}', balance.year_end | date_format) }}</h3>
+            <div class="vacation-detail-grid">
+                <span class="vacation-detail-label">{{ t.admin_vac_user_remaining_at_break }}</span>
+                <span class="vacation-detail-value">{{ balance.remaining_days }} {{ t.admin_vac_user_days_projection }}</span>
+                <span class="vacation-detail-label">{{ t.admin_vac_user_days_to_save }}</span>
+                <span class="vacation-detail-value vacation-detail-value--success">{{ balance.projection.days_to_save }} {{ t.admin_vac_user_days_next_year }}</span>
                 {% if balance.projection.days_to_pay_out > 0 %}
-                <span style="color: var(--muted);">{{ t.admin_vac_user_days_payout }}</span>
-                <span style="font-weight: 600;">{{ balance.projection.days_to_pay_out }} {{ t.admin_vac_user_days_suffix }}</span>
-                <span style="color: var(--muted);">{{ t.vacation_payout_amount }}</span>
-                <span style="font-weight: 600; color: var(--accent-2);">{{ balance.projection.days_to_pay_out }} &times; {{ "%.0f"|format(balance.projection.payout_per_day) }} kr = {{ "{:,.0f}".format(balance.projection.payout_total).replace(",", " ") }} kr</span>
+                <span class="vacation-detail-label">{{ t.admin_vac_user_days_payout }}</span>
+                <span class="vacation-detail-value">{{ balance.projection.days_to_pay_out }} {{ t.admin_vac_user_days_suffix }}</span>
+                <span class="vacation-detail-label">{{ t.vacation_payout_amount }}</span>
+                <span class="vacation-detail-value vacation-detail-value--success">{{ balance.projection.days_to_pay_out }} &times; {{ "%.0f"|format(balance.projection.payout_per_day) }} kr = {{ "{:,.0f}".format(balance.projection.payout_total).replace(",", " ") }} kr</span>
                 {% endif %}
             </div>
             {% if balance.projection.days_to_pay_out > 0 %}
-            <div style="margin-top: 8px; font-size: 0.65rem; color: var(--muted);">
+            <div class="vacation-formula-note">
                 {{ t.admin_vac_user_payout_formula }}
             </div>
             {% endif %}
@@ -98,19 +98,19 @@
 
         <!-- Closed Year Card (past years) -->
         {% if balance.closed %}
-        <div class="card" style="margin-bottom: 16px; border-left: 4px solid var(--accent-2);">
-            <h3 style="margin-top: 0; font-size: 0.95rem;">{{ t.admin_vac_user_closed_title }}</h3>
-            <div style="display: grid; grid-template-columns: auto 1fr; gap: 4px 12px; font-size: 0.85rem;">
+        <div class="card vacation-section">
+            <h3 class="vacation-section-title vacation-card-title-sm">{{ t.admin_vac_user_closed_title }}</h3>
+            <div class="vacation-detail-grid">
                 {% if balance.closed.saved > 0 %}
-                <span style="color: var(--muted);">{{ t.admin_vac_user_closed_saved }}</span>
-                <span style="font-weight: 600; color: var(--accent-2);">{{ balance.closed.saved }} {{ t.admin_vac_user_closed_transferred }}</span>
+                <span class="vacation-detail-label">{{ t.admin_vac_user_closed_saved }}</span>
+                <span class="vacation-detail-value vacation-detail-value--success">{{ balance.closed.saved }} {{ t.admin_vac_user_closed_transferred }}</span>
                 {% endif %}
                 {% if balance.closed.paid_out > 0 %}
-                <span style="color: var(--muted);">{{ t.admin_vac_user_closed_paid_out }}</span>
-                <span style="font-weight: 600;">{{ balance.closed.paid_out }} {{ t.admin_vac_user_days_suffix }} &rarr; {{ "{:,.0f}".format(balance.closed.payout_amount).replace(",", " ") }} kr</span>
+                <span class="vacation-detail-label">{{ t.admin_vac_user_closed_paid_out }}</span>
+                <span class="vacation-detail-value">{{ balance.closed.paid_out }} {{ t.admin_vac_user_days_suffix }} &rarr; {{ "{:,.0f}".format(balance.closed.payout_amount).replace(",", " ") }} kr</span>
                 {% endif %}
                 {% if balance.closed.saved == 0 and balance.closed.paid_out == 0 %}
-                <span style="color: var(--muted);">{{ t.admin_vac_user_all_used }}</span>
+                <span class="vacation-detail-label">{{ t.admin_vac_user_all_used }}</span>
                 {% endif %}
             </div>
         </div>
@@ -118,127 +118,107 @@
 
         <!-- Vacation Supplement Card -->
         {% if balance.pay %}
-        <div class="card" style="margin-bottom: 16px;">
-            <h3 style="margin-top: 0;">{{ t.admin_vac_user_supplement_title }}</h3>
-            <div style="font-size: 0.7rem; color: var(--muted); margin-bottom: 12px;">{{ t.admin_vac_user_supplement_agreement }}</div>
-            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-bottom: 12px;">
-                <div style="text-align: center;">
-                    <div style="color: var(--muted); font-size: 0.75rem; margin-bottom: 4px;">{{ t.admin_vac_user_fixed_per_day }}</div>
-                    <div style="font-size: 1.2rem; font-weight: 700;">{{ "%.0f"|format(balance.pay.fixed_per_day) }} kr</div>
-                    <div style="color: var(--muted); font-size: 0.7rem;">{{ t.admin_vac_user_fixed_pct }}</div>
+        <div class="card vacation-section">
+            <h3 class="vacation-section-title">{{ t.admin_vac_user_supplement_title }}</h3>
+            <div class="vacation-copy">{{ t.admin_vac_user_supplement_agreement }}</div>
+            <div class="vacation-supplement-grid">
+                <div class="vacation-metric">
+                    <div class="vacation-supplement-label">{{ t.admin_vac_user_fixed_per_day }}</div>
+                    <div class="vacation-supplement-value">{{ "%.0f"|format(balance.pay.fixed_per_day) }} kr</div>
+                    <div class="vacation-supplement-note">{{ t.admin_vac_user_fixed_pct }}</div>
                 </div>
-                <div style="text-align: center;">
-                    <div style="color: var(--muted); font-size: 0.75rem; margin-bottom: 4px;">{{ t.admin_vac_user_variable_per_day }}</div>
-                    <div style="font-size: 1.2rem; font-weight: 700; color: var(--accent);">{{ "%.0f"|format(balance.pay.variable_per_day) }} kr</div>
-                    <div style="color: var(--muted); font-size: 0.7rem;">{{ t.admin_vac_user_variable_pct }}</div>
+                <div class="vacation-metric">
+                    <div class="vacation-supplement-label">{{ t.admin_vac_user_variable_per_day }}</div>
+                    <div class="vacation-supplement-value vacation-value-positive">{{ "%.0f"|format(balance.pay.variable_per_day) }} kr</div>
+                    <div class="vacation-supplement-note">{{ t.admin_vac_user_variable_pct }}</div>
                 </div>
             </div>
-            <div style="text-align: center; padding: 8px; background: rgba(255,255,255,0.03); border-radius: var(--radius); margin-bottom: 12px;">
-                <div style="color: var(--muted); font-size: 0.75rem; margin-bottom: 4px;">{{ t.admin_vac_user_supplement_per_day }}</div>
-                <div style="font-size: 1.5rem; font-weight: 700; color: var(--accent-2);">{{ "%.0f"|format(balance.pay.supplement_per_day) }} kr</div>
-                <div style="color: var(--muted); font-size: 0.7rem; margin-top: 4px;">
+            <div class="vacation-supplement-total">
+                <div class="vacation-supplement-total-label">{{ t.admin_vac_user_supplement_per_day }}</div>
+                <div class="vacation-supplement-total-value">{{ "%.0f"|format(balance.pay.supplement_per_day) }} kr</div>
+                <div class="vacation-supplement-note">
                     {{ t.admin_vac_user_total_for.replace('{n}', balance.entitled_days | string) }} {{ "{:,.0f}".format(balance.pay.supplement_total).replace(",", " ") }} kr
                 </div>
             </div>
-            <div style="font-size: 0.75rem; color: var(--muted);">
-                <div style="margin-bottom: 4px;">{{ t.admin_vac_user_variable_parts.replace('{start}', balance.earning_year_start | date_format).replace('{end}', balance.earning_year_end | date_format) }}</div>
-                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 2px 12px;">
+            <div class="vacation-supplement-breakdown">
+                <div class="vacation-supplement-breakdown-note">{{ t.admin_vac_user_variable_parts.replace('{start}', balance.earning_year_start | date_format).replace('{end}', balance.earning_year_end | date_format) }}</div>
+                <div class="vacation-supplement-breakdown-grid">
                     <span>{{ t.admin_vac_user_ob_shifts }}</span>
-                    <span style="text-align: right;">{{ "{:,.0f}".format(balance.pay.ob_total).replace(",", " ") }} kr</span>
+                    <span class="vacation-supplement-breakdown-value">{{ "{:,.0f}".format(balance.pay.ob_total).replace(",", " ") }} kr</span>
                     <span>{{ t.admin_vac_user_overtime }}</span>
-                    <span style="text-align: right;">{{ "{:,.0f}".format(balance.pay.ot_total).replace(",", " ") }} kr</span>
+                    <span class="vacation-supplement-breakdown-value">{{ "{:,.0f}".format(balance.pay.ot_total).replace(",", " ") }} kr</span>
                     <span>{{ t.admin_vac_user_oncall }}</span>
-                    <span style="text-align: right;">{{ "{:,.0f}".format(balance.pay.oncall_total).replace(",", " ") }} kr</span>
+                    <span class="vacation-supplement-breakdown-value">{{ "{:,.0f}".format(balance.pay.oncall_total).replace(",", " ") }} kr</span>
                 </div>
-                <div style="margin-top: 6px; padding-top: 6px; border-top: 1px solid var(--table-border);">
+                <div class="vacation-supplement-sum vacation-supplement-breakdown-grid">
                     <span>{{ t.admin_vac_user_variable_sum }}</span>
-                    <span style="float: right;">{{ "{:,.0f}".format(balance.pay.variable_total).replace(",", " ") }} kr</span>
-                </div>
-                <div>
+                    <span class="vacation-supplement-breakdown-value">{{ "{:,.0f}".format(balance.pay.variable_total).replace(",", " ") }} kr</span>
                     <span>{{ t.admin_vac_user_monthly_salary }}</span>
-                    <span style="float: right;">{{ "{:,.0f}".format(balance.pay.monthly_salary).replace(",", " ") }} kr</span>
+                    <span class="vacation-supplement-breakdown-value">{{ "{:,.0f}".format(balance.pay.monthly_salary).replace(",", " ") }} kr</span>
                 </div>
             </div>
         </div>
         {% endif %}
 
         <!-- Week Selection Grid -->
-        <div class="card" style="margin-bottom: 16px;">
-            <h3 style="margin-top: 0;">{{ t.admin_vac_user_weeks_title }}</h3>
-            <p style="color: var(--muted); margin-bottom: 16px;">{{ t.admin_vac_user_weeks_hint }}</p>
+        <div class="card vacation-section">
+            <h3 class="vacation-section-title">{{ t.admin_vac_user_weeks_title }}</h3>
+            <p class="vacation-copy">{{ t.admin_vac_user_weeks_hint }}</p>
 
             <form method="POST" action="/admin/vacation/{{ edit_user.id }}/weeks" id="vacation-form">
                 <input type="hidden" name="year" value="{{ year }}">
                 <input type="hidden" name="weeks" id="weeks-input" value="{{ vacation_weeks | join(',') }}">
 
-                <div class="week-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(60px, 1fr)); gap: 8px; margin-bottom: 24px;">
+                <div class="vacation-week-grid">
                     {% for week in range(1, 53) %}
                         <button
                             type="button"
-                            class="week-btn {% if week in vacation_weeks %}selected{% endif %}"
+                            class="week-btn vacation-week-btn {% if week in vacation_weeks %}selected{% endif %}"
                             data-week="{{ week }}"
-                            style="
-                                padding: 12px 8px;
-                                border-radius: var(--radius);
-                                border: 1px solid var(--table-border);
-                                background: {% if week in vacation_weeks %}var(--accent){% else %}var(--panel){% endif %};
-                                color: {% if week in vacation_weeks %}var(--bg){% else %}var(--text){% endif %};
-                                cursor: pointer;
-                                font-weight: {% if week in vacation_weeks %}600{% else %}400{% endif %};
-                                transition: all 0.15s;
-                            "
+                            aria-pressed="{% if week in vacation_weeks %}true{% else %}false{% endif %}"
                         >
                             v{{ week }}
                         </button>
                     {% endfor %}
                 </div>
 
-                <button type="submit" class="btn">{{ t.admin_vac_user_save_weeks }}</button>
+                <button type="submit" class="btn btn-primary">{{ t.admin_vac_user_save_weeks }}</button>
             </form>
 
-            <hr style="border: none; border-top: 1px solid var(--table-border); margin: 20px 0;">
+            <hr class="vacation-divider">
 
-            <h4 style="margin: 0 0 8px 0; color: var(--blue);">{{ t.vacation_parental_weeks }}</h4>
-            <p style="color: var(--muted); margin-bottom: 16px; font-size: 0.875rem;">{{ t.vacation_parental_weeks_hint }}</p>
+            <h4 class="vacation-subtitle">{{ t.vacation_parental_weeks }}</h4>
+            <p class="vacation-copy">{{ t.vacation_parental_weeks_hint }}</p>
 
             <form method="POST" action="/admin/vacation/{{ edit_user.id }}/parental/weeks" id="parental-form">
                 <input type="hidden" name="year" value="{{ year }}">
                 <input type="hidden" name="weeks" id="parental-weeks-input" value="{{ parental_weeks | join(',') }}">
 
-                <div class="week-grid" id="parental-week-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(60px, 1fr)); gap: 8px; margin-bottom: 16px;">
+                <div class="vacation-week-grid vacation-week-grid--compact" id="parental-week-grid">
                     {% for week in range(1, 53) %}
                         <button
                             type="button"
-                            class="parental-week-btn {% if week in parental_weeks %}selected{% endif %}"
+                            class="parental-week-btn vacation-week-btn vacation-week-btn--parental {% if week in parental_weeks %}selected{% endif %}"
                             data-week="{{ week }}"
-                            style="
-                                padding: 12px 8px;
-                                border-radius: var(--radius);
-                                border: 1px solid var(--table-border);
-                                background: {% if week in parental_weeks %}var(--blue){% else %}var(--panel){% endif %};
-                                color: {% if week in parental_weeks %}white{% else %}var(--text){% endif %};
-                                cursor: pointer;
-                                font-weight: {% if week in parental_weeks %}600{% else %}400{% endif %};
-                                transition: all 0.15s;
-                            "
+                            aria-pressed="{% if week in parental_weeks %}true{% else %}false{% endif %}"
                         >
                             v{{ week }}
                         </button>
                     {% endfor %}
                 </div>
 
-                <button type="submit" class="btn" style="background: var(--blue); color: white;">{{ t.admin_vac_user_save_weeks }}</button>
+                <button type="submit" class="btn btn-blue">{{ t.admin_vac_user_save_weeks }}</button>
             </form>
         </div>
 
         <!-- Day-Level Vacation Calendar -->
         <div class="card">
-            <h3 style="margin-top: 0;">{{ t.admin_vac_user_day_cal_title }}</h3>
-            <p style="color: var(--muted); margin-bottom: 16px;">{{ t.admin_vac_user_day_cal_hint }}</p>
+            <h3 class="vacation-section-title">{{ t.admin_vac_user_day_cal_title }}</h3>
+            <p class="vacation-copy">{{ t.admin_vac_user_day_cal_hint }}</p>
 
-            <div style="display: flex; gap: 8px; margin-bottom: 16px;">
-                <button type="button" id="mode-vacation" class="btn" style="flex: 1; background: var(--accent); color: var(--bg);" onclick="setMode('vacation')">{{ t.vacation_mode_vacation }}</button>
-                <button type="button" id="mode-parental" class="btn secondary" style="flex: 1;" onclick="setMode('parental')">{{ t.vacation_mode_parental }}</button>
+            <div class="vacation-mode-group" role="group" aria-label="{{ t.admin_vac_user_day_cal_title }}">
+                <button type="button" id="mode-vacation" class="btn vacation-mode-btn is-active" data-mode="vacation" aria-pressed="true" onclick="setMode('vacation')">{{ t.vacation_mode_vacation }}</button>
+                <button type="button" id="mode-parental" class="btn secondary vacation-mode-btn" data-mode="parental" aria-pressed="false" onclick="setMode('parental')">{{ t.vacation_mode_parental }}</button>
             </div>
 
             <form method="POST" action="/admin/vacation/{{ edit_user.id }}/days/sync" id="days-form">
@@ -248,33 +228,32 @@
                 <input type="hidden" name="parental_dates" id="parental-dates-input"
                     value="{% for a in parental_absences %}{{ a.date | date_format }}{% if not loop.last %},{% endif %}{% endfor %}">
 
-                <div id="day-calendar" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 12px; margin-bottom: 16px;"></div>
+                <div id="day-calendar" class="vacation-day-calendar"></div>
 
-                <div style="display: flex; justify-content: space-between; align-items: center;">
-                    <span id="day-count" style="color: var(--muted); font-size: 0.85rem;"></span>
-                    <button type="submit" class="btn">{{ t.admin_vac_user_save_days }}</button>
+                <div class="vacation-form-footer">
+                    <span id="day-count" class="vacation-day-count"></span>
+                    <button type="submit" class="btn btn-primary">{{ t.admin_vac_user_save_days }}</button>
                 </div>
             </form>
         </div>
     </div>
 
     <!-- Right column: settings + summary -->
-    <div class="col" style="min-width: 280px; flex: 1;">
+    <div class="vacation-side">
 
         <!-- Vacation Settings -->
-        <div class="card" style="margin-bottom: 16px;">
-            <h3 style="margin-top: 0;">{{ t.admin_vac_user_settings_title }}</h3>
+        <div class="card vacation-section">
+            <h3 class="vacation-section-title">{{ t.admin_vac_user_settings_title }}</h3>
             <form method="POST" action="/admin/vacation/{{ edit_user.id }}/settings">
-                <div style="margin-bottom: 12px;">
-                    <label style="display: block; margin-bottom: 6px; color: var(--muted); font-size: 0.85rem;">{{ t.admin_vac_user_employment_date }}</label>
+                <div class="form-group avu-field">
+                    <label class="form-label avu-label">{{ t.admin_vac_user_employment_date }}</label>
                     <input type="date" name="employment_start_date"
                         value="{{ edit_user.employment_start_date | date_format }}"
-                        style="width: 100%; padding: 8px 12px; border-radius: var(--radius); border: 1px solid var(--table-border); background: var(--panel); color: var(--text);">
+                        class="form-input">
                 </div>
-                <div style="margin-bottom: 12px;">
-                    <label style="display: block; margin-bottom: 6px; color: var(--muted); font-size: 0.85rem;">{{ t.admin_vac_user_break_month }}</label>
-                    <select name="vacation_year_start_month"
-                        style="width: 100%; padding: 8px 12px; border-radius: var(--radius); border: 1px solid var(--table-border); background: var(--panel); color: var(--text);">
+                <div class="form-group avu-field">
+                    <label class="form-label avu-label">{{ t.admin_vac_user_break_month }}</label>
+                    <select name="vacation_year_start_month" class="form-input">
                         {% for m in range(1, 13) %}
                         <option value="{{ m }}" {% if edit_user.vacation_year_start_month == m %}selected{% endif %}>
                             {{ month_names[m-1] }}
@@ -282,20 +261,20 @@
                         {% endfor %}
                     </select>
                 </div>
-                <div style="margin-bottom: 16px;">
-                    <label style="display: block; margin-bottom: 6px; color: var(--muted); font-size: 0.85rem;">{{ t.admin_vac_user_days_per_year }}</label>
+                <div class="form-group avu-field">
+                    <label class="form-label avu-label">{{ t.admin_vac_user_days_per_year }}</label>
                     <input type="number" name="vacation_days_per_year"
                         value="{{ edit_user.vacation_days_per_year }}" min="0" max="40"
-                        style="width: 100%; padding: 8px 12px; border-radius: var(--radius); border: 1px solid var(--table-border); background: var(--panel); color: var(--text);">
+                        class="form-input">
                 </div>
-                <button type="submit" class="btn" style="width: 100%;">{{ t.admin_vac_user_save_settings }}</button>
+                <button type="submit" class="btn btn-primary avu-btn-full">{{ t.admin_vac_user_save_settings }}</button>
             </form>
         </div>
 
         <!-- Saved Days Editor -->
-        <div class="card" style="margin-bottom: 16px;">
-            <h3 style="margin-top: 0;">{{ t.admin_vac_user_saved_days_title }}</h3>
-            <p style="color: var(--muted); font-size: 0.8rem; margin-bottom: 12px;">
+        <div class="card vacation-section">
+            <h3 class="vacation-section-title">{{ t.admin_vac_user_saved_days_title }}</h3>
+            <p class="vacation-copy avu-copy-sm">
                 {{ t.admin_vac_user_saved_days_desc }}
             </p>
             <form method="POST" action="/admin/vacation/{{ edit_user.id }}/saved">
@@ -305,42 +284,53 @@
                     {% set yk = y|string %}
                     {% if yk in saved_data %}
                     {% set has_entries = true %}
-                    <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
-                        <label style="color: var(--muted); font-size: 0.85rem; min-width: 50px;">{{ y }}:</label>
+                    <div class="avu-saved-row">
+                        <label class="avu-saved-label">{{ y }}:</label>
                         <input type="number" name="saved_{{ y }}" min="0" max="25"
-                            value="{{ saved_data[yk].saved }}"
-                            style="width: 60px; padding: 6px 8px; border-radius: var(--radius); border: 1px solid var(--table-border); background: var(--panel); color: var(--text); text-align: center;">
-                        <span style="color: var(--muted); font-size: 0.75rem;">{{ t.admin_vac_user_days_suffix }}</span>
+                            value="{{ saved_data[yk].saved }}" class="avu-saved-input">
+                        <span class="avu-saved-suffix">{{ t.admin_vac_user_days_suffix }}</span>
                     </div>
                     {% endif %}
                 {% endfor %}
                 {% if not has_entries %}
-                <p style="color: var(--muted); font-size: 0.85rem; margin-bottom: 8px;">{{ t.admin_vac_user_no_closed_years }}</p>
-                <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
-                    <label style="color: var(--muted); font-size: 0.85rem; min-width: 50px;">{{ year - 1 }}:</label>
-                    <input type="number" name="saved_{{ year - 1 }}" min="0" max="25" value="0"
-                        style="width: 60px; padding: 6px 8px; border-radius: var(--radius); border: 1px solid var(--table-border); background: var(--panel); color: var(--text); text-align: center;">
-                    <span style="color: var(--muted); font-size: 0.75rem;">{{ t.admin_vac_user_days_suffix }}</span>
+                <p class="vacation-copy avu-copy-sm">{{ t.admin_vac_user_no_closed_years }}</p>
+                <div class="avu-saved-row">
+                    <label class="avu-saved-label">{{ year - 1 }}:</label>
+                    <input type="number" name="saved_{{ year - 1 }}" min="0" max="25" value="0" class="avu-saved-input">
+                    <span class="avu-saved-suffix">{{ t.admin_vac_user_days_suffix }}</span>
                 </div>
                 {% endif %}
-                <button type="submit" class="btn" style="width: 100%; margin-top: 4px;">{{ t.admin_vac_user_save_button }}</button>
+                <button type="submit" class="btn btn-primary avu-btn-full avu-btn-mt">{{ t.admin_vac_user_save_button }}</button>
             </form>
         </div>
 
         <!-- Week Summary -->
         <div class="card">
-            <h3 style="margin-top: 0;">{{ t.admin_vac_user_selected_weeks_title }}</h3>
+            <h3 class="vacation-section-title">{{ t.admin_vac_user_selected_weeks_title }}</h3>
             <div id="selected-summary">
                 {% if vacation_weeks %}
                     <p><strong>{{ vacation_weeks | length }}</strong> {{ t.admin_vac_user_weeks_selected_js }}</p>
-                    <p style="color: var(--muted);">{{ vacation_weeks | join(', ') }}</p>
+                    <p class="vacation-summary-text">{{ vacation_weeks | join(', ') }}</p>
                 {% else %}
-                    <p style="color: var(--muted);">{{ t.admin_vac_user_none_selected.replace('{year}', year | string) }}</p>
+                    <p class="vacation-summary-text">{{ t.admin_vac_user_none_selected.replace('{year}', year | string) }}</p>
                 {% endif %}
             </div>
         </div>
     </div>
 </div>
+
+<style>
+.avu-field { margin-bottom: 0.75rem; }
+.avu-label { font-size: 0.85rem; }
+.avu-btn-full { width: 100%; }
+.avu-btn-mt { margin-top: 0.25rem; }
+.avu-copy-sm { font-size: 0.8rem; margin-bottom: 0.75rem; }
+.avu-saved-row { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.5rem; }
+.avu-saved-label { color: var(--muted); font-size: 0.85rem; min-width: 50px; }
+.avu-saved-input { width: 60px; text-align: center; }
+.avu-saved-suffix { color: var(--muted); font-size: 0.75rem; }
+.vacation-supplement-breakdown-note { margin-bottom: 0.25rem; }
+</style>
 
 <script>
 const _t = {
@@ -368,10 +358,10 @@ document.addEventListener('DOMContentLoaded', function() {
         if (selectedWeeks.length > 0) {
             summary.innerHTML = `
                 <p><strong>${selectedWeeks.length}</strong> ${_t.weeksSelected}</p>
-                <p style="color: var(--muted);">${selectedWeeks.join(', ')}</p>
+                <p class="vacation-summary-text">${selectedWeeks.join(', ')}</p>
             `;
         } else {
-            summary.innerHTML = `<p style="color: var(--muted);">${_t.noneSelected}</p>`;
+            summary.innerHTML = `<p class="vacation-summary-text">${_t.noneSelected}</p>`;
         }
     }
 
@@ -383,15 +373,11 @@ document.addEventListener('DOMContentLoaded', function() {
             if (index > -1) {
                 selectedWeeks.splice(index, 1);
                 this.classList.remove('selected');
-                this.style.background = 'var(--panel)';
-                this.style.color = 'var(--text)';
-                this.style.fontWeight = '400';
+                this.setAttribute('aria-pressed', 'false');
             } else {
                 selectedWeeks.push(week);
                 this.classList.add('selected');
-                this.style.background = 'var(--accent)';
-                this.style.color = 'var(--bg)';
-                this.style.fontWeight = '600';
+                this.setAttribute('aria-pressed', 'true');
             }
 
             updateSummary();
@@ -417,15 +403,11 @@ document.addEventListener('DOMContentLoaded', function() {
             if (selectedParentalWeeks.has(week)) {
                 selectedParentalWeeks.delete(week);
                 this.classList.remove('selected');
-                this.style.background = 'var(--panel)';
-                this.style.color = 'var(--text)';
-                this.style.fontWeight = '400';
+                this.setAttribute('aria-pressed', 'false');
             } else {
                 selectedParentalWeeks.add(week);
                 this.classList.add('selected');
-                this.style.background = 'var(--blue)';
-                this.style.color = 'white';
-                this.style.fontWeight = '600';
+                this.setAttribute('aria-pressed', 'true');
             }
             updateParentalWeeksInput();
         });
@@ -456,21 +438,13 @@ document.addEventListener('DOMContentLoaded', function() {
         currentMode = mode;
         const btnVac = document.getElementById('mode-vacation');
         const btnPar = document.getElementById('mode-parental');
-        if (mode === 'vacation') {
-            btnVac.style.background = 'var(--accent)';
-            btnVac.style.color = 'var(--bg)';
-            btnVac.classList.remove('secondary');
-            btnPar.style.background = '';
-            btnPar.style.color = '';
-            btnPar.classList.add('secondary');
-        } else {
-            btnPar.style.background = 'var(--blue)';
-            btnPar.style.color = 'white';
-            btnPar.classList.remove('secondary');
-            btnVac.style.background = '';
-            btnVac.style.color = '';
-            btnVac.classList.add('secondary');
-        }
+        const vacationActive = mode === 'vacation';
+        btnVac.classList.toggle('is-active', vacationActive);
+        btnVac.classList.toggle('secondary', !vacationActive);
+        btnVac.setAttribute('aria-pressed', vacationActive ? 'true' : 'false');
+        btnPar.classList.toggle('is-active', !vacationActive);
+        btnPar.classList.toggle('secondary', vacationActive);
+        btnPar.setAttribute('aria-pressed', vacationActive ? 'false' : 'true');
         updateDayCount();
     };
 
@@ -486,15 +460,15 @@ document.addEventListener('DOMContentLoaded', function() {
         calendarEl.innerHTML = '';
         for (let m = 0; m < 12; m++) {
             const monthDiv = document.createElement('div');
-            monthDiv.style.cssText = 'background: var(--panel); border-radius: var(--radius); padding: 8px; border: 1px solid var(--table-border);';
+            monthDiv.className = 'vacation-day-month';
 
             const title = document.createElement('div');
-            title.style.cssText = 'text-align: center; font-weight: 600; font-size: 0.85rem; margin-bottom: 6px;';
+            title.className = 'vacation-day-month-title';
             title.textContent = monthNames[m];
             monthDiv.appendChild(title);
 
             const grid = document.createElement('div');
-            grid.style.cssText = 'display: grid; grid-template-columns: auto repeat(7, 1fr); gap: 2px; font-size: 0.75rem;';
+            grid.className = 'vacation-day-grid';
 
             function isoWeek(dt) {
                 const d = new Date(dt.getTime());
@@ -507,23 +481,22 @@ document.addEventListener('DOMContentLoaded', function() {
             function addWkCell(dt) {
                 const wk = document.createElement('div');
                 wk.textContent = isoWeek(dt);
-                wk.style.cssText = 'text-align: right; color: var(--muted); font-size: 0.6rem; padding: 3px 4px 0 0; opacity: 0.6;';
+                wk.className = 'vacation-week-number';
                 grid.appendChild(wk);
             }
 
             // Week header + day headers
             const wkHdr = document.createElement('div');
             wkHdr.textContent = '{{ "wk" if t.html_lang == "en" else "v" }}';
-            wkHdr.style.cssText = 'text-align: right; color: var(--muted); font-size: 0.65rem; padding: 2px 4px 2px 0; opacity: 0.5;';
+            wkHdr.className = 'vacation-week-number';
             grid.appendChild(wkHdr);
             dayHeaders.forEach(dh => {
                 const hdr = document.createElement('div');
-                hdr.style.cssText = 'text-align: center; color: var(--muted); font-size: 0.65rem; padding: 2px 0;';
+                hdr.className = 'vacation-day-grid-header';
                 hdr.textContent = dh;
                 grid.appendChild(hdr);
             });
 
-            // Find first day of month and how many days
             const firstDay = new Date(calYear, m, 1);
             const daysInMonth = new Date(calYear, m + 1, 0).getDate();
             let startOffset = (firstDay.getDay() + 6) % 7;
@@ -534,18 +507,18 @@ document.addEventListener('DOMContentLoaded', function() {
                 grid.appendChild(document.createElement('div'));
             }
 
-            // Day cells
             for (let d = 1; d <= daysInMonth; d++) {
                 const dt = new Date(calYear, m, d);
                 const iso = calYear + '-' + String(m+1).padStart(2,'0') + '-' + String(d).padStart(2,'0');
                 const dayOfWeek = (dt.getDay() + 6) % 7; // 0=Mon
 
                 if (dayOfWeek === 0 && d > 1) addWkCell(dt);
-                const isWeekend = dayOfWeek >= 5;
 
-                const cell = document.createElement('div');
+                const cell = document.createElement('button');
+                cell.type = 'button';
                 cell.textContent = d;
                 cell.dataset.date = iso;
+                cell.setAttribute('aria-label', iso);
 
                 const isOffDay = offDays.has(iso);
                 const shiftColor = dayColors[iso] || null;
@@ -553,19 +526,19 @@ document.addEventListener('DOMContentLoaded', function() {
                 function applyCellStyle(el, date) {
                     const wd = (new Date(date).getDay() + 6) % 7;
                     const color = dayColors[date] || null;
-                    if (selectedDates.has(date)) {
-                        el.style.cssText = 'text-align: center; padding: 3px 1px; border-radius: 3px; cursor: pointer; transition: all 0.1s; user-select: none; background: var(--accent); color: var(--bg); font-weight: 600;';
-                    } else if (parentalDates.has(date)) {
-                        el.style.cssText = 'text-align: center; padding: 3px 1px; border-radius: 3px; cursor: pointer; transition: all 0.1s; user-select: none; background: var(--blue); color: white; font-weight: 600;';
-                    } else {
-                        el.style.cssText = 'text-align: center; padding: 3px 1px; border-radius: 3px; cursor: pointer; transition: all 0.1s; user-select: none;'
-                            + (wd >= 5 ? ' opacity: 0.5;' : '');
-                        el.style.color = color || (wd >= 5 ? 'var(--muted)' : 'var(--text)');
-                    }
+                    el.setAttribute('aria-pressed', selectedDates.has(date) || parentalDates.has(date) ? 'true' : 'false');
+                    el.className = 'vacation-day-cell';
+                    el.classList.toggle('is-weekend', wd >= 5);
+                    el.classList.toggle('is-vacation', selectedDates.has(date));
+                    el.classList.toggle('is-parental', parentalDates.has(date));
+                    el.style.color = (!selectedDates.has(date) && !parentalDates.has(date) && color) ? color : '';
                 }
 
                 if (isOffDay) {
-                    cell.style.cssText = 'text-align: center; padding: 3px 1px; border-radius: 3px; cursor: not-allowed; user-select: none; opacity: 0.35; text-decoration: line-through;';
+                    cell.disabled = true;
+                    cell.setAttribute('aria-disabled', 'true');
+                    cell.setAttribute('aria-pressed', 'false');
+                    cell.className = 'vacation-day-cell';
                     if (shiftColor) cell.style.color = shiftColor;
                 } else {
                     applyCellStyle(cell, iso);

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -12,6 +12,7 @@
         <link rel="stylesheet" href="/static/css/tables.css">
         <link rel="stylesheet" href="/static/css/navigation.css">
         <link rel="stylesheet" href="/static/css/calendar.css">
+        <script src="/static/js/shift-colors.js" defer></script>
     </head>
     <body>
         {% set path = request.url.path %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -16,15 +16,15 @@
     <body>
         {% set path = request.url.path %}
         <header>
-            <div class="row" style="justify-content: space-between;">
-                <div class="col" style="flex: none;">
-                    <h1 style="margin:0; font-size: 22px;">Periodical</h1>
-                    <div style="color: var(--muted); font-size: 13px; margin-top:2px;">
+            <div class="row app-header-row">
+                <div class="col app-brand">
+                    <h1 class="app-title">Periodical</h1>
+                    <div class="app-subtitle">
                         {{ t.app_subtitle }}
                     </div>
                 </div>
 
-                <button class="hamburger" id="hamburger" aria-label="{{ t.nav_menu }}">
+                <button class="hamburger" id="hamburger" aria-label="{{ t.nav_menu }}" aria-controls="main-nav" aria-expanded="false">
                     <span></span>
                     <span></span>
                     <span></span>
@@ -61,12 +61,12 @@
                                 <a href="/profile" class="nav-link {% if path == '/profile' or path.startswith('/profile/') and not path.startswith('/profile/vacation') %}nav-link--active{% endif %}" {% if path == '/profile' %}aria-current="page"{% endif %}>{{ user.name }}</a>
                                 <a href="/profile/vacation" class="nav-link {% if path.startswith('/profile/vacation') %}nav-link--active{% endif %}" {% if path.startswith('/profile/vacation') %}aria-current="page"{% endif %}>{{ t.nav_vacation }}</a>
                             {% endif %}
-                            <form method="POST" action="/profile/language" style="display:inline;">
+                            <form method="POST" action="/profile/language" class="nav-inline-form">
                                 <input type="hidden" name="lang" value="{{ 'en' if user.language == 'sv' else 'sv' }}">
                                 <input type="hidden" name="next" value="{{ request.url.path }}{% if request.url.query %}?{{ request.url.query }}{% endif %}">
-                                <button type="submit" class="nav-link" style="background:none;border:none;cursor:pointer;padding:0;font:inherit;color:var(--muted);">{{ 'EN' if user.language == 'sv' else 'SV' }}</button>
+                                <button type="submit" class="nav-link nav-link-button">{{ 'EN' if user.language == 'sv' else 'SV' }}</button>
                             </form>
-                            <a href="/logout" class="nav-link" style="color: var(--muted);">{{ t.nav_logout }}</a>
+                            <a href="/logout" class="nav-link">{{ t.nav_logout }}</a>
                         </div>
                     {% else %}
                         <!-- Inloggning -->
@@ -82,19 +82,44 @@
         <script>
             const hamburger = document.getElementById('hamburger');
             const nav = document.getElementById('main-nav');
+            const mobileNavQuery = window.matchMedia('(max-width: 800px)');
+
+            function syncNavAccessibility(isOpen) {
+                const mobileClosed = mobileNavQuery.matches && !isOpen;
+                nav.inert = mobileClosed;
+                if (mobileClosed) {
+                    nav.setAttribute('aria-hidden', 'true');
+                } else {
+                    nav.removeAttribute('aria-hidden');
+                }
+            }
+
+            function setMenuOpen(isOpen) {
+                hamburger.classList.toggle('active', isOpen);
+                nav.classList.toggle('active', isOpen);
+                hamburger.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+                syncNavAccessibility(isOpen);
+            }
 
             hamburger.addEventListener('click', () => {
-                hamburger.classList.toggle('active');
-                nav.classList.toggle('active');
+                setMenuOpen(!nav.classList.contains('active'));
             });
 
             // Stäng menyn när en länk klickas
             document.querySelectorAll('.nav-link').forEach(link => {
                 link.addEventListener('click', () => {
-                    hamburger.classList.remove('active');
-                    nav.classList.remove('active');
+                    setMenuOpen(false);
                 });
             });
+
+            document.addEventListener('keydown', event => {
+                if (event.key === 'Escape') setMenuOpen(false);
+            });
+
+            mobileNavQuery.addEventListener('change', () => {
+                syncNavAccessibility(nav.classList.contains('active'));
+            });
+            syncNavAccessibility(false);
         </script>
 
         <main>
@@ -102,8 +127,8 @@
             {% endblock %}
         </main>
 
-        <footer style="text-align: center; padding: 1.5rem 1rem 1rem; color: var(--muted); font-size: 0.78rem;">
-            <a href="/changelog" style="color: var(--muted); text-decoration: none;" title="Nyheter &amp; versioner">Periodical v{{ app_version }}</a>
+        <footer class="app-footer">
+            <a href="/changelog" class="app-footer-link" title="Nyheter &amp; versioner">Periodical v{{ app_version }}</a>
         </footer>
     </body>
 </html>

--- a/app/templates/change_password.html
+++ b/app/templates/change_password.html
@@ -8,7 +8,7 @@
 <div class="form-shell form-shell--center">
     <div class="card">
         {% if must_change %}
-            <h2 class="form-card-title" style="color: var(--danger);">{{ t.change_pw_title_forced }}</h2>
+            <h2 class="form-card-title heading-danger">{{ t.change_pw_title_forced }}</h2>
             <p class="alert alert--warning">
                 {{ t.change_pw_forced_notice }}
             </p>

--- a/app/templates/change_password.html
+++ b/app/templates/change_password.html
@@ -5,26 +5,26 @@
 
 {% block page_content %}
 
-<div style="max-width: 500px; margin: 60px auto;">
+<div class="form-shell form-shell--center">
     <div class="card">
         {% if must_change %}
-            <h2 style="margin-top: 0; color: var(--danger);">{{ t.change_pw_title_forced }}</h2>
-            <p style="background: rgba(255,193,7,0.2); border: 1px solid #ffc107; padding: 12px; border-radius: var(--radius); margin-bottom: 20px;">
+            <h2 class="form-card-title" style="color: var(--danger);">{{ t.change_pw_title_forced }}</h2>
+            <p class="alert alert--warning">
                 {{ t.change_pw_forced_notice }}
             </p>
         {% else %}
-            <h2 style="margin-top: 0;">{{ t.change_pw_title }}</h2>
+            <h2 class="form-card-title">{{ t.change_pw_title }}</h2>
         {% endif %}
 
         {% if error %}
-            <div style="background: rgba(255,100,100,0.2); border: 1px solid var(--danger); padding: 12px; border-radius: var(--radius); margin-bottom: 16px;">
+            <div class="alert alert--danger">
                 {{ error }}
             </div>
         {% endif %}
 
-        <form method="POST" action="/change-password">
-            <div style="margin-bottom: 16px;">
-                <label for="current_password" style="display: block; margin-bottom: 6px; color: var(--muted);">
+        <form method="POST" action="/change-password" class="form-stack">
+            <div class="form-group">
+                <label for="current_password" class="form-label">
                     {{ t.change_pw_current }}
                 </label>
                 <input
@@ -33,13 +33,13 @@
                     name="current_password"
                     required
                     autocomplete="current-password"
-                    style="width: 100%; box-sizing: border-box;"
+                    class="form-input"
                 >
             </div>
 
-            <div style="margin-bottom: 16px;">
-                <label for="new_password" style="display: block; margin-bottom: 6px; color: var(--muted);">
-                    {{ t.change_pw_new }} <small style="color: var(--muted);">{{ t.change_pw_new_hint }}</small>
+            <div class="form-group">
+                <label for="new_password" class="form-label">
+                    {{ t.change_pw_new }} <small class="form-hint">{{ t.change_pw_new_hint }}</small>
                 </label>
                 <input
                     type="password"
@@ -48,12 +48,12 @@
                     required
                     minlength="8"
                     autocomplete="new-password"
-                    style="width: 100%; box-sizing: border-box;"
+                    class="form-input"
                 >
             </div>
 
-            <div style="margin-bottom: 24px;">
-                <label for="confirm_password" style="display: block; margin-bottom: 6px; color: var(--muted);">
+            <div class="form-group">
+                <label for="confirm_password" class="form-label">
                     {{ t.change_pw_confirm }}
                 </label>
                 <input
@@ -63,22 +63,24 @@
                     required
                     minlength="8"
                     autocomplete="new-password"
-                    style="width: 100%; box-sizing: border-box;"
+                    class="form-input"
                 >
             </div>
 
-            <button type="submit" class="btn btn-primary" style="width: 100%;">{{ t.change_pw_button }}</button>
+            <div class="form-actions--stack">
+                <button type="submit" class="btn btn-primary">{{ t.change_pw_button }}</button>
 
-            {% if not must_change %}
-                <a href="/" class="btn secondary" style="width: 100%; margin-top: 12px; display: block; text-align: center; box-sizing: border-box;">
-                    {{ t.change_pw_cancel }}
-                </a>
-            {% endif %}
+                {% if not must_change %}
+                    <a href="/" class="btn secondary">
+                        {{ t.change_pw_cancel }}
+                    </a>
+                {% endif %}
+            </div>
         </form>
 
-        <div style="margin-top: 20px; padding-top: 20px; border-top: 1px solid var(--border); color: var(--muted); font-size: 0.9em;">
+        <div class="form-note">
             <strong>{{ t.change_pw_tips_title }}</strong>
-            <ul style="margin: 8px 0 0 0; padding-left: 20px;">
+            <ul>
                 <li>{{ t.change_pw_tip1 }}</li>
                 <li>{{ t.change_pw_tip2 }}</li>
                 <li>{{ t.change_pw_tip3 }}</li>

--- a/app/templates/changelog.html
+++ b/app/templates/changelog.html
@@ -5,31 +5,31 @@
 
 {% block page_content %}
 <section>
-    <div style="max-width: 720px;">
-        <h2 style="margin-bottom: 0.25rem;">{{ t.changelog_title }}</h2>
-        <p style="color: var(--muted); margin-top: 0; margin-bottom: 2rem;">{{ t.changelog_current_version }}: <strong>v{{ current_version }}</strong></p>
+    <div class="cl-shell">
+        <h2 class="cl-title">{{ t.changelog_title }}</h2>
+        <p class="cl-sub">{{ t.changelog_current_version }}: <strong>v{{ current_version }}</strong></p>
 
         {% for v in versions %}
-        <div class="card" style="margin-bottom: 1.5rem;">
-            <div style="display: flex; align-items: baseline; gap: 1rem; flex-wrap: wrap; margin-bottom: 0.75rem;">
-                <span style="font-size: 1.1rem; font-weight: 600; color: var(--text);">v{{ v.version }}</span>
-                <span style="color: var(--muted); font-size: 0.85rem;">{{ v.date }}</span>
+        <div class="card mb-3">
+            <div class="cl-head">
+                <span class="cl-version">v{{ v.version }}</span>
+                <span class="text-sm-muted">{{ v.date }}</span>
                 {% if loop.first %}
-                <span style="background: var(--accent); color: #fff; font-size: 0.72rem; font-weight: 600; padding: 0.1rem 0.5rem; border-radius: 99px; letter-spacing: 0.04em;">{{ t.changelog_latest }}</span>
+                <span class="cl-relbadge">{{ t.changelog_latest }}</span>
                 {% endif %}
             </div>
 
-            <ul style="margin: 0; padding: 0; list-style: none; display: flex; flex-direction: column; gap: 0.45rem;">
+            <ul class="cl-list">
                 {% for entry in v.entries %}
-                <li style="display: flex; gap: 0.6rem; align-items: baseline;">
+                <li class="cl-item">
                     {% if entry.type == "nyhet" %}
-                    <span style="flex-shrink: 0; font-size: 0.7rem; font-weight: 700; letter-spacing: 0.05em; background: var(--muted-bg); color: var(--accent); padding: 0.1rem 0.45rem; border-radius: 4px; text-transform: uppercase;">{{ t.changelog_type_nyhet }}</span>
+                    <span class="cl-tag cl-tag--accent">{{ t.changelog_type_nyhet }}</span>
                     {% elif entry.type == "förbättring" %}
-                    <span style="flex-shrink: 0; font-size: 0.7rem; font-weight: 700; letter-spacing: 0.05em; background: var(--muted-bg); color: var(--success, var(--success)); padding: 0.1rem 0.45rem; border-radius: 4px; text-transform: uppercase;">{{ t.changelog_type_forbattring }}</span>
+                    <span class="cl-tag cl-tag--success">{{ t.changelog_type_forbattring }}</span>
                     {% else %}
-                    <span style="flex-shrink: 0; font-size: 0.7rem; font-weight: 700; letter-spacing: 0.05em; background: var(--muted-bg); color: var(--warning, #e0a84e); padding: 0.1rem 0.45rem; border-radius: 4px; text-transform: uppercase;">{{ t.changelog_type_fix }}</span>
+                    <span class="cl-tag cl-tag--warning">{{ t.changelog_type_fix }}</span>
                     {% endif %}
-                    <span style="color: var(--text); line-height: 1.5;">{{ entry.en if t.html_lang == 'en' else entry.sv }}</span>
+                    <span class="cl-text">{{ entry.en if t.html_lang == 'en' else entry.sv }}</span>
                 </li>
                 {% endfor %}
             </ul>
@@ -37,4 +37,21 @@
         {% endfor %}
     </div>
 </section>
+
+<style>
+.cl-shell { max-width: 720px; }
+.cl-title { margin-bottom: 0.25rem; }
+.cl-sub { color: var(--muted); margin-top: 0; margin-bottom: 2rem; }
+.cl-head { display: flex; align-items: baseline; gap: 1rem; flex-wrap: wrap; margin-bottom: 0.75rem; }
+.cl-version { font-size: 1.1rem; font-weight: 600; color: var(--text); }
+.cl-relbadge { background: var(--accent); color: #fff; font-size: 0.72rem; font-weight: 600; padding: 0.1rem 0.5rem; border-radius: 99px; letter-spacing: 0.03em; }
+.cl-list { margin: 0; padding: 0; list-style: none; display: flex; flex-direction: column; gap: 0.45rem; }
+.cl-item { display: flex; gap: 0.6rem; align-items: baseline; }
+.cl-tag { flex-shrink: 0; font-size: 0.7rem; font-weight: 700; letter-spacing: 0.05em; background: var(--muted-bg); padding: 0.1rem 0.4rem; border-radius: 4px; }
+.cl-tag--accent { color: var(--accent); }
+.cl-tag--success { color: var(--success); }
+.cl-tag--warning { color: var(--warning); }
+.cl-text { color: var(--text); line-height: 1.5; }
+</style>
+
 {% endblock %}

--- a/app/templates/cowork.html
+++ b/app/templates/cowork.html
@@ -33,8 +33,8 @@
 <div class="cowork-top-layout">
 
 <!-- Cowork stats-tabell -->
-<div style="overflow-x:auto; flex:0 1 auto;">
-<table class="summary" id="cowork-table" style="width:fit-content;">
+<div class="cw-table-scroll">
+<table class="summary cw-table-fit" id="cowork-table">
     <thead>
         <tr>
             <th class="th_left sortable" data-col="name" data-type="str">{{ t.year_col_person }} <span class="sort-arrow"></span></th>
@@ -78,27 +78,27 @@
 <!-- Alltid synlig sammanfattning -->
 <div class="cowork-sidebar">
 
-    <div style="margin-bottom:1.75rem;">
+    <div class="cw-block">
         <div class="sidebar-label">{{ t.cowork_total_label.replace('{year}', year|string) }}</div>
-        <div style="display:flex; gap:2rem; flex-wrap:wrap; margin-top:.5rem;">
+        <div class="cw-stat-row">
             <div>
-                <div style="font-size:1.6em; font-weight:700; color:var(--text); line-height:1.1;">{{ ns.total_shared }}</div>
-                <div style="font-size:.8em; color:var(--muted);">{{ t.cowork_shared_shifts }}</div>
+                <div class="cw-stat-num">{{ ns.total_shared }}</div>
+                <div class="cw-stat-label">{{ t.cowork_shared_shifts }}</div>
             </div>
             <div>
-                <div style="font-size:1.6em; font-weight:700; color:var(--text); line-height:1.1;">{{ ns.total_handovers }}</div>
-                <div style="font-size:.8em; color:var(--muted);">{{ t.cowork_handovers_label }}</div>
+                <div class="cw-stat-num">{{ ns.total_handovers }}</div>
+                <div class="cw-stat-label">{{ t.cowork_handovers_label }}</div>
             </div>
         </div>
     </div>
 
     {% if top_sorted %}
-    <div style="margin-bottom:1.75rem;">
+    <div class="cw-block">
         <div class="sidebar-label">{{ t.cowork_top3 }}</div>
         {% for r in top_sorted[:3] %}
-        <div style="display:flex; justify-content:space-between; align-items:baseline; padding:.3rem 0; border-bottom:1px solid var(--table-border);">
-            <a href="/cowork/{{ person_id }}?year={{ year }}&with_person_id={{ r.other_id }}#detail" style="font-size:.9em;">{{ r.other_name }}</a>
-            <span style="font-size:.82em; color:var(--muted); white-space:nowrap; margin-left:.5rem;">{{ r.total }} {{ t.cowork_shifts_count }}</span>
+        <div class="cw-top-row">
+            <a href="/cowork/{{ person_id }}?year={{ year }}&with_person_id={{ r.other_id }}#detail" class="cw-top-name">{{ r.other_name }}</a>
+            <span class="cw-top-count">{{ r.total }} {{ t.cowork_shifts_count }}</span>
         </div>
         {% endfor %}
     </div>
@@ -108,12 +108,12 @@
         <div class="sidebar-label">{{ t.cowork_shift_dist }}</div>
         {% for s, val in [('N1', ns.n1), ('N2', ns.n2), ('N3', ns.n3)] %}
         {% set pct = (val / max_bar * 100) | round | int %}
-        <div style="display:flex; align-items:center; gap:.5rem; margin-top:.4rem;">
-            <span style="font-size:.8em; color:var(--muted); width:1.8rem; flex-shrink:0;">{{ s }}</span>
-            <div style="flex:1; height:6px; background:var(--muted-bg); border-radius:3px; min-width:0;">
-                <div style="width:{{ pct }}%; height:100%; background:var(--accent); border-radius:3px; {% if val == 0 %}opacity:0;{% endif %}"></div>
+        <div class="cw-dist-row">
+            <span class="cw-dist-label">{{ s }}</span>
+            <div class="cw-dist-track">
+                <div class="cw-dist-fill" data-pct="{{ pct }}"{% if val == 0 %} data-zero="1"{% endif %}></div>
             </div>
-            <span style="font-size:.8em; color:var(--muted); width:2.5rem; text-align:right; flex-shrink:0;">{{ val }}</span>
+            <span class="cw-dist-val">{{ val }}</span>
         </div>
         {% endfor %}
     </div>
@@ -124,7 +124,7 @@
 
 {# Detaljvy för vald kollega #}
 {% if selected_other_id %}
-<h2 id="detail" class="page-title" style="margin-top: 2rem;">
+<h2 id="detail" class="page-title cw-detail-mt">
     {{ t.cowork_detail_title.replace('{name}', selected_other_name).replace('{id}', selected_other_id|string).replace('{year}', year|string) }}
 </h2>
 
@@ -140,43 +140,43 @@
     <div>
 
         <!-- Nästa datum -->
-        <div style="margin-bottom:1.5rem; font-size:.9em; color:var(--muted); display:flex; flex-direction:column; gap:.4rem;">
-            <span>{{ t.cowork_next_shift }} <strong style="color:var(--text)">{{ selected_cowork_row.next_shared_date or "–" }}</strong></span>
-            <span>{{ t.cowork_next_handover }} <strong style="color:var(--text)">{{ selected_cowork_row.next_handover_date or "–" }}</strong></span>
+        <div class="cw-next">
+            <span>{{ t.cowork_next_shift }} <strong>{{ selected_cowork_row.next_shared_date or "–" }}</strong></span>
+            <span>{{ t.cowork_next_handover }} <strong>{{ selected_cowork_row.next_handover_date or "–" }}</strong></span>
         </div>
 
         <!-- Skiftfördelning N1/N2/N3 -->
-        <div style="display:flex; gap:1.5rem; align-items:flex-end; margin-bottom:1.75rem;">
+        <div class="cw-vbars">
             {% for s in ["N1", "N2", "N3"] %}
             {% set val = selected_cowork_row.by_shift[s] %}
             {% set bar_h = (val / max_shift * 48) | round | int %}
-            <div style="text-align:center; min-width:2.5rem;">
-                <div style="font-size:1em; font-weight:600; color:var(--text)">{{ val }}</div>
-                <div style="width:2.5rem; height:48px; background:var(--muted-bg); border-radius:4px 4px 0 0; display:flex; align-items:flex-end; margin:4px auto 0;">
-                    <div style="width:100%; height:{{ [bar_h, 2 if val > 0 else 0] | max }}px; background:var(--accent); border-radius:4px 4px 0 0;"></div>
+            <div class="cw-vbar">
+                <div class="cw-vbar-num">{{ val }}</div>
+                <div class="cw-vbar-track">
+                    <div class="cw-vbar-fill" data-h="{{ [bar_h, 2 if val > 0 else 0] | max }}"></div>
                 </div>
-                <div style="font-size:.8em; color:var(--muted); margin-top:4px">{{ s }}</div>
+                <div class="cw-vbar-label">{{ s }}</div>
             </div>
             {% endfor %}
         </div>
 
         <!-- Månadsfördelning -->
-        <h3 style="margin-bottom:.5rem;">{{ t.cowork_month_dist }}</h3>
-        <div style="overflow-x:auto; margin-bottom:1rem;">
+        <h3 class="cw-chart-title">{{ t.cowork_month_dist }}</h3>
+        <div class="cw-scroll cw-mb1">
         <table class="summary">
             <thead><tr>
                 {% for m in range(1, 13) %}
-                <th style="text-align:right; font-size:.8em">{{ month_names[m|string] }}</th>
+                <th class="cw-cell cw-cell-sm">{{ month_names[m|string] }}</th>
                 {% endfor %}
             </tr></thead>
             <tbody><tr>
                 {% for m in range(1, 13) %}
                 {% set val = selected_cowork_row.by_month[m] %}
                 {% set pct = (val / max_month * 100) | round | int %}
-                <td style="text-align:right; padding:6px 8px 6px;">
-                    <div style="font-size:.9em; line-height:1.4">{{ val }}</div>
-                    <div style="height:3px; background:var(--muted-bg); border-radius:2px; margin-top:3px; min-width:1.5rem;">
-                        <div style="width:{{ pct }}%; height:100%; background:var(--accent); border-radius:2px; {% if val == 0 %}opacity:0;{% endif %}"></div>
+                <td class="cw-cell">
+                    <div class="cw-cell-num">{{ val }}</div>
+                    <div class="cw-hbar">
+                        <div class="cw-hbar-fill" data-pct="{{ pct }}"{% if val == 0 %} data-zero="1"{% endif %}></div>
                     </div>
                 </td>
                 {% endfor %}
@@ -185,22 +185,22 @@
         </div>
 
         <!-- Veckodagsfördelning -->
-        <h3 style="margin-bottom:.5rem;">{{ t.cowork_weekday_dist }}</h3>
-        <div style="overflow-x:auto;">
+        <h3 class="cw-chart-title">{{ t.cowork_weekday_dist }}</h3>
+        <div class="cw-scroll">
         <table class="summary">
             <thead><tr>
                 {% for d in range(7) %}
-                <th style="text-align:right; font-size:.8em">{{ wd_names[d] }}</th>
+                <th class="cw-cell cw-cell-sm">{{ wd_names[d] }}</th>
                 {% endfor %}
             </tr></thead>
             <tbody><tr>
                 {% for d in range(7) %}
                 {% set val = selected_cowork_row.by_weekday[d] %}
                 {% set pct = (val / max_wd * 100) | round | int %}
-                <td style="text-align:right; padding:6px 8px 6px;">
-                    <div style="font-size:.9em; line-height:1.4">{{ val }}</div>
-                    <div style="height:3px; background:var(--muted-bg); border-radius:2px; margin-top:3px; min-width:1.5rem;">
-                        <div style="width:{{ pct }}%; height:100%; background:var(--accent); border-radius:2px; {% if val == 0 %}opacity:0;{% endif %}"></div>
+                <td class="cw-cell">
+                    <div class="cw-cell-num">{{ val }}</div>
+                    <div class="cw-hbar">
+                        <div class="cw-hbar-fill" data-pct="{{ pct }}"{% if val == 0 %} data-zero="1"{% endif %}></div>
                     </div>
                 </td>
                 {% endfor %}
@@ -214,15 +214,15 @@
     <div>
 
         <!-- Toggle för passerande rader -->
-        <div style="display:flex; align-items:center; gap:1rem; margin-bottom:.75rem;">
+        <div class="cw-toggle-row">
             <button id="toggle-past" class="btn secondary">{{ t.cowork_show_past }}</button>
-            <span id="past-count" style="color:var(--muted); font-size:.9em;"></span>
+            <span id="past-count" class="cw-toggle-count"></span>
         </div>
 
         <!-- Gemensamma pass -->
         {% if cowork_details %}
-        <div style="overflow-x:auto;">
-        <table class="summary" id="cowork-details-table" style="margin-bottom:.5rem;">
+        <div class="cw-scroll">
+        <table class="summary cw-mb05" id="cowork-details-table">
             <thead><tr>
                 <th>{{ t.cowork_col_date }}</th>
                 <th>{{ t.cowork_col_weekday }}</th>
@@ -241,14 +241,14 @@
             </tbody>
         </table>
         </div>
-        <div id="cowork-details-pag" style="margin-bottom:1.5rem;"></div>
+        <div id="cowork-details-pag" class="cw-mb15"></div>
         {% endif %}
 
         <!-- Överlämningar -->
         {% if handover_details %}
-        <h3 style="margin-bottom:.5rem;">{{ t.cowork_handover_title }}</h3>
-        <div style="overflow-x:auto;">
-        <table class="summary" id="handover-details-table" style="margin-bottom:.5rem;">
+        <h3 class="cw-chart-title">{{ t.cowork_handover_title }}</h3>
+        <div class="cw-scroll">
+        <table class="summary cw-mb05" id="handover-details-table">
             <thead><tr>
                 <th>{{ t.cowork_col_date }}</th>
                 <th>{{ t.cowork_col_weekday }}</th>
@@ -267,7 +267,7 @@
             </tbody>
         </table>
         </div>
-        <div id="handover-details-pag" style="margin-bottom:1.5rem;"></div>
+        <div id="handover-details-pag" class="cw-mb15"></div>
         {% endif %}
 
     </div>
@@ -311,10 +311,67 @@
 @media (max-width: 750px) {
     .cowork-detail-grid { grid-template-columns: 1fr; }
 }
+
+/* Layout + chart helpers (page-specific) */
+.cw-table-scroll { overflow-x: auto; flex: 0 1 auto; }
+.cw-table-fit { width: fit-content; }
+.cw-scroll { overflow-x: auto; }
+.cw-block { margin-bottom: 1.75rem; }
+.cw-mb05 { margin-bottom: .5rem; }
+.cw-mb1 { margin-bottom: 1rem; }
+.cw-mb15 { margin-bottom: 1.5rem; }
+.cw-detail-mt { margin-top: 2rem; }
+.cw-chart-title { margin-bottom: .5rem; }
+
+.cw-stat-row { display: flex; gap: 2rem; flex-wrap: wrap; margin-top: .5rem; }
+.cw-stat-num { font-size: 1.6em; font-weight: 700; color: var(--text); line-height: 1.1; }
+.cw-stat-label { font-size: .8em; color: var(--muted); }
+
+.cw-top-row { display: flex; justify-content: space-between; align-items: baseline; padding: .3rem 0; border-bottom: 1px solid var(--table-border); }
+.cw-top-name { font-size: .9em; }
+.cw-top-count { font-size: .82em; color: var(--muted); white-space: nowrap; margin-left: .5rem; }
+
+.cw-dist-row { display: flex; align-items: center; gap: .5rem; margin-top: .4rem; }
+.cw-dist-label { font-size: .8em; color: var(--muted); width: 1.8rem; flex-shrink: 0; }
+.cw-dist-track { flex: 1; height: 6px; background: var(--muted-bg); border-radius: 3px; min-width: 0; }
+.cw-dist-fill { height: 100%; background: var(--accent); border-radius: 3px; }
+.cw-dist-val { font-size: .8em; color: var(--muted); width: 2.5rem; text-align: right; flex-shrink: 0; }
+
+.cw-next { margin-bottom: 1.5rem; font-size: .9em; color: var(--muted); display: flex; flex-direction: column; gap: .4rem; }
+.cw-next strong { color: var(--text); }
+
+.cw-vbars { display: flex; gap: 1.5rem; align-items: flex-end; margin-bottom: 1.75rem; }
+.cw-vbar { text-align: center; min-width: 2.5rem; }
+.cw-vbar-num { font-size: 1em; font-weight: 600; color: var(--text); }
+.cw-vbar-track { width: 2.5rem; height: 48px; background: var(--muted-bg); border-radius: 4px 4px 0 0; display: flex; align-items: flex-end; margin: 4px auto 0; }
+.cw-vbar-fill { width: 100%; background: var(--accent); border-radius: 4px 4px 0 0; }
+.cw-vbar-label { font-size: .8em; color: var(--muted); margin-top: 4px; }
+
+.cw-cell { text-align: right; padding: 6px 8px; }
+.cw-cell-sm { font-size: .8em; }
+.cw-cell-num { font-size: .9em; line-height: 1.4; }
+.cw-hbar { height: 3px; background: var(--muted-bg); border-radius: 2px; margin-top: 3px; min-width: 1.5rem; }
+.cw-hbar-fill { height: 100%; background: var(--accent); border-radius: 2px; }
+
+.cw-toggle-row { display: flex; align-items: center; gap: 1rem; margin-bottom: .75rem; }
+.cw-toggle-count { color: var(--muted); font-size: .9em; }
+.cw-pag-info { color: var(--muted); font-size: .9em; }
+.cw-pag-info--gap { margin: 0 .75rem; }
+.cw-bar-zero { opacity: 0; }
+.sortable { cursor: pointer; }
 </style>
 
 <script>
 (function () {
+    // Apply data-driven chart dimensions without inline style attributes.
+    document.querySelectorAll('.cw-dist-fill[data-pct], .cw-hbar-fill[data-pct]').forEach(function (el) {
+        el.style.width = el.dataset.pct + '%';
+        if (el.dataset.zero === '1') el.classList.add('cw-bar-zero');
+    });
+    document.querySelectorAll('.cw-vbar-fill[data-h]').forEach(function (el) {
+        el.style.height = el.dataset.h + 'px';
+    });
+
     const today = new Date().toISOString().slice(0, 10);
     const PAGE_SIZE = 10;
     let showPast = false;
@@ -349,7 +406,7 @@
             const msgPageOf = "{{ t.cowork_page_of }}";
             if (totalPages <= 1) {
                 pagEl.innerHTML = total > 0
-                    ? `<span style="color:var(--muted);font-size:.9em">${total} ${msgRecords}</span>`
+                    ? `<span class="cw-pag-info">${total} ${msgRecords}</span>`
                     : '';
                 return;
             }
@@ -357,7 +414,7 @@
             const pageLabel = msgPageOf.replace('{page}', page).replace('{total}', totalPages);
             pagEl.innerHTML = `
                 <button class="btn secondary" id="${pagId}-prev" ${page <= 1 ? 'disabled' : ''}>${msgPrev}</button>
-                <span style="color:var(--muted);font-size:.9em;margin:0 .75rem">${pageLabel} &nbsp;(${from}–${to} av ${total})</span>
+                <span class="cw-pag-info cw-pag-info--gap">${pageLabel} &nbsp;(${from}–${to} av ${total})</span>
                 <button class="btn secondary" id="${pagId}-next" ${page >= totalPages ? 'disabled' : ''}>${msgNext}</button>
             `;
             document.getElementById(pagId + '-prev').addEventListener('click', () => { page--; render(); });
@@ -408,7 +465,6 @@
     let sortAsc = true;
 
     table.querySelectorAll('th.sortable').forEach(th => {
-        th.style.cursor = 'pointer';
         th.addEventListener('click', () => {
             const col = th.dataset.col;
             const type = th.dataset.type;

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -13,10 +13,10 @@
         <div class="dashboard-container">
             <!-- Väntande bytesförfrågningar -->
             {% if pending_swap_count and pending_swap_count > 0 %}
-            <div class="card" style="border-color: var(--warning); grid-column: 1 / -1;">
-                <h3 style="color: var(--warning); margin-bottom: 0.5rem;">{{ t.dashboard_shift_swaps }}</h3>
+            <div class="card dash-alert-card">
+                <h3 class="dash-alert-title">{{ t.dashboard_shift_swaps }}</h3>
                 <p>{% if t.html_lang == 'en' %}You have{% else %}Du har{% endif %} <strong>{{ pending_swap_count }}</strong> {% if t.html_lang == 'en' %}pending swap request{{ 's' if pending_swap_count > 1 }}{% else %}väntande bytesförfrågan{{ 'gar' if pending_swap_count > 1 }}{% endif %}.</p>
-                <a href="/swaps" class="btn" style="margin-top: 0.5rem;">{{ t.dashboard_show_swaps }}</a>
+                <a href="/swaps" class="btn dash-alert-btn">{{ t.dashboard_show_swaps }}</a>
             </div>
             {% endif %}
 
@@ -28,15 +28,15 @@
                 <div class="dash-hero-cell">
                     <span class="dash-hero-eyebrow">{% if next_shift %}{{ t.dashboard_next_shift }}{% else %}{{ t.dashboard_next_oncall }}{% endif %}</span>
                     <div class="dash-hero-row">
-                        <div class="dash-hero-rail" style="background: {{ hero_shift.color }};"></div>
+                        <div class="dash-hero-rail" data-bg="{{ hero_shift.color }}"></div>
                         <div>
                             <div class="dash-hero-when">
-                                {% if hero_shift.days_until == 0 %}<span style="color: var(--success);">{{ t.dashboard_today }}</span>
-                                {% elif hero_shift.days_until == 1 %}<span style="color: var(--success);">{{ t.dashboard_tomorrow }}</span>
+                                {% if hero_shift.days_until == 0 %}<span class="text-success">{{ t.dashboard_today }}</span>
+                                {% elif hero_shift.days_until == 1 %}<span class="text-success">{{ t.dashboard_tomorrow }}</span>
                                 {% else %}{{ _wdn_full[hero_shift.date.weekday()] }} {{ hero_shift.date.day }} {{ _month_names[hero_shift.date.month - 1] }}{% endif %}
                             </div>
                             <div class="dash-hero-sub">{{ t.shift_labels.get(hero_shift.shift_code, hero_shift.shift_type) }} &middot; <span class="dash-hero-mono">{{ hero_shift.time_range }}</span>{% if hero_shift.days_until <= 1 %} &middot; {{ _wdn_short[hero_shift.date.weekday()] }} {{ hero_shift.date.day }} {{ _month_names[hero_shift.date.month - 1] }}{% endif %}</div>
-                            <span class="dash-hero-badge" style="background: {{ hero_shift.color }}; color: {{ hero_shift.color|contrast }};">{{ hero_shift.shift_code }}</span>
+                            <span class="dash-hero-badge" data-bg="{{ hero_shift.color }}" data-fg="{{ hero_shift.color|contrast }}">{{ hero_shift.shift_code }}</span>
                         </div>
                     </div>
                 </div>
@@ -58,7 +58,7 @@
                     <div class="dash-hero-foot">{{ t.dashboard_gross }} {{ "{:,.0f}".format(month_summary.gross_pay) }}kr{% if month_summary.total_hours > 0 %} &middot; {{ "%.1f"|format(month_summary.total_hours) }}h &middot; {{ "{:,.0f}".format(month_summary.gross_pay / month_summary.total_hours) }}kr/h{% endif %}</div>
                     {% else %}
                     <span class="dash-hero-eyebrow">{{ t.dashboard_total_hours }}</span>
-                    <div class="dash-hero-pay" style="color: var(--text);">{{ "%.1f"|format(month_summary.total_hours) }}h</div>
+                    <div class="dash-hero-pay">{{ "%.1f"|format(month_summary.total_hours) }}h</div>
                     <div class="dash-hero-foot">{{ t.dashboard_ob_hours }} {{ "%.1f"|format(month_summary.ob_hours) }}h</div>
                     {% endif %}
                 </div>
@@ -74,16 +74,16 @@
                 {% if next_shift %}
                 <h4>{{ t.dashboard_next_shift }}</h4>
                 <div class="shift-info">
-                    <div class="shift-badge" style="background-color: {{ next_shift.color }}; color: {{ next_shift.color|contrast }};">
+                    <div class="shift-badge" data-bg="{{ next_shift.color }}" data-fg="{{ next_shift.color|contrast }}">
                         {{ t.shift_labels.get(next_shift.shift_code, next_shift.shift_type) }}
                     </div>
                     <div class="shift-details">
                         <strong>{{ _wdn_full[next_shift.date.weekday()] }} {{ next_shift.date.day }} {{ _month_names[next_shift.date.month - 1] }} {{ next_shift.date.year }}</strong>
                         <div>{{ next_shift.time_range }}</div>
                         {% if next_shift.days_until == 0 %}
-                            <div class="shift-countdown" style="color: var(--success);">{{ t.dashboard_today }}</div>
+                            <div class="shift-countdown text-success">{{ t.dashboard_today }}</div>
                         {% elif next_shift.days_until == 1 %}
-                            <div class="shift-countdown" style="color: var(--success);">{{ t.dashboard_tomorrow }}</div>
+                            <div class="shift-countdown text-success">{{ t.dashboard_tomorrow }}</div>
                         {% else %}
                             <div class="shift-countdown">{{ t.dashboard_in_days.replace('{n}', next_shift.days_until|string) }}</div>
                         {% endif %}
@@ -92,18 +92,18 @@
                 {% endif %}
 
                 {% if next_oncall_shift %}
-                <h4 style="margin-top: 1.5rem;">{{ t.dashboard_next_oncall }}</h4>
+                <h4 class="dash-h4">{{ t.dashboard_next_oncall }}</h4>
                 <div class="shift-info">
-                    <div class="shift-badge" style="background-color: {{ next_oncall_shift.color }}; color: {{ next_oncall_shift.color|contrast }};">
+                    <div class="shift-badge" data-bg="{{ next_oncall_shift.color }}" data-fg="{{ next_oncall_shift.color|contrast }}">
                         {{ t.shift_labels.get(next_oncall_shift.shift_code, next_oncall_shift.shift_type) }}
                     </div>
                     <div class="shift-details">
                         <strong>{{ _wdn_full[next_oncall_shift.date.weekday()] }} {{ next_oncall_shift.date.day }} {{ _month_names[next_oncall_shift.date.month - 1] }} {{ next_oncall_shift.date.year }}</strong>
                         <div>{{ next_oncall_shift.time_range }}</div>
                         {% if next_oncall_shift.days_until == 0 %}
-                            <div class="shift-countdown" style="color: var(--success);">{{ t.dashboard_today }}</div>
+                            <div class="shift-countdown text-success">{{ t.dashboard_today }}</div>
                         {% elif next_oncall_shift.days_until == 1 %}
-                            <div class="shift-countdown" style="color: var(--success);">{{ t.dashboard_tomorrow }}</div>
+                            <div class="shift-countdown text-success">{{ t.dashboard_tomorrow }}</div>
                         {% else %}
                             <div class="shift-countdown">{{ t.dashboard_in_days.replace('{n}', next_oncall_shift.days_until|string) }}</div>
                         {% endif %}
@@ -132,7 +132,7 @@
                     {% for day in week_schedule %}
                     <div class="schedule-day {% if day.is_today %}today{% endif %}{% if day.is_past %} past{% endif %}">
                         <div class="schedule-weekday">{{ _wdn_short[day.date.weekday()] }}</div>
-                        <div class="schedule-shift" {% if day.color %}style="background-color: {{ day.color }}; color: {{ day.color|contrast }};"{% endif %}>
+                        <div class="schedule-shift" {% if day.color %}data-bg="{{ day.color }}" data-fg="{{ day.color|contrast }}"{% endif %}>
                             {{ day.code }}
                         </div>
                     </div>
@@ -166,7 +166,7 @@
                     {% if week_summary.absence_deduction and week_summary.absence_deduction > 0 %}
                     <div class="summary-item">
                         <div class="summary-label">{{ t.dashboard_absence_deduction }}</div>
-                        <div class="summary-value" style="color: var(--danger);">-{{ "{:,.0f}".format(week_summary.absence_deduction) }}kr</div>
+                        <div class="summary-value summary-value--neg">-{{ "{:,.0f}".format(week_summary.absence_deduction) }}kr</div>
                     </div>
                     {% endif %}
                     {% endif %}
@@ -215,7 +215,7 @@
                     {% if month_summary.absence_deduction and month_summary.absence_deduction > 0 %}
                     <div class="summary-item">
                         <div class="summary-label">{{ t.dashboard_absence_deduction }}</div>
-                        <div class="summary-value" style="color: var(--danger);">-{{ "{:,.0f}".format(month_summary.absence_deduction) }}kr</div>
+                        <div class="summary-value summary-value--neg">-{{ "{:,.0f}".format(month_summary.absence_deduction) }}kr</div>
                     </div>
                     {% endif %}
                     {% if month_summary.total_hours > 0 %}
@@ -224,16 +224,16 @@
                         {% if not has_ot and not has_absence %}
                         <div class="summary-item">
                             <div class="summary-label">{{ t.dashboard_wage_per_hour }}</div>
-                            <div class="summary-value" style="color: var(--success); font-weight: bold;">{{ "{:,.0f}".format(month_summary.gross_pay / month_summary.total_hours) }}kr</div>
+                            <div class="summary-value summary-value--pos">{{ "{:,.0f}".format(month_summary.gross_pay / month_summary.total_hours) }}kr</div>
                         </div>
                         <div class="summary-item">
                             <div class="summary-label">{{ t.dashboard_wage_per_day }}</div>
-                            <div class="summary-value" style="color: var(--success); font-weight: bold;">{{ "{:,.0f}".format(month_summary.gross_pay / (month_summary.total_hours / 8.5)) }}kr</div>
+                            <div class="summary-value summary-value--pos">{{ "{:,.0f}".format(month_summary.gross_pay / (month_summary.total_hours / 8.5)) }}kr</div>
                         </div>
                         {% elif not (has_ot and has_absence) %}
                         <div class="summary-item">
                             <div class="summary-label">{{ t.dashboard_wage_per_hour }}</div>
-                            <div class="summary-value" style="color: var(--success); font-weight: bold;">{{ "{:,.0f}".format(month_summary.gross_pay / month_summary.total_hours) }}kr</div>
+                            <div class="summary-value summary-value--pos">{{ "{:,.0f}".format(month_summary.gross_pay / month_summary.total_hours) }}kr</div>
                         </div>
                         {% endif %}
                     {% endif %}
@@ -243,7 +243,7 @@
                     </div>
                     <div class="summary-item">
                         <div class="summary-label">{{ t.dashboard_net }}</div>
-                        <div class="summary-value" style="color: var(--success); font-weight: bold;">{{ "{:,.0f}".format(month_summary.net_pay) }}kr</div>
+                        <div class="summary-value summary-value--pos">{{ "{:,.0f}".format(month_summary.net_pay) }}kr</div>
                         {% if month_summary.trend %}
                         <div class="summary-subtrend">
                             {% if month_summary.trend.direction == 'up' %}
@@ -273,4 +273,13 @@
 
         </div>
     </section>
+<style>
+.dash-alert-card { border-color: var(--warning); grid-column: 1 / -1; }
+.dash-alert-title { color: var(--warning); margin-bottom: 0.5rem; }
+.dash-alert-btn { margin-top: 0.5rem; }
+.dash-h4 { margin-top: 1.5rem; }
+.summary-value--pos { color: var(--success); font-weight: bold; }
+.summary-value--neg { color: var(--danger); }
+</style>
+
 {% endblock %}

--- a/app/templates/day.html
+++ b/app/templates/day.html
@@ -50,7 +50,7 @@
     </div>
 
     {% if is_vacation_day %}
-    <div style="background:rgba(199,199,0,0.12);border-left:4px solid var(--sem);border-radius:6px;padding:0.6rem 1rem;margin-bottom:1rem;color:var(--sem);font-weight:500;">
+    <div class="day-sem-notice">
         {{ t.day_sem_notice }}
     </div>
     {% endif %}
@@ -70,17 +70,15 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <tr class="shift-row"
-                        style="border-left:6px solid {% if shift %}{{ shift.color }}{% else %}transparent{% endif %};">
+                    <tr class="shift-row day-shift-row"{% if shift %} data-shift-color="{{ shift.color }}"{% endif %}>
                         <td>{% if rotation_week and rotation_length %}{{ rotation_week }}/{{ rotation_length }}{% else %}-{% endif %}</td>
                         <td>
                             {% if is_vacation_day %}
-                                <span style="white-space:nowrap;">
-                                    <span class="badge" style="background:var(--sem);color:#000;">SEM</span>{% if shift %}&nbsp;<span class="badge" style="background:{{ shift.color }};color:{{ shift.color | contrast }};">{{ shift.code }}</span>{% endif %}
+                                <span class="day-nowrap">
+                                    <span class="badge badge-vacation">SEM</span>{% if shift %}&nbsp;<span class="badge" data-shift-color="{{ shift.color }}" data-shift-contrast="{{ shift.color | contrast }}">{{ shift.code }}</span>{% endif %}
                                 </span>
                             {% elif shift %}
-                                <span class="badge"
-                                      style="background: {{ shift.color }}; color: {{ shift.color | contrast }};">
+                                <span class="badge" data-shift-color="{{ shift.color }}" data-shift-contrast="{{ shift.color | contrast }}">
                                     {{ shift.code }}
                                 </span>
                             {% else %}
@@ -116,10 +114,10 @@
             </table>
 
             {% set has_active = ot_shift or absence or oncall_override or shift_override %}
-            <button id="day-edit-btn" class="btn secondary" style="margin-top:1rem;"
+            <button id="day-edit-btn" class="btn secondary day-edit-toggle-btn"
                     onclick="toggleDayEdit()">{{ t.day_edit_toggle }} ▾</button>
 
-            <div id="day-edit-panel" style="display:{% if has_active %}block{% else %}none{% endif %};">
+            <div id="day-edit-panel"{% if not has_active %} hidden{% endif %}>
 
             <h3>{{ t.day_overtime }}</h3>
 
@@ -141,14 +139,14 @@
                             </thead>
                             <tbody>
                                 <tr>
-                                    <td><span class="badge" style="background:var(--warning);color:#000;">{{ t.day_extension_type }}</span></td>
+                                    <td><span class="badge badge-warning">{{ t.day_extension_type }}</span></td>
                                     <td>{{ ot_shift.start_time }}</td>
                                     <td>{{ ot_shift.end_time }}</td>
                                     <td>{{ "%.2f"|format(ot_shift.hours) }} h</td>
                                     <td>{{ "%.2f"|format(ot_shift.hourly_rate) }} kr/h</td>
                                     <td>{{ "%.2f"|format(ot_shift.pay) }} kr</td>
                                     <td>
-                                        <form method="POST" action="/overtime/{{ ot_shift_id }}/delete" style="display: inline;">
+                                        <form method="POST" action="/overtime/{{ ot_shift_id }}/delete" class="inline-form">
                                             <button type="submit" class="btn btn-danger" onclick="return confirm('{{ t.day_delete_extension_confirm }}')">{{ t.day_delete }}</button>
                                         </form>
                                     </td>
@@ -178,7 +176,7 @@
                                     <td>{{ "%.2f"|format(ot_shift.hourly_rate) }} kr/h</td>
                                     <td>{{ "%.2f"|format(ot_shift.pay) }} kr</td>
                                     <td>
-                                        <form method="POST" action="/overtime/{{ ot_shift_id }}/delete" style="display: inline;">
+                                        <form method="POST" action="/overtime/{{ ot_shift_id }}/delete" class="inline-form">
                                             <button type="submit" class="btn btn-danger" onclick="return confirm('{{ t.day_delete_ot_confirm }}')">{{ t.day_delete }}</button>
                                         </form>
                                     </td>
@@ -196,7 +194,7 @@
             {% else %}
                 {# Förlängningsformulär för ordinarie arbetspass #}
                 {% if shift and shift.code in ('N1', 'N2', 'N3') %}
-                    <p class="info-text" style="margin-bottom:0.5rem;">{{ t.day_ext_stayed.replace('{time}', shift.end_time) }}</p>
+                    <p class="info-text day-hint-tight">{{ t.day_ext_stayed.replace('{time}', shift.end_time) }}</p>
                     <form method="POST" action="/overtime/add" class="ot-form" id="ext-form">
                         <input type="hidden" name="user_id" value="{{ person_id }}">
                         <input type="hidden" name="date" value="{{ date }}">
@@ -205,7 +203,7 @@
                         <div class="form-row">
                             <div class="form-group">
                                 <label for="ext_start_time">{{ t.day_ext_normal_end }}</label>
-                                <input type="time" id="ext_start_time" name="start_time" value="{{ shift.end_time }}" readonly style="opacity:0.6;">
+                                <input type="time" id="ext_start_time" name="start_time" value="{{ shift.end_time }}" readonly class="input-readonly">
                             </div>
                             <div class="form-group">
                                 <label for="ext_end_time">{{ t.day_ext_actual_end }}</label>
@@ -242,13 +240,13 @@
                 {% endif %}
 
                 {# Fullt övertidspass (inkallning) #}
-                <form method="POST" action="/overtime/add" class="ot-form" style="margin-top: {% if shift and shift.code in ('N1', 'N2', 'N3') %}1.5rem{% else %}0{% endif %};">
+                <form method="POST" action="/overtime/add" class="ot-form{% if shift and shift.code in ('N1', 'N2', 'N3') %} ot-form-spaced{% endif %}">
                     <input type="hidden" name="user_id" value="{{ person_id }}">
                     <input type="hidden" name="date" value="{{ date }}">
 
                     <details>
-                        <summary style="cursor:pointer; color: var(--text-muted); font-size:0.9rem;">{{ t.day_add_called_ot }}</summary>
-                        <div class="form-row" style="margin-top:0.75rem;">
+                        <summary class="day-summary-toggle">{{ t.day_add_called_ot }}</summary>
+                        <div class="form-row form-row--mt">
                             <div class="form-group">
                                 <label for="start_time">{{ t.day_start_time }}</label>
                                 <input type="time" id="start_time" name="start_time" value="14:00" required>
@@ -304,32 +302,32 @@
                                         {{ absence.absence_type.value }}
                                     {% endif %}
                                     {% if absence.arrived_at is not none %}
-                                        <span style="color: var(--text-muted); font-size: 0.9em;">(kom {{ absence.arrived_at }})</span>
+                                        <span class="day-inline-note">(kom {{ absence.arrived_at }})</span>
                                     {% endif %}
                                     {% if absence.left_at is not none %}
-                                        <span style="color: var(--text-muted); font-size: 0.9em;">(slutade {{ absence.left_at }})</span>
+                                        <span class="day-inline-note">(slutade {{ absence.left_at }})</span>
                                     {% endif %}
                                 </td>
                                 <td>
                                     {% if absence.absence_type.value == 'SICK' %}
-                                        <span class="badge" style="background: var(--danger); color: white;">{{ t.day_absence_sick }}</span>
+                                        <span class="badge badge-sick">{{ t.day_absence_sick }}</span>
                                     {% elif absence.absence_type.value == 'VAB' %}
-                                        <span class="badge" style="background: var(--ob-sick); color: white;">VAB</span>
+                                        <span class="badge badge-vab">VAB</span>
                                     {% elif absence.absence_type.value == 'LEAVE' %}
-                                        <span class="badge" style="background: var(--ob5); color: white;">{{ t.day_absence_leave }}</span>
+                                        <span class="badge badge-leave">{{ t.day_absence_leave }}</span>
                                     {% elif absence.absence_type.value == 'OFF' %}
-                                        <span class="badge" style="background: #888888; color: white;">{{ t.day_absence_off }}</span>
+                                        <span class="badge badge-off-gray">{{ t.day_absence_off }}</span>
                                     {% elif absence.absence_type.value == 'VACATION' %}
-                                        <span class="badge" style="background: var(--sem); color: #000;">{{ t.day_absence_vacation }}</span>
+                                        <span class="badge badge-vacation">{{ t.day_absence_vacation }}</span>
                                     {% elif absence.absence_type.value == 'PARENTAL' %}
-                                        <span class="badge" style="background: var(--blue); color: white;">{{ t.day_absence_parental }}</span>
+                                        <span class="badge badge-parental">{{ t.day_absence_parental }}</span>
                                     {% endif %}
                                     {% if absence.left_at is not none or absence.arrived_at is not none %}
-                                        <span class="badge" style="background: #0ea5e9; color: white;">Deldag</span>
+                                        <span class="badge badge-partial">Deldag</span>
                                     {% endif %}
                                 </td>
                                 <td>
-                                    <form method="POST" action="/absence/{{ absence.id }}/delete" style="display: inline;">
+                                    <form method="POST" action="/absence/{{ absence.id }}/delete" class="inline-form">
                                         <button type="submit" class="btn btn-danger" onclick="return confirm('{{ t.day_delete_absence_confirm }}')">{{ t.day_delete }}</button>
                                     </form>
                                 </td>
@@ -377,10 +375,10 @@
                                 <td>
                                     {% if absence.absence_type.value == 'SICK' %}
                                         {% if karens_hours_today > 0 and sjuklon_hours_today > 0 %}
-                                            <span class="badge" style="background: var(--danger-hover); color: white;">{{ t.day_karens }}</span>
+                                            <span class="badge badge-karens">{{ t.day_karens }}</span>
                                             + {{ t.day_sick_deduction }}
                                         {% elif karens_hours_today > 0 %}
-                                            <span class="badge" style="background: var(--danger-hover); color: white;">{{ t.day_karens }}</span>
+                                            <span class="badge badge-karens">{{ t.day_karens }}</span>
                                         {% else %}
                                             {{ t.day_sick_deduction }}
                                         {% endif %}
@@ -396,12 +394,12 @@
                     {% endif %}
 
                     {% if show_salary and sick_ob_pay_today > 0 %}
-                    <table style="margin-top: 8px;">
+                    <table class="day-table-mt">
                         <tbody>
                             <tr>
                                 <td>{{ "%.1f"|format(sjuklon_hours_today) }} h</td>
-                                <td style="padding-left: 16px;">+{{ "%.2f"|format(sick_ob_pay_today) }} kr</td>
-                                <td style="padding-left: 16px; color: var(--muted); font-size: 0.85rem;">{{ t.day_sick_ob_pay }}</td>
+                                <td class="day-td-indent">+{{ "%.2f"|format(sick_ob_pay_today) }} kr</td>
+                                <td class="day-td-note">{{ t.day_sick_ob_pay }}</td>
                             </tr>
                         </tbody>
                     </table>
@@ -474,14 +472,14 @@
                             <tr>
                                 <td>
                                     {% if oncall_override.override_type.value == 'ADD' %}
-                                        <span class="badge" style="background: #22c55e; color: white;">{{ t.day_oncall_added }}</span>
+                                        <span class="badge badge-added">{{ t.day_oncall_added }}</span>
                                     {% else %}
-                                        <span class="badge" style="background: var(--danger); color: white;">{{ t.day_oncall_removed }}</span>
+                                        <span class="badge badge-danger">{{ t.day_oncall_removed }}</span>
                                     {% endif %}
                                 </td>
                                 <td>{{ oncall_override.reason or '-' }}</td>
                                 <td>
-                                    <form method="POST" action="/oncall/{{ oncall_override.id }}/delete" style="display: inline;">
+                                    <form method="POST" action="/oncall/{{ oncall_override.id }}/delete" class="inline-form">
                                         <button type="submit" class="btn btn-danger" onclick="return confirm('{{ t.day_oncall_undo_confirm }}')">{{ t.day_oncall_undo }}</button>
                                     </form>
                                 </td>
@@ -560,7 +558,7 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        <span class="badge" style="background: var(--blue); color: white;">{{ shift_override.shift_code }}</span>
+                                        <span class="badge badge-blue">{{ shift_override.shift_code }}</span>
                                     </td>
                                 </tr>
                             </tbody>
@@ -589,7 +587,7 @@
                 </form>
 
                 {% if shift_override %}
-                    <form method="POST" action="/shift-override/{{ shift_override.id }}/delete" style="margin-top: 0.75rem;">
+                    <form method="POST" action="/shift-override/{{ shift_override.id }}/delete" class="form-row--mt">
                         <button type="submit" class="btn btn-danger" onclick="return confirm('{{ t.day_shift_override_revert_confirm }}')">{{ t.day_shift_override_revert }}</button>
                     </form>
                 {% endif %}
@@ -622,7 +620,7 @@
 
         {% if swap_users and user and user.id == person_id %}
         {% set is_one_way = not shift or shift.code == 'OFF' %}
-        <h3 style="margin-top: 1.5rem;">{% if is_one_way %}{{ t.day_take_shift }}{% else %}{{ t.day_propose_swap }}{% endif %}</h3>
+        <h3 class="day-h-mt">{% if is_one_way %}{{ t.day_take_shift }}{% else %}{{ t.day_propose_swap }}{% endif %}</h3>
         <form method="POST" action="/swaps/propose" class="ot-form" id="swap-form">
             <input type="hidden" name="requester_date" value="{{ date }}">
             <div class="form-row">
@@ -706,7 +704,7 @@
         </section>
 
         {% if show_salary %}
-            <section class="day-section">
+            <section class="day-section" id="pay-section">
             {% if is_effective_oc %}
             {# On-call compensation section - for effective OC shifts (including ADD overrides) #}
                 <h3>{{ t.day_oncall_pay_title }}</h3>
@@ -725,14 +723,13 @@
                             {% for oc_type in all_oncall_types %}
                                 {% set h = oc_breakdown[oc_type.code].hours if oc_type.code in oc_breakdown else 0.0 %}
                                 {% set p = oc_breakdown[oc_type.code].pay if oc_type.code in oc_breakdown else 0.0 %}
-                                <tr{% if h == 0 %} class="pay-zero-row" style="display:none"{% endif %}>
+                                <tr{% if h == 0 %} class="pay-zero-row"{% endif %}>
                                     <td class="td_left">{{ oc_type.label }}</td>
                                     <td class="td_right num">
                                         <span class="pay-view">{{ "%.2f"|format(h) }}</span>
-                                        <input class="pay-edit" form="pay-override-form"
+                                        <input class="pay-edit pay-edit-num" form="pay-override-form"
                                                name="oc_hours_{{ oc_type.code }}" type="number"
-                                               step="0.01" min="0" value="{{ "%.2f"|format(h) }}"
-                                               style="display:none; width:5rem; text-align:right;">
+                                               step="0.01" min="0" value="{{ "%.2f"|format(h) }}">
                                     </td>
                                     <td class="td_right num pay-view">{{ "%.2f"|format(p) }} kr</td>
                                 </tr>
@@ -771,14 +768,13 @@
                         <tbody>
                             {% for code in ob_codes %}
                                 {% set h = ob_hours.get(code, 0.0) %}
-                                <tr{% if h == 0 %} class="pay-zero-row" style="display:none"{% endif %}>
+                                <tr{% if h == 0 %} class="pay-zero-row"{% endif %}>
                                     <td class="num">{{ ob_labels.get(code, code) }}</td>
                                     <td class="td_right num">
                                         <span class="pay-view">{{ "%.2f"|format(h) }}</span>
-                                        <input class="pay-edit" form="pay-override-form"
+                                        <input class="pay-edit pay-edit-num" form="pay-override-form"
                                                name="ob_hours_{{ code }}" type="number"
-                                               step="0.01" min="0" value="{{ "%.2f"|format(h) }}"
-                                               style="display:none; width:5rem; text-align:right;">
+                                               step="0.01" min="0" value="{{ "%.2f"|format(h) }}">
                                     </td>
                                 </tr>
                             {% endfor %}
@@ -865,23 +861,22 @@
                     <input type="hidden" name="date" value="{{ date }}">
                 </form>
 
-                <div style="display:flex; align-items:center; gap:0.5rem; flex-wrap:wrap; margin-top:0.75rem;">
+                <div class="pay-actions">
                     {% if day_pay_override %}
-                        <span class="badge pay-view" style="background:var(--warning); color:white;">{{ t.day_pay_override_active_ob if not is_effective_oc else t.day_pay_override_active_oncall }}</span>
+                        <span class="badge badge-warning pay-view">{{ t.day_pay_override_active_ob if not is_effective_oc else t.day_pay_override_active_oncall }}</span>
                         {% if day_pay_override.reason %}
-                            <span class="pay-view" style="color:var(--text-muted); font-size:0.875rem;">{{ day_pay_override.reason }}</span>
+                            <span class="pay-view day-note-sm">{{ day_pay_override.reason }}</span>
                         {% endif %}
-                        <form method="POST" action="/day-pay-override/{{ day_pay_override.id }}/delete" style="display:inline;" class="pay-view">
+                        <form method="POST" action="/day-pay-override/{{ day_pay_override.id }}/delete" class="pay-view inline-form">
                             <button type="submit" class="btn btn-danger" onclick="return confirm('{{ t.day_pay_override_remove_confirm }}')">{{ t.day_pay_override_remove }}</button>
                         </form>
                     {% endif %}
                     <button type="button" class="btn btn-secondary pay-view" onclick="togglePayOverrideEdit()">{{ t.day_pay_override_edit }}</button>
-                    <input type="text" class="pay-edit" form="pay-override-form" name="reason"
+                    <input type="text" class="pay-edit pay-edit-reason" form="pay-override-form" name="reason"
                            placeholder="{{ t.day_pay_override_reason_label }}"
-                           value="{{ day_pay_override.reason or '' }}"
-                           style="display:none; max-width:14rem;">
-                    <button type="submit" form="pay-override-form" class="btn btn-primary pay-edit" style="display:none;">{{ t.day_pay_override_save }}</button>
-                    <button type="button" class="btn btn-secondary pay-edit" onclick="togglePayOverrideEdit()" style="display:none;">{{ t.day_oncall_undo }}</button>
+                           value="{{ day_pay_override.reason or '' }}">
+                    <button type="submit" form="pay-override-form" class="btn btn-primary pay-edit">{{ t.day_pay_override_save }}</button>
+                    <button type="button" class="btn btn-secondary pay-edit" onclick="togglePayOverrideEdit()">{{ t.day_oncall_undo }}</button>
                 </div>
             {% endif %}
         </section>
@@ -890,27 +885,57 @@
 
     </div>
 
+<style>
+.day-sem-notice { background: rgba(199,199,0,0.12); border-left: 4px solid var(--sem); border-radius: 6px; padding: 0.6rem 1rem; margin-bottom: 1rem; color: var(--sem); font-weight: 500; }
+.day-shift-row { border-left: 6px solid transparent; }
+.day-nowrap { white-space: nowrap; }
+.day-edit-toggle-btn { margin-top: 1rem; }
+.day-hint-tight { margin-bottom: 0.5rem; }
+.input-readonly { opacity: 0.6; }
+.ot-form-spaced { margin-top: 1.5rem; }
+.day-summary-toggle { cursor: pointer; color: var(--muted); font-size: 0.9rem; }
+.form-row--mt { margin-top: 0.75rem; }
+.day-inline-note { color: var(--muted); font-size: 0.9em; }
+.day-table-mt { margin-top: 0.5rem; }
+.day-td-indent { padding-left: 1rem; }
+.day-td-note { padding-left: 1rem; color: var(--muted); font-size: 0.85rem; }
+.day-h-mt { margin-top: 1.5rem; }
+.pay-actions { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; margin-top: 0.75rem; }
+.pay-edit-num { width: 5rem; text-align: right; }
+.pay-edit-reason { max-width: 14rem; }
+.day-note-sm { color: var(--muted); font-size: 0.875rem; }
+
+/* Pay override edit toggle: CSP-safe class switch instead of inline display. */
+.pay-edit { display: none; }
+#pay-section.is-editing .pay-view { display: none; }
+#pay-section.is-editing .pay-edit { display: revert; }
+tr.pay-zero-row { display: none; }
+#pay-section.is-editing tr.pay-zero-row { display: table-row; }
+</style>
+
 <script>
+// Apply data-driven shift colours without inline style attributes (colours are
+// admin-configured in the DB, so they cannot live in static CSS).
+document.querySelectorAll('[data-shift-color]').forEach(function (el) {
+    var color = el.getAttribute('data-shift-color');
+    if (!color) return;
+    if (el.classList.contains('day-shift-row')) {
+        el.style.borderLeftColor = color;
+    } else {
+        el.style.backgroundColor = color;
+        el.style.color = el.getAttribute('data-shift-contrast') || 'var(--bg)';
+    }
+});
+
 function toggleDayEdit() {
     var panel = document.getElementById('day-edit-panel');
     var btn = document.getElementById('day-edit-btn');
-    var open = panel.style.display !== 'none';
-    panel.style.display = open ? 'none' : 'block';
-    btn.textContent = open ? '{{ t.day_edit_toggle }} ▾' : '{{ t.day_edit_close }} ▲';
+    panel.hidden = !panel.hidden;
+    btn.textContent = panel.hidden ? '{{ t.day_edit_toggle }} ▾' : '{{ t.day_edit_close }} ▲';
 }
 
 function togglePayOverrideEdit() {
-    var firstEdit = document.querySelector('.pay-edit');
-    var editing = firstEdit && getComputedStyle(firstEdit).display !== 'none';
-    document.querySelectorAll('.pay-view').forEach(function(el) {
-        el.style.display = editing ? '' : 'none';
-    });
-    document.querySelectorAll('.pay-edit').forEach(function(el) {
-        el.style.display = editing ? 'none' : '';
-    });
-    document.querySelectorAll('tr.pay-zero-row').forEach(function(el) {
-        el.style.display = editing ? 'none' : 'table-row';
-    });
+    document.getElementById('pay-section').classList.toggle('is-editing');
 }
 </script>
 

--- a/app/templates/handover.html
+++ b/app/templates/handover.html
@@ -33,7 +33,7 @@
            class="date-picker-input"
            value="{{ date }}"
            onchange="window.location.href='/handover?date=' + this.value">
-    <button onclick="selectReport()" class="btn btn-primary" style="margin-left: auto;">
+    <button onclick="selectReport()" class="btn btn-primary ml-auto">
         {{ t.handover_copy }}
     </button>
 </div>
@@ -41,29 +41,29 @@
 <h2 class="page-title">{{ t.handover_title }} – {{ weekday_name }} {{ date }}</h2>
 
 {# Allt i #handover-content använder inline-stilar så att OneNote bevarar dem vid inklistring #}
-<div id="handover-content" style="max-width: 780px;">
+<div id="handover-content" class="ho-content">
 
 {% for group in shift_groups %}
-<p style="margin: 16px 0 10px 0;">_______________________________________________________________________________________________________________</p>
-<table style="border-collapse: collapse; width: 100%; margin-bottom: 8px;">
+<p class="ho-p3">_______________________________________________________________________________________________________________</p>
+<table class="ho-table">
     <tr>
-        <td style="border: 1px solid black; padding: 5px 10px; white-space: nowrap;"><b>{{ group.label }}:</b></td>
+        <td class="ho-cell ho-nowrap"><b>{{ group.label }}:</b></td>
         {% for name in group.persons %}
-        <td style="border: 1px solid black; padding: 5px 10px;">{{ name }}</td>
+        <td class="ho-cell">{{ name }}</td>
         {% endfor %}
         {% if not group.persons %}
-        <td style="border: 1px solid black; padding: 5px 10px;">&nbsp;</td>
+        <td class="ho-cell">&nbsp;</td>
         {% endif %}
     </tr>
 </table>
 
 {% if group.code != 'OC' %}
-<p style="margin: 8px 0 4px 0;"><b><u>{{ t.handover_important }}</u></b></p>
-<p style="margin: 4px 0;">&nbsp;</p>
-<p style="margin: 4px 0;">&nbsp;</p>
-<p style="margin: 8px 0 4px 0;"><b><u>{{ t.handover_other }}</u></b></p>
-<p style="margin: 4px 0;">&nbsp;</p>
-<p style="margin: 4px 0;">&nbsp;</p>
+<p class="ho-p2"><b><u>{{ t.handover_important }}</u></b></p>
+<p class="ho-p">&nbsp;</p>
+<p class="ho-p">&nbsp;</p>
+<p class="ho-p2"><b><u>{{ t.handover_other }}</u></b></p>
+<p class="ho-p">&nbsp;</p>
+<p class="ho-p">&nbsp;</p>
 {% endif %}
 {% endfor %}
 
@@ -79,5 +79,16 @@ function selectReport() {
     sel.addRange(range);
 }
 </script>
+
+
+<style>
+.ho-content { max-width: 780px; }
+.ho-p { margin: 4px 0; }
+.ho-p2 { margin: 8px 0 4px; }
+.ho-p3 { margin: 16px 0 10px; }
+.ho-table { border-collapse: collapse; width: 100%; margin-bottom: 8px; }
+.ho-cell { border: 1px solid black; padding: 5px 10px; }
+.ho-nowrap { white-space: nowrap; }
+</style>
 
 {% endblock %}

--- a/app/templates/month.html
+++ b/app/templates/month.html
@@ -99,29 +99,29 @@
     {% set sick_total_ob = days.sick_total_ob or 0 %}
     {% set sick_ob_lost = days.sick_ob_lost or 0 %}
     {% set sick_total_loss = (days.absence_deduction or 0) + sick_ob_lost %}
-    <div style="background: rgba(239,68,68,0.07); border: 1px solid rgba(239,68,68,0.35); padding: 10px 16px; border-radius: var(--radius); margin-bottom: 12px; font-size: 0.9rem;">
+    <div class="alert alert--danger">
         <strong>{{ t.month_sick_label }}:</strong>
         {{ days.sick_days }} {{ t.month_sick_days_unit }}, {{ "%.1f"|format(days.sick_hours or 0) }} h
         &nbsp;&mdash;&nbsp;
-        <span style="color: var(--danger);">{{ t.month_sick_deduction_label }}: -{{ "%.0f"|format(days.absence_deduction or 0) }} kr</span>
+        <span class="text-danger">{{ t.month_sick_deduction_label }}: -{{ "%.0f"|format(days.absence_deduction or 0) }} kr</span>
         {% if sick_total_ob > 0 %}
         &nbsp;|&nbsp;
-        <span style="color: var(--ob-sick);" title="Total OB på sjukdagarna, ingår ej i brutto">{{ t.month_sick_ob_lost_label }}: -{{ "%.0f"|format(sick_total_ob) }} kr</span>
+        <span class="text-ob-sick" title="Total OB på sjukdagarna, ingår ej i brutto">{{ t.month_sick_ob_lost_label }}: -{{ "%.0f"|format(sick_total_ob) }} kr</span>
         {% endif %}
         {% if days.sick_ob_pay and days.sick_ob_pay > 0 %}
         &nbsp;|&nbsp;
-        <span style="color: var(--success);">{{ t.month_sick_ob_label }}: +{{ "%.0f"|format(days.sick_ob_pay) }} kr</span>
+        <span class="text-success">{{ t.month_sick_ob_label }}: +{{ "%.0f"|format(days.sick_ob_pay) }} kr</span>
         {% endif %}
         &nbsp;|&nbsp;
-        <span style="color: var(--muted);">{{ t.month_sick_net_label }}: -{{ "%.0f"|format(sick_total_loss) }} kr</span>
+        <span class="text-muted">{{ t.month_sick_net_label }}: -{{ "%.0f"|format(sick_total_loss) }} kr</span>
     </div>
     {% endif %}
 
     {% if vacation_month %}
-    <div style="background: rgba(100,200,255,0.08); border: 1px solid var(--accent); padding: 10px 16px; border-radius: var(--radius); margin-bottom: 16px; font-size: 0.9rem;">
+    <div class="alert alert--info">
         <strong>{{ t.month_vacation_days.replace('{n}', vacation_month.days|string).replace('{suffix}', 'ar' if vacation_month.days != 1 else '') }}</strong>
-        &rarr; {{ t.month_vacation_supplement }} <strong style="color: var(--accent-2);">{{ "{:,.0f}".format(vacation_month.supplement_month).replace(",", " ") }} kr</strong>
-        <span style="color: var(--muted);">({{ "%.0f"|format(vacation_month.supplement_per_day) }} kr/dag)</span>
+        &rarr; {{ t.month_vacation_supplement }} <strong class="text-accent2">{{ "{:,.0f}".format(vacation_month.supplement_month).replace(",", " ") }} kr</strong>
+        <span class="text-muted">({{ "%.0f"|format(vacation_month.supplement_per_day) }} kr/dag)</span>
     </div>
     {% endif %}
     {% endif %}{# /before_employment_month #}
@@ -145,7 +145,7 @@
                         {% set is_current = day_data.is_current_month %}
 
                         <td class="calendar-day {% if not is_current %}adjacent-month{% endif %} {% if is_today %}today-cell{% endif %}"
-                            style="border-top: 4px solid {% if day_data.shift %}{{ day_data.shift.color }}{% else %}#333{% endif %};">
+                            data-border-top="{% if day_data.shift %}{{ day_data.shift.color }}{% else %}#333{% endif %}">
 
                             <div class="calendar-day-content">
                                 <div class="calendar-day-header">
@@ -154,9 +154,9 @@
                                         {{ day_data.date.day }}
                                     </a>
                                     {% if storhelg_dates is defined and day_data.date in storhelg_dates %}
-                                        <span class="badge badge-ob5" style="font-size:0.6rem;padding:1px 4px;">S</span>
+                                        <span class="badge badge-ob5 badge-calendar-marker">S</span>
                                     {% elif holiday_dates is defined and day_data.date in holiday_dates %}
-                                        <span class="badge badge-ob4" style="font-size:0.6rem;padding:1px 4px;">H</span>
+                                        <span class="badge badge-ob4 badge-calendar-marker">H</span>
                                     {% endif %}
                                     {% if day_data.date.weekday() == 0 %}
                                         <a href="/week/{{ person_id }}?year={{ day_data.date.isocalendar()[0] }}&week={{ day_data.date.isocalendar()[1] }}" class="rotation-week-small">v{{ day_data.date.isocalendar()[1] }}</a>
@@ -172,14 +172,14 @@
                                 <div class="calendar-day-body">
                                     {% if day_data.shift %}
                                         <span class="badge calendar-badge"
-                                              style="background: {{ day_data.shift.color }}; color: {{ day_data.shift.color | contrast }};">
+                                              data-bg="{{ day_data.shift.color }}" data-fg="{{ day_data.shift.color | contrast }}">
                                             {{ day_data.shift.code }}
                                         </span>
                                     {% else %}
                                         <span class="badge badge-off calendar-badge">OFF</span>
                                     {% endif %}
                                     {% if day_data.partial_absence %}
-                                        <span class="badge" style="background:var(--danger);color:white;font-size:0.6rem;padding:1px 4px;" title="Sjuk deldag (slutade {{ day_data.partial_absence.left_at }})">SJ</span>
+                                        <span class="badge badge-danger badge-calendar-marker" title="Sjuk deldag (slutade {{ day_data.partial_absence.left_at }})">SJ</span>
                                     {% endif %}
 
                                     {% if day_data.shift and day_data.shift.code != 'OC' %}
@@ -206,7 +206,7 @@
 
     {# ── Detailed OB / Beredskap / OT breakdown ── #}
     {% if show_salary %}
-    <div style="margin-top: 1.5rem; text-align: center; display: flex; gap: 0.5rem; justify-content: center; flex-wrap: wrap;">
+    <div class="month-actions">
         <button class="btn secondary" id="breakdown-toggle" onclick="toggleBreakdown()">
             {{ t.month_show_breakdown }}
         </button>
@@ -219,16 +219,16 @@
         {% endif %}
     </div>
 
-    <div id="breakdown-section" style="display: none; margin-top: 1rem;" class="ob-by-shift">
-        <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.75rem; flex-wrap: wrap; gap: 0.5rem;">
-            <h3 style="margin: 0;">{{ t.month_breakdown_title }}</h3>
-            <button class="btn secondary" id="ob-day-toggle" onclick="toggleObDayMode()" style="font-size: 0.85rem;"
+    <div id="breakdown-section" class="ob-by-shift" hidden>
+        <div class="flex-between">
+            <h3 class="title-inline">{{ t.month_breakdown_title }}</h3>
+            <button class="btn secondary btn-sm" id="ob-day-toggle" onclick="toggleObDayMode()"
                 data-label-shift="{{ t.month_ob_per_shift }}"
                 data-label-calendar="{{ t.month_ob_per_calendar_day }}">
                 {{ t.month_ob_per_calendar_day }}
             </button>
         </div>
-        <div style="overflow-x: auto;">
+        <div class="scroll-x">
             <table class="breakdown-table">
                 <thead>
                     <tr>
@@ -424,7 +424,7 @@
 
                     {% if not ns.has_rows %}
                         <tr>
-                            <td colspan="16" style="text-align: center; color: var(--muted); padding: 1rem;">
+                            <td colspan="16" class="table-empty">
                                 {{ t.month_no_ob }}
                             </td>
                         </tr>
@@ -457,9 +457,9 @@
     </div>
 
     {% if hourly_breakdown %}
-    <div style="margin-top: 2rem;">
-        <h3 style="margin-bottom: 0.75rem;">{{ t.month_payslip_title }}</h3>
-        <div style="overflow-x: auto;">
+    <div class="section-mt">
+        <h3 class="h-mb">{{ t.month_payslip_title }}</h3>
+        <div class="scroll-x">
             <table class="breakdown-table">
                 <thead>
                     <tr>
@@ -649,6 +649,7 @@
 
     <style>
     /* Per-shift mode (default): show shift rows, hide day rows */
+    #breakdown-section { margin-top: 1rem; }
     #breakdown-section.ob-by-shift .ob-row-day  { display: none; }
     /* Per-calendar-day mode: show day rows, hide shift rows */
     #breakdown-section.ob-by-day   .ob-row-shift { display: none; }
@@ -658,13 +659,13 @@
     function toggleBreakdown() {
         var section = document.getElementById('breakdown-section');
         var btn = document.getElementById('breakdown-toggle');
-        if (section.style.display === 'none') {
-            section.style.display = 'block';
+        if (section.hidden) {
+            section.hidden = false;
             btn.textContent = '{{ t.month_hide_breakdown }}';
             history.replaceState(null, '', window.location.pathname + window.location.search + '#breakdown');
             section.scrollIntoView({ behavior: 'smooth', block: 'start' });
         } else {
-            section.style.display = 'none';
+            section.hidden = true;
             btn.textContent = '{{ t.month_show_breakdown }}';
             history.replaceState(null, '', window.location.pathname + window.location.search);
         }
@@ -687,7 +688,7 @@
     if (window.location.hash === '#breakdown') {
         var section = document.getElementById('breakdown-section');
         var btn = document.getElementById('breakdown-toggle');
-        section.style.display = 'block';
+        section.hidden = false;
         btn.textContent = '{{ t.month_hide_breakdown }}';
         section.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }

--- a/app/templates/month_all.html
+++ b/app/templates/month_all.html
@@ -46,18 +46,18 @@
 
 <h2 class="page-title">{{ t.month_all_title.replace('{year}', year|string).replace('{month}', "%02d"|format(month)) }}</h2>
 
-    <div style="display:flex;flex-wrap:wrap;gap:0.5rem;margin-bottom:0.75rem;padding:0.5rem 0.75rem;background:var(--panel);border-radius:var(--radius);border:1px solid var(--border);align-items:center;">
-        <button onclick="setAllPersonCols(true)" class="btn secondary" style="font-size:0.8rem;padding:2px 8px;">Markera alla</button>
-        <button onclick="setAllPersonCols(false)" class="btn secondary" style="font-size:0.8rem;padding:2px 8px;">Avmarkera alla</button>
-        <span style="color:var(--border);margin:0 0.25rem;">|</span>
+    <div class="col-toggle-bar">
+        <button onclick="setAllPersonCols(true)" class="btn secondary btn-xs">Markera alla</button>
+        <button onclick="setAllPersonCols(false)" class="btn secondary btn-xs">Avmarkera alla</button>
+        <span class="col-sep">|</span>
         {% for p in persons %}
-        <label style="display:flex;align-items:center;gap:0.3rem;cursor:pointer;font-size:0.85rem;user-select:none;">
-            <input type="checkbox" checked onchange="togglePersonCol({% if p.is_substitute %}'{{ p.person_id }}'{% else %}{{ p.person_id }}{% endif %}, this.checked)" style="cursor:pointer;">
+        <label class="col-toggle-label">
+            <input type="checkbox" checked onchange="togglePersonCol({% if p.is_substitute %}'{{ p.person_id }}'{% else %}{{ p.person_id }}{% endif %}, this.checked)" class="cursor-pointer">
             {{ p.person_name }}
         </label>
         {% endfor %}
-        <span style="color:var(--border);margin:0 0.25rem;">|</span>
-        <button id="orig-toggle-btn" onclick="toggleOriginalMode()" class="btn secondary" style="font-size:0.8rem;padding:2px 8px;">
+        <span class="col-sep">|</span>
+        <button id="orig-toggle-btn" onclick="toggleOriginalMode()" class="btn secondary btn-xs">
             {% if t.html_lang == 'en' %}Show rotation{% else %}Visa rotation{% endif %}
         </button>
     </div>
@@ -118,9 +118,9 @@
                                 <a href="/week?year={{ day.date.isocalendar()[0] }}&week={{ day.date.isocalendar()[1] }}" class="rotation-week-small">v{{ day.date.isocalendar()[1] }}</a>
                             {% endif %}
                             {% if storhelg_dates is defined and day.date in storhelg_dates %}
-                                <span class="badge badge-ob5" style="font-size:0.55rem;padding:1px 3px;">S</span>
+                                <span class="badge badge-ob5 badge-marker-xs">S</span>
                             {% elif holiday_dates is defined and day.date in holiday_dates %}
-                                <span class="badge badge-ob4" style="font-size:0.55rem;padding:1px 3px;">H</span>
+                                <span class="badge badge-ob4 badge-marker-xs">H</span>
                             {% endif %}
                         </td>
                         {% for p in persons %}
@@ -128,34 +128,34 @@
                             {% set orig_code = d.original_shift.code if d.original_shift else (d.shift.code if d.shift else 'OFF') %}
                             {% set orig_color = d.original_shift.color if d.original_shift else (d.shift.color if d.shift else 'transparent') %}
                             {% set is_changed = d.shift and d.original_shift and d.shift.code != d.original_shift.code %}
-                            <td class="day-cell" data-person="{{ p.person_id }}"
+                            <td class="day-cell month-shift-cell" data-person="{{ p.person_id }}"
                                 title="{{ d.date.isoformat() }}"
                                 data-act-color="{{ d.shift.color if d.shift else 'transparent' }}"
                                 data-orig-color="{{ orig_color }}"
                                 data-orig-code="{{ orig_code }}"
                                 data-changed="{{ '1' if is_changed else '0' }}"
-                                style="border-left:6px solid {% if d.shift %}{{ d.shift.color }}{% else %}transparent{% endif %}; padding-left:8px;">
+                                data-border-left="{% if d.shift %}{{ d.shift.color }}{% else %}transparent{% endif %}">
                                 {% if d.shift %}
                                     {# Länka till day-sida bara om admin eller egen (ej vikarier, de saknar dagsida) #}
                                     {% if not p.is_substitute and user and (user.role.value == 'admin' or user.rotation_person_id == p.person_id) %}
                                         {% set link_id = user.id if user.rotation_person_id == p.person_id else p.person_id %}
                                         <a href="/day/{{ link_id }}/{{ d.date.year }}/{{ d.date.month }}/{{ d.date.day }}"
-                                           style="text-decoration:none;">
+                                           class="plain-link">
                                     {% endif %}
                                         {% if d.shift.code == 'SEM' %}
                                             <span class="badge badge-sem js-sb"
                                                   title="{{ t.month_shift_sem_title }}"
                                                   data-act-label="SEM"
-                                                  style="background: {{ d.shift.color }}; color: {{ d.shift.color | contrast }};">SEM</span>{% if is_changed %}<sup class="orig-asterisk" style="display:none;">*</sup>{% endif %}
+                                                  data-bg="{{ d.shift.color }}" data-fg="{{ d.shift.color | contrast }}">SEM</span>{% if is_changed %}<sup class="orig-asterisk">*</sup>{% endif %}
                                         {% elif d.shift.code == 'OT' %}
                                             <span class="badge js-sb"
                                                   {% if d.start and d.end %}title="{{ t.month_shift_ot_title.replace('{start}', d.start | time_format).replace('{end}', d.end | time_format) }}"{% endif %}
                                                   data-act-label="OT"
-                                                  style="background: {{ d.shift.color }}; color: {{ d.shift.color | contrast }};">OT</span>{% if is_changed %}<sup class="orig-asterisk" style="display:none;">*</sup>{% endif %}
+                                                  data-bg="{{ d.shift.color }}" data-fg="{{ d.shift.color | contrast }}">OT</span>{% if is_changed %}<sup class="orig-asterisk">*</sup>{% endif %}
                                         {% else %}
                                             <span class="badge js-sb"
                                                   data-act-label="{{ d.shift.code }}"
-                                                  style="background: {{ d.shift.color }}; color: {{ d.shift.color | contrast }};">{{ d.shift.code }}</span>{% if is_changed %}<sup class="orig-asterisk" style="display:none;">*</sup>{% endif %}
+                                                  data-bg="{{ d.shift.color }}" data-fg="{{ d.shift.color | contrast }}">{{ d.shift.code }}</span>{% if is_changed %}<sup class="orig-asterisk">*</sup>{% endif %}
                                         {% endif %}
                                     {% if not p.is_substitute and user and (user.role.value == 'admin' or user.rotation_person_id == p.person_id) %}
                                         </a>
@@ -264,7 +264,7 @@ function applyShiftMode() {
             badge.style.background = origColor;
             badge.style.color = _contrast(origColor);
             badge.textContent = origCode;
-            if (asterisk) asterisk.style.display = changed ? '' : 'none';
+            if (asterisk) asterisk.style.display = changed ? 'inline' : 'none';
         } else {
             var actColor = td.dataset.actColor || 'transparent';
             td.style.borderLeftColor = actColor;

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -7,72 +7,72 @@
 
 <h2 class="page-title">{{ t.profile_title }}</h2>
 
-<div class="row" style="gap: 24px; flex-wrap: wrap; align-items: flex-start;">
+<div class="split-cols">
 
     <!-- Profil info -->
-    <div class="col" style="min-width: 300px; flex: 1;">
+    <div class="split-col">
         <div class="card">
-            <h3 style="margin-top: 0;">{{ t.profile_personal_info }}</h3>
+            <h3 class="form-card-title">{{ t.profile_personal_info }}</h3>
 
             {% if error %}
-                <div style="background: rgba(255,100,100,0.2); border: 1px solid var(--danger); padding: 12px; border-radius: var(--radius); margin-bottom: 16px;">
+                <div class="alert alert--danger">
                     {{ error }}
                 </div>
             {% endif %}
 
-            <form method="POST" action="/profile">
-                <div style="margin-bottom: 16px;">
-                    <label style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.profile_username }}</label>
-                    <input type="text" value="{{ user.username }}" disabled style="width: 100%; box-sizing: border-box; opacity: 0.6;">
-                    <small style="color: var(--muted);">{{ t.profile_username_hint }}</small>
+            <form method="POST" action="/profile" class="form-stack">
+                <div class="form-group">
+                    <label class="form-label">{{ t.profile_username }}</label>
+                    <input type="text" value="{{ user.username }}" disabled class="form-input">
+                    <small class="form-hint">{{ t.profile_username_hint }}</small>
                 </div>
 
-                <div style="margin-bottom: 16px;">
-                    <label for="name" style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.profile_name }}</label>
-                    <input type="text" id="name" name="name" value="{{ user.name }}" required style="width: 100%; box-sizing: border-box;">
+                <div class="form-group">
+                    <label for="name" class="form-label">{{ t.profile_name }}</label>
+                    <input type="text" id="name" name="name" value="{{ user.name }}" required class="form-input">
                 </div>
 
-                <div style="margin-bottom: 16px;">
+                <div class="form-group">
                     {% set wage_unit = t.admin_wage_unit_hourly if user.wage_type and user.wage_type.value == 'hourly' else t.admin_wage_unit_monthly %}
-                    <label style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.profile_current_wage }}</label>
-                    <input type="text" value="{{ '{:,}'.format(user.wage).replace(',', ' ') }} {{ wage_unit }}" disabled style="width: 100%; box-sizing: border-box; opacity: 0.6;">
-                    <small style="color: var(--muted);">{{ t.profile_wage_hint }}</small>
+                    <label class="form-label">{{ t.profile_current_wage }}</label>
+                    <input type="text" value="{{ '{:,}'.format(user.wage).replace(',', ' ') }} {{ wage_unit }}" disabled class="form-input">
+                    <small class="form-hint">{{ t.profile_wage_hint }}</small>
                 </div>
 
-                <div style="margin-bottom: 16px;">
-                    <label for="tax_table" style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.profile_tax_table }} ({{ user.tax_table }})</label>
-                    <select id="tax_table" name="tax_table" style="width: 100%; box-sizing: border-box; padding: 8px; border: 1px solid var(--border); border-radius: var(--radius); background: var(--bg); color: var(--text);">
+                <div class="form-group">
+                    <label for="tax_table" class="form-label">{{ t.profile_tax_table }} ({{ user.tax_table }})</label>
+                    <select id="tax_table" name="tax_table" class="form-input">
                         {% for table in available_tax_tables %}
                         <option value="{{ table }}" {% if user.tax_table == table %}selected{% endif %}>Tabell {{ table }}</option>
                         {% endfor %}
                     </select>
-                    <small style="color: var(--muted);">{{ t.profile_tax_hint }}</small>
+                    <small class="form-hint">{{ t.profile_tax_hint }}</small>
                 </div>
 
-                <div style="margin-bottom: 16px;">
-                    <label style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.profile_role }}</label>
-                    <input type="text" value="{{ user.role.value }}" disabled style="width: 100%; box-sizing: border-box; opacity: 0.6;">
+                <div class="form-group">
+                    <label class="form-label">{{ t.profile_role }}</label>
+                    <input type="text" value="{{ user.role.value }}" disabled class="form-input">
                 </div>
 
-                <button type="submit" class="btn">{{ t.profile_save }}</button>
+                <button type="submit" class="btn btn-primary">{{ t.profile_save }}</button>
             </form>
         </div>
     </div>
 
     <!-- Byt lösenord -->
-    <div class="col" style="min-width: 300px; flex: 1;">
+    <div class="split-col">
         <div class="card">
-            <h3 style="margin-top: 0;">{{ t.profile_change_password }}</h3>
+            <h3 class="form-card-title">{{ t.profile_change_password }}</h3>
 
-            <form method="POST" action="/profile/password">
-                <div style="margin-bottom: 16px;">
-                    <label for="current_password" style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.profile_current_pw }}</label>
-                    <input type="password" id="current_password" name="current_password" required style="width: 100%; box-sizing: border-box;">
+            <form method="POST" action="/profile/password" class="form-stack">
+                <div class="form-group">
+                    <label for="current_password" class="form-label">{{ t.profile_current_pw }}</label>
+                    <input type="password" id="current_password" name="current_password" required class="form-input">
                 </div>
 
-                <div style="margin-bottom: 24px;">
-                    <label for="new_password" style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.profile_new_pw }}</label>
-                    <input type="password" id="new_password" name="new_password" required minlength="6" style="width: 100%; box-sizing: border-box;">
+                <div class="form-group">
+                    <label for="new_password" class="form-label">{{ t.profile_new_pw }}</label>
+                    <input type="password" id="new_password" name="new_password" required minlength="6" class="form-input">
                 </div>
 
                 <button type="submit" class="btn secondary">{{ t.profile_change_pw_button }}</button>
@@ -80,20 +80,20 @@
         </div>
 
         <!-- Semester länk -->
-        <div class="card" style="margin-top: 16px;">
-            <h3 style="margin-top: 0;">{{ t.profile_vacation_title }}</h3>
-            <p style="color: var(--muted);">{{ t.profile_vacation_desc }}</p>
-            <a href="/profile/vacation" class="btn">{{ t.profile_vacation_link }}</a>
+        <div class="card card-mt">
+            <h3 class="form-card-title">{{ t.profile_vacation_title }}</h3>
+            <p class="text-muted">{{ t.profile_vacation_desc }}</p>
+            <a href="/profile/vacation" class="btn btn-primary">{{ t.profile_vacation_link }}</a>
         </div>
 
         <!-- Övertag länk -->
-        <div class="card" style="margin-top: 16px;">
-            <h3 style="margin-top: 0;">{{ t.profile_transition_title }}</h3>
-            <p style="color: var(--muted);">{{ t.profile_transition_desc }}</p>
+        <div class="card card-mt">
+            <h3 class="form-card-title">{{ t.profile_transition_title }}</h3>
+            <p class="text-muted">{{ t.profile_transition_desc }}</p>
             {% if user.employment_transition %}
-            <span class="badge" style="margin-bottom: 0.75rem; display: inline-block;">{{ t.profile_transition_configured }}</span><br>
+            <span class="badge profile-transition-badge">{{ t.profile_transition_configured }}</span><br>
             {% endif %}
-            <a href="/profile/transition" class="btn">{{ t.profile_transition_edit if user.employment_transition else t.profile_transition_configure }}</a>
+            <a href="/profile/transition" class="btn btn-primary">{{ t.profile_transition_edit if user.employment_transition else t.profile_transition_configure }}</a>
         </div>
 
     </div>
@@ -101,47 +101,47 @@
 </div>
 
     <!-- Lönehistorik -->
-    <section style="margin-top: 32px;">
+    <section class="section-mt">
         <h2>{{ t.profile_wage_history }}</h2>
 
         {% if wage_history %}
             <div class="card">
-                <table style="width: 100%; border-collapse: collapse;">
+                <table class="history-table">
                     <thead>
-                        <tr style="border-bottom: 1px solid var(--border);">
-                            <th style="text-align: left; padding: 8px; color: var(--muted); font-weight: 500;">{{ t.profile_wage_col }}</th>
-                            <th style="text-align: left; padding: 8px; color: var(--muted); font-weight: 500;">{{ t.profile_from_date }}</th>
-                            <th style="text-align: left; padding: 8px; color: var(--muted); font-weight: 500;">{{ t.profile_to_date }}</th>
-                            <th style="text-align: left; padding: 8px; color: var(--muted); font-weight: 500;">{{ t.profile_status }}</th>
-                            <th style="text-align: left; padding: 8px; color: var(--muted); font-weight: 500;">{{ t.profile_action }}</th>
+                        <tr>
+                            <th>{{ t.profile_wage_col }}</th>
+                            <th>{{ t.profile_from_date }}</th>
+                            <th>{{ t.profile_to_date }}</th>
+                            <th>{{ t.profile_status }}</th>
+                            <th>{{ t.profile_action }}</th>
                         </tr>
                     </thead>
                     <tbody>
                         {% for record in wage_history %}
-                        <tr style="border-bottom: 1px solid var(--border);">
-                            <td style="padding: 8px; font-weight: 500;">{{ "{:,}".format(record.wage).replace(',', ' ') }} {{ wage_unit }}</td>
-                            <td style="padding: 8px;">{{ record.effective_from }}</td>
-                            <td style="padding: 8px;">
+                        <tr>
+                            <td class="cell-strong">{{ "{:,}".format(record.wage).replace(',', ' ') }} {{ wage_unit }}</td>
+                            <td>{{ record.effective_from }}</td>
+                            <td>
                                 {% if record.effective_to %}
                                     {{ record.effective_to }}
                                 {% else %}
-                                    <span style="color: var(--muted); font-style: italic;">{{ t.profile_ongoing }}</span>
+                                    <span class="text-italic-muted">{{ t.profile_ongoing }}</span>
                                 {% endif %}
                             </td>
-                            <td style="padding: 8px;">
+                            <td>
                                 {% if record.is_current %}
-                                    <span style="color: var(--success); font-weight: 500;">{{ t.profile_current }}</span>
+                                    <span class="status-pos">{{ t.profile_current }}</span>
                                 {% else %}
-                                    <span style="color: var(--muted);">{{ t.profile_historical }}</span>
+                                    <span class="text-muted">{{ t.profile_historical }}</span>
                                 {% endif %}
                             </td>
-                            <td style="padding: 8px;">
+                            <td>
                                 {% if wage_history | length > 1 %}
-                                    <form method="POST" action="/profile/delete-wage/{{ record.id }}" style="display: inline;" onsubmit="return confirm('{{ t.profile_delete_wage_confirm }}');">
-                                        <button type="submit" class="btn danger" style="padding: 4px 8px; font-size: 0.875rem;">{{ t.profile_delete }}</button>
+                                    <form method="POST" action="/profile/delete-wage/{{ record.id }}" class="inline-form" onsubmit="return confirm('{{ t.profile_delete_wage_confirm }}');">
+                                        <button type="submit" class="btn danger">{{ t.profile_delete }}</button>
                                     </form>
                                 {% else %}
-                                    <span style="color: var(--muted); font-size: 0.875rem;">-</span>
+                                    <span class="text-muted rates-sm">-</span>
                                 {% endif %}
                             </td>
                         </tr>
@@ -151,28 +151,28 @@
             </div>
         {% else %}
             <div class="card">
-                <p style="color: var(--muted);">{{ t.profile_no_wage_history }}</p>
+                <p class="text-muted">{{ t.profile_no_wage_history }}</p>
             </div>
         {% endif %}
 
         <!-- Add New Wage -->
-        <div class="card" style="margin-top: 16px;">
-            <h3 style="margin-top: 0;">{{ t.profile_add_wage_title }}</h3>
-            <p style="color: var(--muted); margin-bottom: 16px;">
+        <div class="card card-mt">
+            <h3 class="form-card-title">{{ t.profile_add_wage_title }}</h3>
+            <p class="text-muted profile-add-desc">
                 {{ t.profile_add_wage_desc }}
             </p>
 
             <form method="POST" action="/profile/add-wage" id="profile-add-wage-form">
-                <div style="margin-bottom: 16px;">
-                    <label style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.admin_wage_type_label }}</label>
-                    <div style="display: flex; gap: 1.5rem;">
-                        <label style="display: flex; align-items: center; gap: 0.4rem; cursor: pointer;">
+                <div class="form-group profile-field-block">
+                    <label class="form-label">{{ t.admin_wage_type_label }}</label>
+                    <div class="form-options">
+                        <label class="form-option">
                             <input type="radio" name="wage_type" value="monthly"
                                 {% if not user.wage_type or user.wage_type.value == 'monthly' %}checked{% endif %}
                                 onchange="updateProfileWageUnit(this.value)">
                             {{ t.admin_wage_type_monthly }}
                         </label>
-                        <label style="display: flex; align-items: center; gap: 0.4rem; cursor: pointer;">
+                        <label class="form-option">
                             <input type="radio" name="wage_type" value="hourly"
                                 {% if user.wage_type and user.wage_type.value == 'hourly' %}checked{% endif %}
                                 onchange="updateProfileWageUnit(this.value)">
@@ -181,9 +181,9 @@
                     </div>
                 </div>
 
-                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 16px;">
+                <div class="profile-wage-grid">
                     <div>
-                        <label for="new_wage" style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.profile_new_wage }} (<span id="profile-wage-unit">{{ wage_unit }}</span>)</label>
+                        <label for="new_wage" class="form-label">{{ t.profile_new_wage }} (<span id="profile-wage-unit">{{ wage_unit }}</span>)</label>
                         <input
                             type="number"
                             id="new_wage"
@@ -192,23 +192,23 @@
                             min="0"
                             step="1"
                             placeholder="{{ '300' if user.wage_type and user.wage_type.value == 'hourly' else '35000' }}"
-                            style="width: 100%; box-sizing: border-box;"
+                            class="form-input"
                         >
                     </div>
 
                     <div>
-                        <label for="effective_from" style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.profile_from_date }}</label>
+                        <label for="effective_from" class="form-label">{{ t.profile_from_date }}</label>
                         <input
                             type="date"
                             id="effective_from"
                             name="effective_from"
                             required
-                            style="width: 100%; box-sizing: border-box;"
+                            class="form-input"
                         >
                     </div>
                 </div>
 
-                <button type="submit" class="btn">{{ t.profile_add_wage_button }}</button>
+                <button type="submit" class="btn btn-primary">{{ t.profile_add_wage_button }}</button>
             </form>
             <script>
             function updateProfileWageUnit(type) {
@@ -223,21 +223,20 @@
     </section>
 
     <!-- API-nyckel -->
-    <section style="margin-top: 32px;">
+    <section class="section-mt">
         <h2>{{ t.profile_api_key_title }}</h2>
         <div class="card">
-            <p style="color: var(--muted); margin-top: 0;">{{ t.profile_api_key_desc }}</p>
+            <p class="text-muted form-card-title">{{ t.profile_api_key_desc }}</p>
 
             {% if api_key_plain %}
-                <input type="text" value="{{ api_key_plain }}" readonly
-                       style="width: 100%; box-sizing: border-box; font-family: monospace; margin-bottom: 12px;">
+                <input type="text" value="{{ api_key_plain }}" readonly class="profile-api-input">
             {% elif user.api_key %}
-                <p style="color: var(--muted);">{{ t.profile_api_key_configured }}</p>
+                <p class="text-muted">{{ t.profile_api_key_configured }}</p>
             {% else %}
-                <p style="color: var(--muted);">{{ t.profile_api_key_none }}</p>
+                <p class="text-muted">{{ t.profile_api_key_none }}</p>
             {% endif %}
 
-            <div style="display: flex; gap: 8px; flex-wrap: wrap; margin-top: 8px; align-items: center;">
+            <div class="profile-actions">
                 <form method="POST" action="/profile/api-key/generate">
                     <button type="submit" class="btn btn-primary">{{ t.profile_api_key_generate }}</button>
                 </form>
@@ -270,5 +269,17 @@
     {% set rates_form_action = "/profile/rates" %}
     {% set rates_delete_prefix = "/profile/delete-rate/" %}
     {% include "rates_form.html" with context %}
+
+<style>
+.profile-transition-badge { margin-bottom: 0.75rem; display: inline-block; }
+.profile-add-desc { margin-bottom: 1rem; }
+.profile-field-block { margin-bottom: 1rem; }
+.profile-wage-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; margin-bottom: 1rem; }
+.profile-api-input { width: 100%; box-sizing: border-box; font-family: var(--font-mono); margin-bottom: 0.75rem; }
+.profile-actions { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-top: 0.5rem; align-items: center; }
+@media (max-width: 520px) {
+    .profile-wage-grid { grid-template-columns: 1fr; }
+}
+</style>
 
 {% endblock %}

--- a/app/templates/range.html
+++ b/app/templates/range.html
@@ -47,22 +47,18 @@
             <a href="/range/{{ person_id }}" class="btn btn-primary">{{ t.week_today }}</a>
         {% endif %}
     </div>
-    <div class="page-header-right" style="position:relative;">
-        <select onchange="window.location='/range/{{ person_id }}?weeks='+this.value+'&from={{ start_date.isoformat() }}'"
-                style="background:var(--panel);color:var(--text);border:1px solid rgba(255,255,255,0.15);border-radius:4px;padding:4px 8px;font-size:0.9rem;cursor:pointer;color-scheme:dark;">
+    <div class="page-header-right range-controls">
+        <select class="range-select" onchange="window.location='/range/{{ person_id }}?weeks='+this.value+'&from={{ start_date.isoformat() }}'" aria-label="{{ t.range_title }}">
             {% for w in range(1, 11) %}
-                <option value="{{ w }}" {% if active_weeks == w %}selected{% endif %} style="background:var(--panel);color:var(--text);">{{ w }}v</option>
+                <option value="{{ w }}" {% if active_weeks == w %}selected{% endif %}>{{ w }}v</option>
             {% endfor %}
         </select>
-        <button class="btn secondary" onclick="var f=this.nextElementSibling;f.style.display=f.style.display==='flex'?'none':'flex';">{{ t.range_from }}/{{ t.range_to }} ▾</button>
-        <form method="get" action="/range/{{ person_id }}"
-              style="display:none;gap:0.5rem;align-items:center;flex-wrap:wrap;position:absolute;right:0;top:100%;background:var(--card-bg);border:1px solid var(--border);border-radius:6px;padding:0.5rem;z-index:10;margin-top:4px;">
-            <label style="color:var(--muted);font-size:0.85rem;">{{ t.range_from }}</label>
-            <input type="date" name="from" value="{{ start_date.isoformat() }}"
-                   style="background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:4px 8px;font-size:0.9rem;">
-            <label style="color:var(--muted);font-size:0.85rem;">{{ t.range_to }}</label>
-            <input type="date" name="to" value="{{ end_date.isoformat() }}"
-                   style="background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:4px 8px;font-size:0.9rem;">
+        <button type="button" class="btn secondary range-filter-toggle" aria-expanded="false" aria-controls="range-date-panel" onclick="toggleRangeDatePanel(this)">{{ t.range_from }}/{{ t.range_to }} ▾</button>
+        <form method="get" action="/range/{{ person_id }}" id="range-date-panel" class="range-date-panel" hidden>
+            <label for="range-from">{{ t.range_from }}</label>
+            <input type="date" id="range-from" name="from" value="{{ start_date.isoformat() }}">
+            <label for="range-to">{{ t.range_to }}</label>
+            <input type="date" id="range-to" name="to" value="{{ end_date.isoformat() }}">
             <button type="submit" class="btn btn-primary">{{ t.range_apply }}</button>
         </form>
     </div>
@@ -87,28 +83,27 @@
             {% if ns.current_week is not none %}
                 {% set prev_day = days[loop.index0 - 1] %}
                 {% for pad in range(6 - prev_day.date.weekday()) %}
-                    <td class="calendar-day" style="background:transparent;border:none;"></td>
+                    <td class="calendar-day calendar-day--empty"></td>
                 {% endfor %}
                 </tr>
             {% endif %}
             {% set ns.current_week = week_key %}
             <tr>
             {% for pad in range(day.date.weekday()) %}
-                <td class="calendar-day" style="background:transparent;border:none;"></td>
+                <td class="calendar-day calendar-day--empty"></td>
             {% endfor %}
         {% endif %}
 
         {% set is_today = today is defined and day.date == today %}
-        <td class="calendar-day {% if is_today %}today-cell{% endif %}"
-            style="border-top: 4px solid {% if day.shift %}{{ day.shift.color }}{% else %}#333{% endif %};">
+        <td class="calendar-day range-day-cell {% if is_today %}today-cell{% endif %}"{% if day.shift %} data-shift-color="{{ day.shift.color }}"{% endif %}>
             <div class="calendar-day-content">
                 <div class="calendar-day-header">
                     <a href="/day/{{ person_id }}/{{ day.date.year }}/{{ day.date.month }}/{{ day.date.day }}"
                        class="day-number">{{ day.date.day }}/{{ day.date.month }}</a>
                     {% if storhelg_dates is defined and day.date in storhelg_dates %}
-                        <span class="badge badge-ob5" style="font-size:0.6rem;padding:1px 4px;">S</span>
+                        <span class="badge badge-ob5 badge-calendar-marker">S</span>
                     {% elif holiday_dates is defined and day.date in holiday_dates %}
-                        <span class="badge badge-ob4" style="font-size:0.6rem;padding:1px 4px;">H</span>
+                        <span class="badge badge-ob4 badge-calendar-marker">H</span>
                     {% endif %}
                     {% if day.date.weekday() == 0 %}
                         <a href="/week/{{ person_id }}?year={{ day.date.isocalendar()[0] }}&week={{ day.date.isocalendar()[1] }}" class="rotation-week-small">v{{ day.date.isocalendar()[1] }}</a>
@@ -122,8 +117,7 @@
                 </div>
                 <div class="calendar-day-body">
                     {% if day.shift %}
-                        <span class="badge calendar-badge"
-                              style="background:{{ day.shift.color }};color:{{ day.shift.color | contrast }};">
+                        <span class="badge calendar-badge" data-shift-color="{{ day.shift.color }}" data-shift-contrast="{{ day.shift.color | contrast }}">
                             {{ day.shift.code }}
                         </span>
                     {% else %}
@@ -148,11 +142,46 @@
 
     {% set last_day = days[-1] %}
     {% for pad in range(6 - last_day.date.weekday()) %}
-        <td class="calendar-day" style="background:transparent;border:none;"></td>
+        <td class="calendar-day calendar-day--empty"></td>
     {% endfor %}
     </tr>
     </tbody>
 </table>
 {% endif %}
+
+<script>
+function toggleRangeDatePanel(button) {
+    const panel = document.getElementById(button.getAttribute('aria-controls'));
+    const isOpening = panel.hidden;
+    panel.hidden = !isOpening;
+    button.setAttribute('aria-expanded', isOpening ? 'true' : 'false');
+    if (isOpening) {
+        const firstControl = panel.querySelector('input, button');
+        if (firstControl) firstControl.focus();
+    }
+}
+
+document.querySelectorAll('[data-shift-color]').forEach(function(el) {
+    const color = el.getAttribute('data-shift-color');
+    if (!color) return;
+    if (el.classList.contains('range-day-cell')) {
+        el.style.borderTopColor = color;
+    } else {
+        el.style.backgroundColor = color;
+        el.style.color = el.getAttribute('data-shift-contrast') || 'var(--bg)';
+    }
+});
+
+document.addEventListener('keydown', function(event) {
+    if (event.key !== 'Escape') return;
+    const button = document.querySelector('.range-filter-toggle[aria-expanded="true"]');
+    if (!button) return;
+    const panel = document.getElementById(button.getAttribute('aria-controls'));
+    if (!panel || panel.hidden) return;
+    panel.hidden = true;
+    button.setAttribute('aria-expanded', 'false');
+    button.focus();
+});
+</script>
 
 {% endblock %}

--- a/app/templates/rates_form.html
+++ b/app/templates/rates_form.html
@@ -3,31 +3,31 @@
 
 <!-- Rate History -->
 {% if rate_history %}
-<div class="card" style="margin-top: 16px;">
-    <h3 style="margin-top: 0;">{{ t.rates_history_title }}</h3>
+<div class="card rates-block">
+    <h3 class="form-card-title">{{ t.rates_history_title }}</h3>
 
-    <table style="width: 100%; border-collapse: collapse;">
+    <table class="rates-history-table">
         <thead>
-            <tr style="border-bottom: 1px solid var(--border);">
-                <th style="text-align: left; padding: 8px; color: var(--muted); font-weight: 500;">{{ t.rates_from_date }}</th>
-                <th style="text-align: left; padding: 8px; color: var(--muted); font-weight: 500;">{{ t.rates_to_date }}</th>
-                <th style="text-align: left; padding: 8px; color: var(--muted); font-weight: 500;">{{ t.rates_overview }}</th>
-                <th style="text-align: left; padding: 8px; color: var(--muted); font-weight: 500;">{{ t.rates_status }}</th>
-                <th style="text-align: left; padding: 8px; color: var(--muted); font-weight: 500;">{{ t.rates_action }}</th>
+            <tr>
+                <th>{{ t.rates_from_date }}</th>
+                <th>{{ t.rates_to_date }}</th>
+                <th>{{ t.rates_overview }}</th>
+                <th>{{ t.rates_status }}</th>
+                <th>{{ t.rates_action }}</th>
             </tr>
         </thead>
         <tbody>
             {% for record in rate_history %}
-            <tr style="border-bottom: 1px solid var(--border);">
-                <td style="padding: 8px;">{{ record.effective_from }}</td>
-                <td style="padding: 8px;">
+            <tr>
+                <td>{{ record.effective_from }}</td>
+                <td>
                     {% if record.effective_to %}
                         {{ record.effective_to }}
                     {% else %}
-                        <span style="color: var(--muted); font-style: italic;">{{ t.rates_ongoing }}</span>
+                        <span class="rates-ongoing">{{ t.rates_ongoing }}</span>
                     {% endif %}
                 </td>
-                <td style="padding: 8px; font-size: 0.8rem; line-height: 1.6;">
+                <td class="rates-overview-cell">
                     {% set r = record.rates %}
                     {% set parts = [] %}
 
@@ -75,25 +75,25 @@
                     {% if parts %}
                         {{ parts|join('<br>')|safe }}
                     {% else %}
-                        <span style="color: var(--muted);">{{ t.rates_default }}</span>
+                        <span class="text-muted">{{ t.rates_default }}</span>
                     {% endif %}
                 </td>
-                <td style="padding: 8px;">
+                <td>
                     {% if record.status == 'current' %}
-                        <span style="color: var(--success); font-weight: 500;">{{ t.rates_current }}</span>
+                        <span class="rate-status-current">{{ t.rates_current }}</span>
                     {% elif record.status == 'future' %}
-                        <span style="color: var(--warning); font-weight: 500;">{{ t.rates_upcoming }}</span>
+                        <span class="rate-status-future">{{ t.rates_upcoming }}</span>
                     {% else %}
-                        <span style="color: var(--muted);">{{ t.rates_historical }}</span>
+                        <span class="text-muted">{{ t.rates_historical }}</span>
                     {% endif %}
                 </td>
-                <td style="padding: 8px;">
+                <td>
                     {% if rate_history | length > 1 %}
-                        <form method="POST" action="{{ rates_delete_prefix }}{{ record.id }}" style="display: inline;" onsubmit="return confirm('{{ t.rates_delete_confirm }}');">
-                            <button type="submit" class="btn danger" style="padding: 4px 8px; font-size: 0.875rem;">{{ t.rates_delete }}</button>
+                        <form method="POST" action="{{ rates_delete_prefix }}{{ record.id }}" class="inline-form" onsubmit="return confirm('{{ t.rates_delete_confirm }}');">
+                            <button type="submit" class="btn danger">{{ t.rates_delete }}</button>
                         </form>
                     {% else %}
-                        <span style="color: var(--muted); font-size: 0.875rem;">&mdash;</span>
+                        <span class="text-muted rates-sm">&mdash;</span>
                     {% endif %}
                 </td>
             </tr>
@@ -104,52 +104,51 @@
 {% endif %}
 
 <!-- Add New Rates -->
-<div class="card" style="margin-top: 16px;">
-    <h3 style="margin-top: 0;">{% if rate_history %}{{ t.rates_add_title }}{% else %}{{ t.rates_only_title }}{% endif %}</h3>
-    <p style="color: var(--muted); font-size: 0.85rem; margin-bottom: 16px;">
+<div class="card rates-block">
+    <h3 class="form-card-title">{% if rate_history %}{{ t.rates_add_title }}{% else %}{{ t.rates_only_title }}{% endif %}</h3>
+    <p class="rate-intro">
         {{ t.rates_add_desc }}{% if rate_history %} {{ t.rates_add_desc_history }}{% endif %}
     </p>
 
     <form method="POST" action="{{ rates_form_action }}" class="rates-form-instance">
 
         <!-- Från datum + timlön -->
-        <div style="display: flex; gap: 24px; align-items: flex-end; margin-bottom: 20px; flex-wrap: wrap;">
+        <div class="rates-row">
             <div>
-                <label for="effective_from_rates" style="display: block; margin-bottom: 6px; color: var(--muted);">{{ t.rates_from_date_label }}</label>
+                <label for="effective_from_rates" class="form-label">{{ t.rates_from_date_label }}</label>
                 <input type="date" id="effective_from_rates" name="effective_from" required
-                       style="width: 200px; box-sizing: border-box;">
+                       class="rate-input rate-input--date">
             </div>
             <div>
-                <label for="rates_base_wage" style="display: block; margin-bottom: 6px; color: var(--muted);">
-                    {{ t.rates_base_wage_label }} <span style="font-size: 0.8rem;">{{ t.rates_base_wage_hint }}</span>
+                <label for="rates_base_wage" class="form-label">
+                    {{ t.rates_base_wage_label }} <span class="rate-hint-sm">{{ t.rates_base_wage_hint }}</span>
                 </label>
                 <input type="number" id="rates_base_wage" step="0.01" min="0" placeholder="kr/tim"
-                       class="input" style="width: 160px; box-sizing: border-box;">
+                       class="input rate-input rate-input--wage">
             </div>
         </div>
 
         <!-- OB-tillägg (kr/tim) -->
-        <h4 style="margin-bottom: 8px; margin-top: 0;">{{ t.rates_ob_title }} <span style="color: var(--muted); font-weight: 400; font-size: 0.8rem;">{{ t.rates_ob_unit }}</span></h4>
-        <p style="color: var(--muted); font-size: 0.8rem; margin-top: -4px; margin-bottom: 8px;">
+        <h4 class="rate-section-title rate-section-title--first">{{ t.rates_ob_title }} <span class="rate-unit">{{ t.rates_ob_unit }}</span></h4>
+        <p class="rate-section-hint">
             {{ t.rates_ob_hint }}
         </p>
-        <div style="display: grid; grid-template-columns: repeat(5, 1fr); gap: 8px; margin-bottom: 16px;">
+        <div class="rate-grid rate-grid--5">
             {% for code, divisor in rate_defaults.ob_divisors.items() %}
             <div class="rate-field">
-                <div style="display: flex; justify-content: space-between; align-items: flex-end; margin-bottom: 2px;">
-                    <label style="font-size: 0.75rem; color: var(--muted);">{{ code }} <span style="font-size: 0.7rem;">(std: l&ouml;n/{{ divisor }})</span></label>
+                <div class="rate-field-head">
+                    <label class="rate-field-label">{{ code }} <span class="rate-hint-xs">(std: l&ouml;n/{{ divisor }})</span></label>
                     <button type="button" class="rate-factor-toggle" title="Ange som timl&ouml;n &times; faktor">&times;f</button>
                 </div>
                 <input type="number" step="0.01" name="rate_ob_{{ code }}" min="0"
                        value="{{ custom_rates.get('ob', {}).get(code, '') }}"
                        placeholder="kr/tim"
-                       class="rate-value-input input" style="width: 100%; box-sizing: border-box;">
-                <div class="rate-factor-row" style="display: none; margin-top: 4px;">
-                    <div style="display: flex; align-items: center; gap: 4px;">
-                        <input type="number" class="input rate-factor" placeholder="&times; faktor" step="0.01" min="0"
-                               style="flex: 1; min-width: 0;">
-                        <span style="color: var(--muted); font-size: 0.8rem;">=</span>
-                        <span class="rate-computed" style="font-size: 0.75rem; font-weight: 600; color: var(--accent); white-space: nowrap; min-width: 28px;">-</span>
+                       class="rate-value-input input rate-input--full">
+                <div class="rate-factor-row">
+                    <div class="rate-factor-inner">
+                        <input type="number" class="input rate-factor" placeholder="&times; faktor" step="0.01" min="0">
+                        <span class="rate-eq">=</span>
+                        <span class="rate-computed">-</span>
                     </div>
                 </div>
             </div>
@@ -157,48 +156,47 @@
         </div>
 
         <!-- Övertid (kr/tim) -->
-        <h4 style="margin-bottom: 8px;">{{ t.rates_ot_title }} <span style="color: var(--muted); font-weight: 400; font-size: 0.8rem;">{{ t.rates_ot_unit }}</span></h4>
-        <p style="color: var(--muted); font-size: 0.8rem; margin-top: -4px; margin-bottom: 8px;">
+        <h4 class="rate-section-title">{{ t.rates_ot_title }} <span class="rate-unit">{{ t.rates_ot_unit }}</span></h4>
+        <p class="rate-section-hint">
             {{ t.rates_ob_hint }}
         </p>
-        <div class="rate-field" style="margin-bottom: 16px;">
-            <div style="display: flex; align-items: center; gap: 8px;">
+        <div class="rate-field rate-field--ot">
+            <div class="rate-ot-input-row">
                 <input type="number" step="0.01" name="rate_ot" min="0"
                        value="{{ custom_rates.get('ot', '') }}"
                        placeholder="kr/tim"
-                       class="rate-value-input input" style="width: 200px;">
+                       class="rate-value-input input rate-input--date">
                 <button type="button" class="rate-factor-toggle" title="Ange som timl&ouml;n &times; faktor">&times;f</button>
             </div>
-            <div class="rate-factor-row" style="display: none; margin-top: 6px;">
-                <div style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
-                    <input type="number" class="input rate-factor" placeholder="faktor" step="0.01" min="0" style="width: 100px;">
-                    <span style="color: var(--muted);">=</span>
-                    <span class="rate-computed" style="font-weight: 600; color: var(--accent);">-</span>
-                    <span style="color: var(--muted); font-size: 0.85rem;">kr/tim</span>
+            <div class="rate-factor-row rate-factor-row--lg">
+                <div class="rate-factor-inner rate-factor-inner--lg">
+                    <input type="number" class="input rate-factor rate-factor--fixed" placeholder="faktor" step="0.01" min="0">
+                    <span class="rate-eq rate-eq--lg">=</span>
+                    <span class="rate-computed rate-computed--lg">-</span>
+                    <span class="rate-eq-unit">kr/tim</span>
                 </div>
             </div>
         </div>
 
         <!-- Beredskap (kr/tim) -->
-        <h4 style="margin-bottom: 8px;">{{ t.rates_oncall_title }} <span style="color: var(--muted); font-weight: 400; font-size: 0.8rem;">{{ t.rates_ob_unit }}</span></h4>
-        <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; margin-bottom: 16px;">
+        <h4 class="rate-section-title">{{ t.rates_oncall_title }} <span class="rate-unit">{{ t.rates_ob_unit }}</span></h4>
+        <div class="rate-grid rate-grid--2">
             {% set oc_groups = [("OC_WEEKDAY", "Vardag" if t.html_lang == "sv" else "Weekday", 75), ("OC_WEEKEND", "Helg" if t.html_lang == "sv" else "Weekend", 97), ("OC_HOLIDAY", "Röd dag" if t.html_lang == "sv" else "Public holiday", 112), ("OC_SPECIAL", "Storhelg" if t.html_lang == "sv" else "Major holiday", 192)] %}
             {% for code, label, default in oc_groups %}
             <div class="rate-field">
-                <div style="display: flex; justify-content: space-between; align-items: flex-end; margin-bottom: 2px;">
-                    <label style="font-size: 0.75rem; color: var(--muted);">{{ label }} (std: {{ default }} kr)</label>
+                <div class="rate-field-head">
+                    <label class="rate-field-label">{{ label }} (std: {{ default }} kr)</label>
                     <button type="button" class="rate-factor-toggle" title="Ange som timl&ouml;n &times; faktor">&times;f</button>
                 </div>
                 <input type="number" step="0.01" name="rate_oc_{{ code }}" min="0"
                        value="{{ custom_rates.get('oncall', {}).get(code, '') }}"
                        placeholder="{{ default }}"
-                       class="rate-value-input input" style="width: 100%; box-sizing: border-box;">
-                <div class="rate-factor-row" style="display: none; margin-top: 4px;">
-                    <div style="display: flex; align-items: center; gap: 4px;">
-                        <input type="number" class="input rate-factor" placeholder="&times; faktor" step="0.01" min="0"
-                               style="flex: 1; min-width: 0;">
-                        <span style="color: var(--muted); font-size: 0.8rem;">=</span>
-                        <span class="rate-computed" style="font-size: 0.75rem; font-weight: 600; color: var(--accent); white-space: nowrap; min-width: 28px;">-</span>
+                       class="rate-value-input input rate-input--full">
+                <div class="rate-factor-row">
+                    <div class="rate-factor-inner">
+                        <input type="number" class="input rate-factor" placeholder="&times; faktor" step="0.01" min="0">
+                        <span class="rate-eq">=</span>
+                        <span class="rate-computed">-</span>
                     </div>
                 </div>
             </div>
@@ -206,36 +204,90 @@
         </div>
 
         <!-- Semester -->
-        <h4 style="margin-bottom: 8px;">{{ t.rates_vacation_title }} <span style="color: var(--muted); font-weight: 400; font-size: 0.8rem;">{{ t.rates_vacation_unit }}</span></h4>
-        <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; margin-bottom: 16px;">
+        <h4 class="rate-section-title">{{ t.rates_vacation_title }} <span class="rate-unit">{{ t.rates_vacation_unit }}</span></h4>
+        <div class="rate-grid rate-grid--3">
             {% set vac_fields = [("fixed_pct", "Fast del" if t.html_lang == "sv" else "Fixed part", 0.008, "0.8%"), ("variable_pct", "Rörlig del" if t.html_lang == "sv" else "Variable part", 0.005, "0.5%"), ("payout_pct", "Utbetalning" if t.html_lang == "sv" else "Payout", 0.046, "4.6%")] %}
             {% for key, label, default, pct in vac_fields %}
             <div>
-                <label style="display: block; font-size: 0.75rem; color: var(--muted); margin-bottom: 2px;">{{ label }} (std: {{ pct }})</label>
+                <label class="rate-vac-label">{{ label }} (std: {{ pct }})</label>
                 <input type="number" step="0.001" name="rate_vac_{{ key }}" min="0" max="1"
                        value="{{ custom_rates.get('vacation', {}).get(key, '') }}"
                        placeholder="{{ default }}"
-                       class="input" style="width: 100%; box-sizing: border-box;">
+                       class="input rate-input--full">
             </div>
             {% endfor %}
         </div>
 
         <!-- Sjukfrånvaro -->
-        <h4 style="margin-bottom: 8px;">{{ t.rates_sick_title }}</h4>
-        <div style="margin-bottom: 16px;">
-            <label style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
+        <h4 class="rate-section-title">{{ t.rates_sick_title }}</h4>
+        <div class="rate-sick-block">
+            <label class="rate-check-label">
                 <input type="checkbox" name="sick_ob_compensation"
                        {% if custom_rates.get('sick', {}).get('ob_compensation') %}checked{% endif %}>
                 <span>{{ t.rates_sick_ob_label }}</span>
             </label>
-            <p style="color: var(--muted); font-size: 0.8rem; margin: 4px 0 0 22px;">{{ t.rates_sick_ob_hint }}</p>
+            <p class="rate-check-hint">{{ t.rates_sick_ob_hint }}</p>
         </div>
 
-        <button type="submit" class="btn">{{ t.rates_save }}</button>
+        <button type="submit" class="btn btn-primary">{{ t.rates_save }}</button>
     </form>
 </div>
 
 <style>
+.rates-block { margin-top: 1rem; }
+.rates-history-table { width: 100%; border-collapse: collapse; }
+.rates-history-table thead tr,
+.rates-history-table tbody tr { border-bottom: 1px solid var(--border); }
+.rates-history-table th { text-align: left; padding: 8px; color: var(--muted); font-weight: 500; }
+.rates-history-table td { padding: 8px; }
+.rates-overview-cell { font-size: 0.8rem; line-height: 1.6; }
+.rates-ongoing { color: var(--muted); font-style: italic; }
+.rate-status-current { color: var(--success); font-weight: 500; }
+.rate-status-future { color: var(--warning); font-weight: 500; }
+.rates-sm { font-size: 0.875rem; }
+
+.rate-intro { color: var(--muted); font-size: 0.85rem; margin-bottom: 1rem; }
+.rates-row { display: flex; gap: 1.5rem; align-items: flex-end; margin-bottom: 1.25rem; flex-wrap: wrap; }
+.rate-input { box-sizing: border-box; }
+.rate-input--full { width: 100%; box-sizing: border-box; }
+.rate-input--date { width: 200px; box-sizing: border-box; }
+.rate-input--wage { width: 160px; box-sizing: border-box; }
+
+.rate-section-title { margin: 1rem 0 8px; }
+.rate-section-title--first { margin-top: 0; }
+.rate-section-hint { color: var(--muted); font-size: 0.8rem; margin-top: -4px; margin-bottom: 8px; }
+.rate-unit { color: var(--muted); font-weight: 400; font-size: 0.8rem; }
+.rate-hint-sm { font-size: 0.8rem; }
+.rate-hint-xs { font-size: 0.7rem; }
+
+.rate-grid { display: grid; gap: 8px; margin-bottom: 1rem; }
+.rate-grid--5 { grid-template-columns: repeat(5, 1fr); }
+.rate-grid--3 { grid-template-columns: repeat(3, 1fr); }
+.rate-grid--2 { grid-template-columns: repeat(2, 1fr); }
+
+.rate-field-head { display: flex; justify-content: space-between; align-items: flex-end; margin-bottom: 2px; }
+.rate-field-label { font-size: 0.75rem; color: var(--muted); }
+.rate-vac-label { display: block; font-size: 0.75rem; color: var(--muted); margin-bottom: 2px; }
+
+.rate-field--ot { margin-bottom: 1rem; }
+.rate-ot-input-row { display: flex; align-items: center; gap: 8px; }
+
+.rate-factor-row { display: none; margin-top: 4px; }
+.rate-factor-row--lg { margin-top: 6px; }
+.rate-factor-inner { display: flex; align-items: center; gap: 4px; }
+.rate-factor-inner--lg { gap: 8px; flex-wrap: wrap; }
+.rate-factor { flex: 1; min-width: 0; }
+.rate-factor--fixed { flex: none; width: 100px; }
+.rate-eq { color: var(--muted); font-size: 0.8rem; }
+.rate-eq--lg { font-size: 1rem; }
+.rate-eq-unit { color: var(--muted); font-size: 0.85rem; }
+.rate-computed { font-size: 0.75rem; font-weight: 600; color: var(--accent); white-space: nowrap; min-width: 28px; }
+.rate-computed--lg { font-size: 1rem; }
+
+.rate-sick-block { margin-bottom: 1rem; }
+.rate-check-label { display: flex; align-items: center; gap: 8px; cursor: pointer; }
+.rate-check-hint { color: var(--muted); font-size: 0.8rem; margin: 4px 0 0 22px; }
+
 .rate-factor-toggle {
     background: none;
     border: 1px solid var(--border);
@@ -283,10 +335,13 @@
         }
     }
 
+    function isFactorMode(factorRow) {
+        return factorRow && getComputedStyle(factorRow).display !== 'none';
+    }
+
     function updateAllActiveFields() {
         form.querySelectorAll('.rate-field').forEach(function (field) {
-            var factorRow = field.querySelector('.rate-factor-row');
-            if (factorRow && factorRow.style.display !== 'none') {
+            if (isFactorMode(field.querySelector('.rate-factor-row'))) {
                 updateComputed(field);
             }
         });
@@ -299,14 +354,14 @@
             var field = btn.closest('.rate-field');
             var factorRow = field.querySelector('.rate-factor-row');
             var valueInput = field.querySelector('.rate-value-input');
-            var inFactorMode = factorRow.style.display !== 'none';
+            var inFactorMode = isFactorMode(factorRow);
 
             if (inFactorMode) {
                 factorRow.style.display = 'none';
                 valueInput.style.display = '';
                 btn.classList.remove('active');
             } else {
-                factorRow.style.display = '';
+                factorRow.style.display = 'block';
                 valueInput.style.display = 'none';
                 btn.classList.add('active');
                 updateComputed(field);
@@ -322,8 +377,7 @@
 
     form.addEventListener('submit', function () {
         form.querySelectorAll('.rate-field').forEach(function (field) {
-            var factorRow = field.querySelector('.rate-factor-row');
-            if (factorRow && factorRow.style.display !== 'none') {
+            if (isFactorMode(field.querySelector('.rate-factor-row'))) {
                 updateComputed(field);
             }
         });

--- a/app/templates/shift_swaps.html
+++ b/app/templates/shift_swaps.html
@@ -8,8 +8,8 @@
     <h2>{{ t.swaps_title }}</h2>
 
     {% if pending_count > 0 %}
-    <div class="card" style="border-color: var(--warning); margin-bottom: 1.5rem;">
-        <strong style="color: var(--warning);">{% if t.html_lang == 'en' %}{{ pending_count }} pending request{{ 's' if pending_count > 1 }}{% else %}{{ pending_count }} väntande förfrågan{{ 'gar' if pending_count > 1 }}{% endif %}</strong>
+    <div class="card border-warning mb-3">
+        <strong class="text-warning">{% if t.html_lang == 'en' %}{{ pending_count }} pending request{{ 's' if pending_count > 1 }}{% else %}{{ pending_count }} väntande förfrågan{{ 'gar' if pending_count > 1 }}{% endif %}</strong>
     </div>
     {% endif %}
 
@@ -37,26 +37,26 @@
                 <td data-label="{{ t.swaps_message }}">{{ swap.message or '-' }}</td>
                 <td data-label="{{ t.swaps_status }}">
                     {% if swap.status.value == 'PENDING' %}
-                        <span class="badge" style="background: var(--warning); color: #000;">{{ t.swaps_pending_badge }}</span>
+                        <span class="badge badge-warning">{{ t.swaps_pending_badge }}</span>
                     {% elif swap.status.value == 'ACCEPTED' %}
-                        <span class="badge" style="background: var(--accent-2); color: #000;">{{ t.swaps_accepted_badge }}</span>
+                        <span class="badge badge-accent2">{{ t.swaps_accepted_badge }}</span>
                     {% elif swap.status.value == 'REJECTED' %}
-                        <span class="badge" style="background: var(--danger); color: #fff;">{{ t.swaps_rejected_badge }}</span>
+                        <span class="badge badge-danger">{{ t.swaps_rejected_badge }}</span>
                     {% else %}
                         <span class="badge badge-off">{{ t.swaps_cancelled_badge }}</span>
                     {% endif %}
                 </td>
                 <td>
                     {% if swap.status.value == 'PENDING' %}
-                        <form method="POST" action="/swaps/{{ swap.id }}/accept" style="display:inline;">
-                            <button type="submit" class="btn" style="font-size:0.8rem; padding:0.3rem 0.6rem;">{{ t.swaps_accept }}</button>
+                        <form method="POST" action="/swaps/{{ swap.id }}/accept" class="inline-form">
+                            <button type="submit" class="btn btn-swap">{{ t.swaps_accept }}</button>
                         </form>
-                        <form method="POST" action="/swaps/{{ swap.id }}/reject" style="display:inline; margin-left:0.25rem;">
-                            <button type="submit" class="btn btn-danger" style="font-size:0.8rem;">{{ t.swaps_reject }}</button>
+                        <form method="POST" action="/swaps/{{ swap.id }}/reject" class="inline-form ml-1">
+                            <button type="submit" class="btn btn-danger btn-fs-sm">{{ t.swaps_reject }}</button>
                         </form>
                     {% elif swap.status.value == 'ACCEPTED' %}
-                        <form method="POST" action="/swaps/{{ swap.id }}/cancel" style="display:inline;">
-                            <button type="submit" class="btn btn-danger" style="font-size:0.8rem;"
+                        <form method="POST" action="/swaps/{{ swap.id }}/cancel" class="inline-form">
+                            <button type="submit" class="btn btn-danger btn-fs-sm"
                                     onclick="return confirm('{{ t.swaps_undo_confirm }}')">{{ t.swaps_undo }}</button>
                         </form>
                     {% endif %}
@@ -69,7 +69,7 @@
         <p class="info-text">{{ t.swaps_no_received }}</p>
     {% endif %}
 
-    <h3 style="margin-top: 2rem;">{{ t.swaps_sent }}</h3>
+    <h3 class="section-mt">{{ t.swaps_sent }}</h3>
     {% if sent_swaps %}
     <table class="summary">
         <thead>
@@ -91,19 +91,19 @@
                 <td data-label="{{ t.swaps_you_get }}">{% if is_one_way_tgt_free %}&ndash;{% else %}{{ swap.target_shift_code or '?' }} ({{ swap.target_date }}){% endif %}</td>
                 <td data-label="{{ t.swaps_status }}">
                     {% if swap.status.value == 'PENDING' %}
-                        <span class="badge" style="background: var(--warning); color: #000;">{{ t.swaps_pending_badge }}</span>
+                        <span class="badge badge-warning">{{ t.swaps_pending_badge }}</span>
                     {% elif swap.status.value == 'ACCEPTED' %}
-                        <span class="badge" style="background: var(--accent-2); color: #000;">{{ t.swaps_accepted_badge }}</span>
+                        <span class="badge badge-accent2">{{ t.swaps_accepted_badge }}</span>
                     {% elif swap.status.value == 'REJECTED' %}
-                        <span class="badge" style="background: var(--danger); color: #fff;">{{ t.swaps_rejected_badge }}</span>
+                        <span class="badge badge-danger">{{ t.swaps_rejected_badge }}</span>
                     {% else %}
                         <span class="badge badge-off">{{ t.swaps_cancelled_badge }}</span>
                     {% endif %}
                 </td>
                 <td>
                     {% if swap.status.value in ('PENDING', 'ACCEPTED') %}
-                        <form method="POST" action="/swaps/{{ swap.id }}/cancel" style="display:inline;">
-                            <button type="submit" class="btn btn-danger" style="font-size:0.8rem;"
+                        <form method="POST" action="/swaps/{{ swap.id }}/cancel" class="inline-form">
+                            <button type="submit" class="btn btn-danger btn-fs-sm"
                                     onclick="return confirm('{{ t.swaps_undo_confirm if swap.status.value == 'ACCEPTED' else t.swaps_cancel_confirm }}')">
                                 {{ t.swaps_undo if swap.status.value == 'ACCEPTED' else t.swaps_cancel }}
                             </button>

--- a/app/templates/statistics.html
+++ b/app/templates/statistics.html
@@ -5,13 +5,13 @@
 
 {% block page_content %}
 <section>
-    <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 0.5rem;">
+    <div class="stat-header">
         <h2>{{ t.stats_title.replace('{year}', year|string).replace('{name}', person_name) }}</h2>
-        <div style="display: flex; gap: 0.5rem; align-items: center;">
+        <div class="stat-header-controls">
             <a href="/statistics/{{ person_id }}?year={{ year - 1 }}" class="btn btn-primary">&larr; {{ year - 1 }}</a>
             <a href="/statistics/{{ person_id }}?year={{ year + 1 }}" class="btn btn-primary">{{ year + 1 }} &rarr;</a>
             {% if all_persons %}
-            <select onchange="window.location.href='/statistics/' + this.value + '?year={{ year }}'" style="padding: 0.4rem; border-radius: 4px; background: var(--bg-card); color: var(--text); border: 1px solid var(--muted-bg);">
+            <select onchange="window.location.href='/statistics/' + this.value + '?year={{ year }}'" class="stat-select">
                 {% for p in all_persons %}
                 <option value="{{ p.id }}" {% if p.id == person_id %}selected{% endif %}>{{ p.name }}</option>
                 {% endfor %}
@@ -21,27 +21,27 @@
     </div>
 
     {% if show_salary %}
-    <div style="display: grid; grid-template-columns: 1fr; gap: 1.5rem; margin-top: 1.5rem;">
+    <div class="stat-grid-1">
 
         {# Pay trend chart - full width #}
         <div class="card">
             <h3>{{ t.stats_pay_trend }}</h3>
-            <canvas id="payChart" style="min-height: 300px;"></canvas>
+            <canvas id="payChart" class="chart-tall"></canvas>
         </div>
 
         {# OB breakdown chart - full width #}
         <div class="card">
             <h3>{{ t.stats_ob_per_month }}</h3>
-            <canvas id="obChart" style="min-height: 300px;"></canvas>
+            <canvas id="obChart" class="chart-tall"></canvas>
         </div>
 
-        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1.5rem;">
+        <div class="stat-grid-auto">
             {# Absence doughnut #}
             <div class="card">
                 <h3>{{ t.stats_absence }}</h3>
                 {% set total_absence = absence_data.sick + absence_data.vab + absence_data.leave + absence_data.off %}
                 {% if total_absence > 0 %}
-                <canvas id="absenceChart" style="min-height: 280px;"></canvas>
+                <canvas id="absenceChart" class="chart-med"></canvas>
                 {% else %}
                 <p class="info-text">{{ t.stats_no_absence.replace('{year}', year|string) }}</p>
                 {% endif %}
@@ -50,41 +50,41 @@
             {# Hours chart #}
             <div class="card">
                 <h3>{{ t.stats_hours_per_month }}</h3>
-                <canvas id="hoursChart" style="min-height: 280px;"></canvas>
+                <canvas id="hoursChart" class="chart-med"></canvas>
             </div>
         </div>
     </div>
 
     {# Summary cards #}
-    <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 1rem; margin-top: 1.5rem;">
-        <div class="card" style="text-align: center;">
-            <div style="color: var(--muted); font-size: 0.85rem;">{{ t.stats_total_gross }}</div>
-            <div style="font-size: 1.4rem; font-weight: bold;">{{ "{:,.0f}".format(year_summary.total_brutto or 0).replace(",", " ") }} kr</div>
+    <div class="stat-grid-cards">
+        <div class="card stat-card">
+            <div class="stat-label">{{ t.stats_total_gross }}</div>
+            <div class="stat-value">{{ "{:,.0f}".format(year_summary.total_brutto or 0).replace(",", " ") }} kr</div>
         </div>
-        <div class="card" style="text-align: center;">
-            <div style="color: var(--muted); font-size: 0.85rem;">{{ t.stats_total_net }}</div>
-            <div style="font-size: 1.4rem; font-weight: bold;">{{ "{:,.0f}".format(year_summary.total_netto or 0).replace(",", " ") }} kr</div>
+        <div class="card stat-card">
+            <div class="stat-label">{{ t.stats_total_net }}</div>
+            <div class="stat-value">{{ "{:,.0f}".format(year_summary.total_netto or 0).replace(",", " ") }} kr</div>
         </div>
-        <div class="card" style="text-align: center;">
-            <div style="color: var(--muted); font-size: 0.85rem;">{{ t.stats_total_ob }}</div>
-            <div style="font-size: 1.4rem; font-weight: bold;">{{ "{:,.0f}".format(year_summary.total_ob or 0).replace(",", " ") }} kr</div>
+        <div class="card stat-card">
+            <div class="stat-label">{{ t.stats_total_ob }}</div>
+            <div class="stat-value">{{ "{:,.0f}".format(year_summary.total_ob or 0).replace(",", " ") }} kr</div>
         </div>
-        <div class="card" style="text-align: center;">
-            <div style="color: var(--muted); font-size: 0.85rem;">{{ t.stats_total_oncall }}</div>
-            <div style="font-size: 1.4rem; font-weight: bold;">{{ "{:,.0f}".format(year_summary.total_oncall or 0).replace(",", " ") }} kr</div>
+        <div class="card stat-card">
+            <div class="stat-label">{{ t.stats_total_oncall }}</div>
+            <div class="stat-value">{{ "{:,.0f}".format(year_summary.total_oncall or 0).replace(",", " ") }} kr</div>
         </div>
-        <div class="card" style="text-align: center;">
-            <div style="color: var(--muted); font-size: 0.85rem;">{{ t.stats_total_hours }}</div>
-            <div style="font-size: 1.4rem; font-weight: bold;">{{ "{:,.0f}".format(year_summary.total_hours or 0).replace(",", " ") }}h</div>
+        <div class="card stat-card">
+            <div class="stat-label">{{ t.stats_total_hours }}</div>
+            <div class="stat-value">{{ "{:,.0f}".format(year_summary.total_hours or 0).replace(",", " ") }}h</div>
         </div>
-        <div class="card" style="text-align: center;">
-            <div style="color: var(--muted); font-size: 0.85rem;">{{ t.stats_total_shifts }}</div>
-            <div style="font-size: 1.4rem; font-weight: bold;">{{ year_summary.total_shifts or 0 }}</div>
+        <div class="card stat-card">
+            <div class="stat-label">{{ t.stats_total_shifts }}</div>
+            <div class="stat-value">{{ year_summary.total_shifts or 0 }}</div>
         </div>
     </div>
 
     {# Monthly detail table #}
-    <h3 style="margin-top: 2rem;">{{ t.stats_monthly_overview }}</h3>
+    <h3 class="section-mt">{{ t.stats_monthly_overview }}</h3>
     <table class="summary">
         <thead>
             <tr>
@@ -130,7 +130,7 @@
     </table>
 
     {% else %}
-    <p class="info-text" style="margin-top: 2rem;">{{ t.stats_salary_hidden }}</p>
+    <p class="info-text section-mt">{{ t.stats_salary_hidden }}</p>
     {% endif %}
 </section>
 

--- a/app/templates/transition.html
+++ b/app/templates/transition.html
@@ -19,10 +19,10 @@
 <div class="alert alert--danger">{{ error }}</div>
 {% endif %}
 
-<div class="row" style="gap: 1.5rem; flex-wrap: wrap; align-items: flex-start;">
+<div class="split-cols">
 
     {# === Inställningskort === #}
-    <div class="col" style="min-width: 320px; flex: 1;">
+    <div class="split-col">
         <div class="card">
             <h3>{{ t.transition_settings_card }}</h3>
 
@@ -59,7 +59,7 @@
                         {{ t.transition_vacation_missing.replace('{days}', transition.consultant_vacation_days|string) }}
                     </div>
                     {% endif %}
-                    <label class="form-label" style="margin-top: 0.4rem;">
+                    <label class="form-label form-label--mt">
                         {{ t.transition_vacation_manual_label }}
                     </label>
                     <input type="number" id="consultant_vacation_days" name="consultant_vacation_days" class="form-input"
@@ -114,8 +114,7 @@
 
                 <div class="form-group">
                     <label for="notes" class="form-label">{{ t.transition_notes_label }}</label>
-                    <textarea id="notes" name="notes" rows="2" class="form-input"
-                              style="padding: 0.5rem; resize: vertical;">{{ transition.notes if transition and transition.notes else '' }}</textarea>
+                    <textarea id="notes" name="notes" rows="2" class="form-input form-textarea">{{ transition.notes if transition and transition.notes else '' }}</textarea>
                 </div>
 
                 <hr class="form-section-divider">
@@ -162,7 +161,7 @@
 
     {# === Beräkningskort === #}
     {% if preview %}
-    <div class="col" style="min-width: 320px; flex: 1;">
+    <div class="split-col">
         <div class="card">
             <h3>{{ t.transition_preview_title.replace('{month}', preview.transition_month|string).replace('{year}', preview.transition_year|string) }}</h3>
 

--- a/app/templates/vacation.html
+++ b/app/templates/vacation.html
@@ -8,7 +8,7 @@
 <div class="page-header">
     <div class="page-header-left">
         <a href="/profile/vacation?year={{ year - 1 }}" class="btn secondary">{{ year - 1 }}</a>
-        <span style="padding: 8px 16px; font-weight: 600;">{{ year }}</span>
+        <span class="vacation-year-label">{{ year }}</span>
         <a href="/profile/vacation?year={{ year + 1 }}" class="btn secondary">{{ year + 1 }}</a>
     </div>
     <div class="page-header-right">
@@ -18,88 +18,70 @@
 
 <h2 class="page-title">{{ t.profile_vacation_title }} {{ year }} - {{ user.name }}</h2>
 
-<div class="row" style="gap: 24px; flex-wrap: wrap; align-items: flex-start;">
+<div class="vacation-layout">
 
     <!-- Left column: week grid + day-level -->
-    <div class="col" style="min-width: 400px; flex: 2;">
+    <div class="vacation-main">
 
         <!-- Week Selection -->
-        <div class="card" style="margin-bottom: 16px;">
-            <h3 style="margin-top: 0;">{{ t.vacation_choose_weeks }}</h3>
-            <p style="color: var(--muted); margin-bottom: 16px;">{{ t.vacation_choose_weeks_hint }}</p>
+        <div class="card vacation-section">
+            <h3 class="vacation-section-title">{{ t.vacation_choose_weeks }}</h3>
+            <p class="vacation-copy">{{ t.vacation_choose_weeks_hint }}</p>
 
             <form method="POST" action="/profile/vacation" id="vacation-form">
                 <input type="hidden" name="year" value="{{ year }}">
                 <input type="hidden" name="weeks" id="weeks-input" value="{{ vacation_weeks | join(',') }}">
 
-                <div class="week-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(60px, 1fr)); gap: 8px; margin-bottom: 24px;">
+                <div class="vacation-week-grid">
                     {% for week in range(1, 53) %}
                         <button
                             type="button"
-                            class="week-btn {% if week in vacation_weeks %}selected{% endif %}"
+                            class="week-btn vacation-week-btn {% if week in vacation_weeks %}selected{% endif %}"
                             data-week="{{ week }}"
-                            style="
-                                padding: 12px 8px;
-                                border-radius: var(--radius);
-                                border: 1px solid var(--table-border);
-                                background: {% if week in vacation_weeks %}var(--accent){% else %}var(--panel){% endif %};
-                                color: {% if week in vacation_weeks %}var(--bg){% else %}var(--text){% endif %};
-                                cursor: pointer;
-                                font-weight: {% if week in vacation_weeks %}600{% else %}400{% endif %};
-                                transition: all 0.15s;
-                            "
+                            aria-pressed="{% if week in vacation_weeks %}true{% else %}false{% endif %}"
                         >
                             v{{ week }}
                         </button>
                     {% endfor %}
                 </div>
 
-                <button type="submit" class="btn">{{ t.vacation_save }}</button>
+                <button type="submit" class="btn btn-primary">{{ t.vacation_save }}</button>
             </form>
 
-            <hr style="border: none; border-top: 1px solid var(--table-border); margin: 20px 0;">
+            <hr class="vacation-divider">
 
-            <h4 style="margin: 0 0 8px 0; color: var(--blue);">{{ t.vacation_parental_weeks }}</h4>
-            <p style="color: var(--muted); margin-bottom: 16px; font-size: 0.875rem;">{{ t.vacation_parental_weeks_hint }}</p>
+            <h4 class="vacation-subtitle">{{ t.vacation_parental_weeks }}</h4>
+            <p class="vacation-copy">{{ t.vacation_parental_weeks_hint }}</p>
 
             <form method="POST" action="/profile/vacation/parental/weeks" id="parental-form">
                 <input type="hidden" name="year" value="{{ year }}">
                 <input type="hidden" name="weeks" id="parental-weeks-input" value="{{ parental_weeks | join(',') }}">
 
-                <div class="week-grid" id="parental-week-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(60px, 1fr)); gap: 8px; margin-bottom: 16px;">
+                <div class="vacation-week-grid vacation-week-grid--compact" id="parental-week-grid">
                     {% for week in range(1, 53) %}
                         <button
                             type="button"
-                            class="parental-week-btn {% if week in parental_weeks %}selected{% endif %}"
+                            class="parental-week-btn vacation-week-btn vacation-week-btn--parental {% if week in parental_weeks %}selected{% endif %}"
                             data-week="{{ week }}"
-                            style="
-                                padding: 12px 8px;
-                                border-radius: var(--radius);
-                                border: 1px solid var(--table-border);
-                                background: {% if week in parental_weeks %}var(--blue){% else %}var(--panel){% endif %};
-                                color: {% if week in parental_weeks %}white{% else %}var(--text){% endif %};
-                                cursor: pointer;
-                                font-weight: {% if week in parental_weeks %}600{% else %}400{% endif %};
-                                transition: all 0.15s;
-                            "
+                            aria-pressed="{% if week in parental_weeks %}true{% else %}false{% endif %}"
                         >
                             v{{ week }}
                         </button>
                     {% endfor %}
                 </div>
 
-                <button type="submit" class="btn" style="background: var(--blue); color: white;">{{ t.vacation_save }}</button>
+                <button type="submit" class="btn btn-blue">{{ t.vacation_save }}</button>
             </form>
         </div>
 
         <!-- Day-Level Vacation Calendar -->
         <div class="card">
-            <h3 style="margin-top: 0;">{{ t.vacation_day_level }}</h3>
-            <p style="color: var(--muted); margin-bottom: 16px;">{{ t.vacation_day_level_hint }}</p>
+            <h3 class="vacation-section-title">{{ t.vacation_day_level }}</h3>
+            <p class="vacation-copy">{{ t.vacation_day_level_hint }}</p>
 
-            <div style="display: flex; gap: 8px; margin-bottom: 16px;">
-                <button type="button" id="mode-vacation" class="btn" style="flex: 1; background: var(--accent); color: var(--bg);" onclick="setMode('vacation')">{{ t.vacation_mode_vacation }}</button>
-                <button type="button" id="mode-parental" class="btn secondary" style="flex: 1;" onclick="setMode('parental')">{{ t.vacation_mode_parental }}</button>
+            <div class="vacation-mode-group" role="group" aria-label="{{ t.vacation_day_level }}">
+                <button type="button" id="mode-vacation" class="btn vacation-mode-btn is-active" data-mode="vacation" aria-pressed="true" onclick="setMode('vacation')">{{ t.vacation_mode_vacation }}</button>
+                <button type="button" id="mode-parental" class="btn secondary vacation-mode-btn" data-mode="parental" aria-pressed="false" onclick="setMode('parental')">{{ t.vacation_mode_parental }}</button>
             </div>
 
             <form method="POST" action="/profile/vacation/days/sync" id="days-form">
@@ -109,76 +91,76 @@
                 <input type="hidden" name="parental_dates" id="parental-dates-input"
                     value="{% for a in parental_absences %}{{ a.date | date_format }}{% if not loop.last %},{% endif %}{% endfor %}">
 
-                <div id="day-calendar" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 12px; margin-bottom: 16px;"></div>
+                <div id="day-calendar" class="vacation-day-calendar"></div>
 
-                <div style="display: flex; justify-content: space-between; align-items: center;">
-                    <span id="day-count" style="color: var(--muted); font-size: 0.85rem;"></span>
-                    <button type="submit" class="btn">{{ t.vacation_save_days }}</button>
+                <div class="vacation-form-footer">
+                    <span id="day-count" class="vacation-day-count"></span>
+                    <button type="submit" class="btn btn-primary">{{ t.vacation_save_days }}</button>
                 </div>
             </form>
         </div>
     </div>
 
     <!-- Right column: balance + summary -->
-    <div class="col" style="min-width: 250px; flex: 1;">
+    <div class="vacation-side">
 
         <!-- Balance Card -->
         {% if balance %}
-        <div class="card" style="margin-bottom: 16px;">
-            <h3 style="margin-top: 0;">{{ t.vacation_balance_title }}</h3>
-            <div style="display: grid; grid-template-columns: repeat(5, 1fr); gap: 6px;">
-                <div style="text-align: center;">
-                    <div style="color: var(--muted); font-size: 0.7rem; margin-bottom: 4px;">{{ t.vacation_entitled }}</div>
-                    <div style="font-size: 1.2rem; font-weight: 700;">{{ balance.entitled_days }}</div>
+        <div class="card vacation-section">
+            <h3 class="vacation-section-title">{{ t.vacation_balance_title }}</h3>
+            <div class="vacation-metric-grid">
+                <div class="vacation-metric">
+                    <div class="vacation-metric-label">{{ t.vacation_entitled }}</div>
+                    <div class="vacation-metric-value">{{ balance.entitled_days }}</div>
                 </div>
-                <div style="text-align: center;">
-                    <div style="color: var(--muted); font-size: 0.7rem; margin-bottom: 4px;">{{ t.vacation_saved }}</div>
-                    <div style="font-size: 1.2rem; font-weight: 700; color: {% if balance.saved_from_previous > 0 %}var(--accent){% else %}var(--muted){% endif %};">{{ balance.saved_from_previous }}</div>
+                <div class="vacation-metric">
+                    <div class="vacation-metric-label">{{ t.vacation_saved }}</div>
+                    <div class="vacation-metric-value {% if balance.saved_from_previous > 0 %}vacation-value-positive{% else %}vacation-value-muted{% endif %}">{{ balance.saved_from_previous }}</div>
                 </div>
-                <div style="text-align: center;">
-                    <div style="color: var(--muted); font-size: 0.7rem; margin-bottom: 4px;">{{ t.vacation_total }}</div>
-                    <div style="font-size: 1.2rem; font-weight: 700;">{{ balance.total_available }}</div>
+                <div class="vacation-metric">
+                    <div class="vacation-metric-label">{{ t.vacation_total }}</div>
+                    <div class="vacation-metric-value">{{ balance.total_available }}</div>
                 </div>
-                <div style="text-align: center;">
-                    <div style="color: var(--muted); font-size: 0.7rem; margin-bottom: 4px;">{{ t.vacation_used }}</div>
-                    <div style="font-size: 1.2rem; font-weight: 700;">{{ balance.used_days }}</div>
+                <div class="vacation-metric">
+                    <div class="vacation-metric-label">{{ t.vacation_used }}</div>
+                    <div class="vacation-metric-value">{{ balance.used_days }}</div>
                 </div>
-                <div style="text-align: center;">
-                    <div style="color: var(--muted); font-size: 0.7rem; margin-bottom: 4px;">{{ t.vacation_remaining }}</div>
-                    <div style="font-size: 1.2rem; font-weight: 700; color: {% if balance.remaining_days > 5 %}var(--accent-2){% elif balance.remaining_days > 0 %}var(--warning){% else %}var(--danger){% endif %};">
+                <div class="vacation-metric">
+                    <div class="vacation-metric-label">{{ t.vacation_remaining }}</div>
+                    <div class="vacation-metric-value {% if balance.remaining_days > 5 %}vacation-value-success{% elif balance.remaining_days > 0 %}vacation-value-warning{% else %}vacation-value-danger{% endif %}">
                         {{ balance.remaining_days }}
                     </div>
                 </div>
             </div>
             {% if balance.saved_breakdown %}
-            <div style="margin-top: 8px; font-size: 0.7rem; color: var(--muted); text-align: center;">
+            <div class="vacation-small-note">
                 {{ t.vacation_saved_from }} {% for s in balance.saved_breakdown %}{{ s.year }} ({{ s.days }}d){% if not loop.last %}, {% endif %}{% endfor %}
             </div>
             {% endif %}
-            <div style="margin-top: 6px; font-size: 0.75rem; color: var(--muted); text-align: center;">
+            <div class="vacation-small-note">
                 {{ balance.year_start | date_format }} &mdash; {{ balance.year_end | date_format }}
-                {% if balance.is_first_year %}<br><span style="color: var(--warning);">{{ t.vacation_first_year }}</span>{% endif %}
+                {% if balance.is_first_year %}<br><span class="vacation-value-warning">{{ t.vacation_first_year }}</span>{% endif %}
             </div>
         </div>
 
         <!-- Projection Card (open years) -->
         {% if balance.projection %}
-        <div class="card" style="margin-bottom: 16px; border: 1px solid var(--accent); border-left: 4px solid var(--accent);">
-            <h3 style="margin-top: 0; font-size: 0.95rem;">{{ t.vacation_at_break.replace('{date}', balance.year_end | date_format) }}</h3>
-            <div style="display: grid; grid-template-columns: auto 1fr; gap: 4px 12px; font-size: 0.85rem;">
-                <span style="color: var(--muted);">{{ t.vacation_remaining_at_break }}</span>
-                <span style="font-weight: 600;">{{ balance.remaining_days }} {{ t.vacation_days_projection }}</span>
-                <span style="color: var(--muted);">{{ t.vacation_saved_next }}</span>
-                <span style="font-weight: 600; color: var(--accent-2);">{{ balance.projection.days_to_save }} {{ t.vacation_days_next_year }}</span>
+        <div class="card vacation-callout">
+            <h3 class="vacation-section-title vacation-card-title-sm">{{ t.vacation_at_break.replace('{date}', balance.year_end | date_format) }}</h3>
+            <div class="vacation-detail-grid">
+                <span class="vacation-detail-label">{{ t.vacation_remaining_at_break }}</span>
+                <span class="vacation-detail-value">{{ balance.remaining_days }} {{ t.vacation_days_projection }}</span>
+                <span class="vacation-detail-label">{{ t.vacation_saved_next }}</span>
+                <span class="vacation-detail-value vacation-detail-value--success">{{ balance.projection.days_to_save }} {{ t.vacation_days_next_year }}</span>
                 {% if balance.projection.days_to_pay_out > 0 %}
-                <span style="color: var(--muted);">{{ t.vacation_paid_out }}</span>
-                <span style="font-weight: 600;">{{ balance.projection.days_to_pay_out }} {{ t.vacation_days_payout }}</span>
-                <span style="color: var(--muted);">{{ t.vacation_payout_amount }}</span>
-                <span style="font-weight: 600; color: var(--accent-2);">{{ balance.projection.days_to_pay_out }} &times; {{ "%.0f"|format(balance.projection.payout_per_day) }} kr = {{ "{:,.0f}".format(balance.projection.payout_total).replace(",", " ") }} kr</span>
+                <span class="vacation-detail-label">{{ t.vacation_paid_out }}</span>
+                <span class="vacation-detail-value">{{ balance.projection.days_to_pay_out }} {{ t.vacation_days_payout }}</span>
+                <span class="vacation-detail-label">{{ t.vacation_payout_amount }}</span>
+                <span class="vacation-detail-value vacation-detail-value--success">{{ balance.projection.days_to_pay_out }} &times; {{ "%.0f"|format(balance.projection.payout_per_day) }} kr = {{ "{:,.0f}".format(balance.projection.payout_total).replace(",", " ") }} kr</span>
                 {% endif %}
             </div>
             {% if balance.projection.days_to_pay_out > 0 %}
-            <div style="margin-top: 8px; font-size: 0.65rem; color: var(--muted);">
+            <div class="vacation-formula-note">
                 {{ t.vacation_payout_formula }}
             </div>
             {% endif %}
@@ -187,19 +169,19 @@
 
         <!-- Closed Year Card (past years) -->
         {% if balance.closed %}
-        <div class="card" style="margin-bottom: 16px; border-left: 4px solid var(--accent-2);">
-            <h3 style="margin-top: 0; font-size: 0.95rem;">{{ t.vacation_year_closed }}</h3>
-            <div style="display: grid; grid-template-columns: auto 1fr; gap: 4px 12px; font-size: 0.85rem;">
+        <div class="card vacation-section">
+            <h3 class="vacation-section-title vacation-card-title-sm">{{ t.vacation_year_closed }}</h3>
+            <div class="vacation-detail-grid">
                 {% if balance.closed.saved > 0 %}
-                <span style="color: var(--muted);">{{ t.vacation_saved_label }}</span>
-                <span style="font-weight: 600; color: var(--accent-2);">{{ balance.closed.saved }} {{ t.vacation_days_transferred }}</span>
+                <span class="vacation-detail-label">{{ t.vacation_saved_label }}</span>
+                <span class="vacation-detail-value vacation-detail-value--success">{{ balance.closed.saved }} {{ t.vacation_days_transferred }}</span>
                 {% endif %}
                 {% if balance.closed.paid_out > 0 %}
-                <span style="color: var(--muted);">{{ t.vacation_paid_out_label }}</span>
-                <span style="font-weight: 600;">{{ balance.closed.paid_out }} {{ t.vacation_days_payout }} &rarr; {{ "{:,.0f}".format(balance.closed.payout_amount).replace(",", " ") }} kr</span>
+                <span class="vacation-detail-label">{{ t.vacation_paid_out_label }}</span>
+                <span class="vacation-detail-value">{{ balance.closed.paid_out }} {{ t.vacation_days_payout }} &rarr; {{ "{:,.0f}".format(balance.closed.payout_amount).replace(",", " ") }} kr</span>
                 {% endif %}
                 {% if balance.closed.saved == 0 and balance.closed.paid_out == 0 %}
-                <span style="color: var(--muted);" colspan="2">{{ t.vacation_all_used }}</span>
+                <span class="vacation-detail-label" colspan="2">{{ t.vacation_all_used }}</span>
                 {% endif %}
             </div>
         </div>
@@ -207,38 +189,38 @@
 
         <!-- Vacation Supplement Card -->
         {% if balance.pay %}
-        <div class="card" style="margin-bottom: 16px;">
-            <h3 style="margin-top: 0;">{{ t.vacation_supplement_title }}</h3>
-            <div style="font-size: 0.7rem; color: var(--muted); margin-bottom: 10px;">{{ t.vacation_supplement_agreement }}</div>
-            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 6px; margin-bottom: 10px;">
-                <div style="text-align: center;">
-                    <div style="color: var(--muted); font-size: 0.7rem; margin-bottom: 4px;">{{ t.vacation_fixed_per_day }}</div>
-                    <div style="font-size: 1rem; font-weight: 700;">{{ "%.0f"|format(balance.pay.fixed_per_day) }} kr</div>
-                    <div style="color: var(--muted); font-size: 0.65rem;">0,8%</div>
+        <div class="card vacation-section">
+            <h3 class="vacation-section-title">{{ t.vacation_supplement_title }}</h3>
+            <div class="vacation-copy">{{ t.vacation_supplement_agreement }}</div>
+            <div class="vacation-supplement-grid">
+                <div class="vacation-metric">
+                    <div class="vacation-supplement-label">{{ t.vacation_fixed_per_day }}</div>
+                    <div class="vacation-supplement-value">{{ "%.0f"|format(balance.pay.fixed_per_day) }} kr</div>
+                    <div class="vacation-supplement-note">0,8%</div>
                 </div>
-                <div style="text-align: center;">
-                    <div style="color: var(--muted); font-size: 0.7rem; margin-bottom: 4px;">{{ t.vacation_variable_per_day }}</div>
-                    <div style="font-size: 1rem; font-weight: 700; color: var(--accent);">{{ "%.0f"|format(balance.pay.variable_per_day) }} kr</div>
-                    <div style="color: var(--muted); font-size: 0.65rem;">0,5%</div>
+                <div class="vacation-metric">
+                    <div class="vacation-supplement-label">{{ t.vacation_variable_per_day }}</div>
+                    <div class="vacation-supplement-value vacation-value-positive">{{ "%.0f"|format(balance.pay.variable_per_day) }} kr</div>
+                    <div class="vacation-supplement-note">0,5%</div>
                 </div>
             </div>
-            <div style="text-align: center; padding: 6px; background: rgba(255,255,255,0.03); border-radius: var(--radius); margin-bottom: 10px;">
-                <div style="color: var(--muted); font-size: 0.7rem; margin-bottom: 2px;">{{ t.vacation_supplement_per_day }}</div>
-                <div style="font-size: 1.3rem; font-weight: 700; color: var(--accent-2);">{{ "%.0f"|format(balance.pay.supplement_per_day) }} kr</div>
-                <div style="color: var(--muted); font-size: 0.65rem; margin-top: 2px;">
+            <div class="vacation-supplement-total">
+                <div class="vacation-supplement-total-label">{{ t.vacation_supplement_per_day }}</div>
+                <div class="vacation-supplement-total-value">{{ "%.0f"|format(balance.pay.supplement_per_day) }} kr</div>
+                <div class="vacation-supplement-note">
                     {{ t.vacation_supplement_total.replace('{n}', balance.entitled_days|string) }}: {{ "{:,.0f}".format(balance.pay.supplement_total).replace(",", " ") }} kr
                 </div>
             </div>
-            <div style="font-size: 0.7rem; color: var(--muted);">
-                <div style="display: grid; grid-template-columns: 1fr auto; gap: 2px 8px;">
+            <div class="vacation-supplement-breakdown">
+                <div class="vacation-supplement-breakdown-grid">
                     <span>{{ t.vacation_ob_shifts }}</span>
-                    <span style="text-align: right;">{{ "{:,.0f}".format(balance.pay.ob_total).replace(",", " ") }} kr</span>
+                    <span class="vacation-supplement-breakdown-value">{{ "{:,.0f}".format(balance.pay.ob_total).replace(",", " ") }} kr</span>
                     <span>{{ t.vacation_overtime }}</span>
-                    <span style="text-align: right;">{{ "{:,.0f}".format(balance.pay.ot_total).replace(",", " ") }} kr</span>
+                    <span class="vacation-supplement-breakdown-value">{{ "{:,.0f}".format(balance.pay.ot_total).replace(",", " ") }} kr</span>
                     <span>{{ t.vacation_standby }}</span>
-                    <span style="text-align: right;">{{ "{:,.0f}".format(balance.pay.oncall_total).replace(",", " ") }} kr</span>
+                    <span class="vacation-supplement-breakdown-value">{{ "{:,.0f}".format(balance.pay.oncall_total).replace(",", " ") }} kr</span>
                 </div>
-                <div style="margin-top: 4px; padding-top: 4px; border-top: 1px solid var(--table-border);">
+                <div class="vacation-supplement-sum">
                     {{ t.vacation_variable_sum }} {{ "{:,.0f}".format(balance.pay.variable_total).replace(",", " ") }} kr
                 </div>
             </div>
@@ -247,29 +229,29 @@
         {% endif %}
 
         <!-- Week Summary -->
-        <div class="card" style="margin-bottom: 16px;">
-            <h3 style="margin-top: 0;">{{ t.vacation_selected_weeks }}</h3>
+        <div class="card vacation-section">
+            <h3 class="vacation-section-title">{{ t.vacation_selected_weeks }}</h3>
             <div id="selected-summary">
                 {% if vacation_weeks %}
                     <p><strong>{{ vacation_weeks | length }}</strong> {{ t.vacation_weeks_selected_js }}</p>
-                    <p style="color: var(--muted);">{{ vacation_weeks | join(', ') }}</p>
+                    <p class="vacation-summary-text">{{ vacation_weeks | join(', ') }}</p>
                 {% else %}
-                    <p style="color: var(--muted);">{{ t.vacation_none_selected.replace('{year}', year|string) }}</p>
+                    <p class="vacation-summary-text">{{ t.vacation_none_selected.replace('{year}', year|string) }}</p>
                 {% endif %}
             </div>
         </div>
 
         <!-- Employment start date -->
         <div class="card">
-            <h3 style="margin-top: 0;">{{ t.vacation_employment_start }}</h3>
+            <h3 class="vacation-section-title">{{ t.vacation_employment_start }}</h3>
             <form method="POST" action="/profile/vacation/settings">
-                <div style="margin-bottom: 12px;">
-                    <label style="display: block; margin-bottom: 6px; color: var(--muted); font-size: 0.85rem;">{{ t.vacation_start_date }}</label>
+                <div class="form-group">
+                    <label class="form-label">{{ t.vacation_start_date }}</label>
                     <input type="date" name="employment_start_date"
                         value="{{ user.employment_start_date | date_format }}"
-                        style="width: 100%; padding: 8px 12px; border-radius: var(--radius); border: 1px solid var(--table-border); background: var(--panel); color: var(--text); box-sizing: border-box;">
+                        class="form-input">
                 </div>
-                <button type="submit" class="btn" style="width: 100%;">{{ t.vacation_save_button }}</button>
+                <button type="submit" class="btn btn-primary login-submit">{{ t.vacation_save_button }}</button>
             </form>
         </div>
     </div>
@@ -293,10 +275,10 @@ document.addEventListener('DOMContentLoaded', function() {
         if (selectedWeeks.length > 0) {
             summary.innerHTML = `
                 <p><strong>${selectedWeeks.length}</strong> {{ t.vacation_weeks_selected_js }}</p>
-                <p style="color: var(--muted);">${selectedWeeks.join(', ')}</p>
+                <p class="vacation-summary-text">${selectedWeeks.join(', ')}</p>
             `;
         } else {
-            summary.innerHTML = '<p style="color: var(--muted);">{{ t.vacation_none_selected_js }}</p>';
+            summary.innerHTML = '<p class="vacation-summary-text">{{ t.vacation_none_selected_js }}</p>';
         }
     }
 
@@ -308,15 +290,11 @@ document.addEventListener('DOMContentLoaded', function() {
             if (index > -1) {
                 selectedWeeks.splice(index, 1);
                 this.classList.remove('selected');
-                this.style.background = 'var(--panel)';
-                this.style.color = 'var(--text)';
-                this.style.fontWeight = '400';
+                this.setAttribute('aria-pressed', 'false');
             } else {
                 selectedWeeks.push(week);
                 this.classList.add('selected');
-                this.style.background = 'var(--accent)';
-                this.style.color = 'var(--bg)';
-                this.style.fontWeight = '600';
+                this.setAttribute('aria-pressed', 'true');
             }
 
             updateSummary();
@@ -342,15 +320,11 @@ document.addEventListener('DOMContentLoaded', function() {
             if (selectedParentalWeeks.has(week)) {
                 selectedParentalWeeks.delete(week);
                 this.classList.remove('selected');
-                this.style.background = 'var(--panel)';
-                this.style.color = 'var(--text)';
-                this.style.fontWeight = '400';
+                this.setAttribute('aria-pressed', 'false');
             } else {
                 selectedParentalWeeks.add(week);
                 this.classList.add('selected');
-                this.style.background = 'var(--blue)';
-                this.style.color = 'white';
-                this.style.fontWeight = '600';
+                this.setAttribute('aria-pressed', 'true');
             }
             updateParentalWeeksInput();
         });
@@ -381,21 +355,13 @@ document.addEventListener('DOMContentLoaded', function() {
         currentMode = mode;
         const btnVac = document.getElementById('mode-vacation');
         const btnPar = document.getElementById('mode-parental');
-        if (mode === 'vacation') {
-            btnVac.style.background = 'var(--accent)';
-            btnVac.style.color = 'var(--bg)';
-            btnVac.classList.remove('secondary');
-            btnPar.style.background = '';
-            btnPar.style.color = '';
-            btnPar.classList.add('secondary');
-        } else {
-            btnPar.style.background = 'var(--blue)';
-            btnPar.style.color = 'white';
-            btnPar.classList.remove('secondary');
-            btnVac.style.background = '';
-            btnVac.style.color = '';
-            btnVac.classList.add('secondary');
-        }
+        const vacationActive = mode === 'vacation';
+        btnVac.classList.toggle('is-active', vacationActive);
+        btnVac.classList.toggle('secondary', !vacationActive);
+        btnVac.setAttribute('aria-pressed', vacationActive ? 'true' : 'false');
+        btnPar.classList.toggle('is-active', !vacationActive);
+        btnPar.classList.toggle('secondary', vacationActive);
+        btnPar.setAttribute('aria-pressed', vacationActive ? 'false' : 'true');
         updateDayCount();
     };
 
@@ -411,15 +377,15 @@ document.addEventListener('DOMContentLoaded', function() {
         calendarEl.innerHTML = '';
         for (let m = 0; m < 12; m++) {
             const monthDiv = document.createElement('div');
-            monthDiv.style.cssText = 'background: var(--panel); border-radius: var(--radius); padding: 8px; border: 1px solid var(--table-border);';
+            monthDiv.className = 'vacation-day-month';
 
             const title = document.createElement('div');
-            title.style.cssText = 'text-align: center; font-weight: 600; font-size: 0.85rem; margin-bottom: 6px;';
+            title.className = 'vacation-day-month-title';
             title.textContent = monthNames[m];
             monthDiv.appendChild(title);
 
             const grid = document.createElement('div');
-            grid.style.cssText = 'display: grid; grid-template-columns: auto repeat(7, 1fr); gap: 2px; font-size: 0.75rem;';
+            grid.className = 'vacation-day-grid';
 
             function isoWeek(dt) {
                 const d = new Date(dt.getTime());
@@ -432,18 +398,18 @@ document.addEventListener('DOMContentLoaded', function() {
             function addWkCell(dt) {
                 const wk = document.createElement('div');
                 wk.textContent = isoWeek(dt);
-                wk.style.cssText = 'text-align: right; color: var(--muted); font-size: 0.6rem; padding: 3px 4px 0 0; opacity: 0.6;';
+                wk.className = 'vacation-week-number';
                 grid.appendChild(wk);
             }
 
             // Week header + day headers
             const wkHdr = document.createElement('div');
             wkHdr.textContent = '{{ "wk" if t.html_lang == "en" else "v" }}';
-            wkHdr.style.cssText = 'text-align: right; color: var(--muted); font-size: 0.65rem; padding: 2px 4px 2px 0; opacity: 0.5;';
+            wkHdr.className = 'vacation-week-number';
             grid.appendChild(wkHdr);
             dayHeaders.forEach(dh => {
                 const hdr = document.createElement('div');
-                hdr.style.cssText = 'text-align: center; color: var(--muted); font-size: 0.65rem; padding: 2px 0;';
+                hdr.className = 'vacation-day-grid-header';
                 hdr.textContent = dh;
                 grid.appendChild(hdr);
             });
@@ -467,9 +433,11 @@ document.addEventListener('DOMContentLoaded', function() {
                 if (dayOfWeek === 0 && d > 1) addWkCell(dt);
                 const isWeekend = dayOfWeek >= 5;
 
-                const cell = document.createElement('div');
+                const cell = document.createElement('button');
+                cell.type = 'button';
                 cell.textContent = d;
                 cell.dataset.date = iso;
+                cell.setAttribute('aria-label', iso);
 
                 const isSelected = selectedDates.has(iso);
                 const isOffDay = offDays.has(iso);
@@ -481,19 +449,19 @@ document.addEventListener('DOMContentLoaded', function() {
                 function applyCellStyle(el, date) {
                     const wd = (new Date(date).getDay() + 6) % 7;
                     const color = dayColors[date] || null;
-                    if (selectedDates.has(date)) {
-                        el.style.cssText = 'text-align: center; padding: 3px 1px; border-radius: 3px; cursor: pointer; transition: all 0.1s; user-select: none; background: var(--accent); color: var(--bg); font-weight: 600;';
-                    } else if (parentalDates.has(date)) {
-                        el.style.cssText = 'text-align: center; padding: 3px 1px; border-radius: 3px; cursor: pointer; transition: all 0.1s; user-select: none; background: var(--blue); color: white; font-weight: 600;';
-                    } else {
-                        el.style.cssText = 'text-align: center; padding: 3px 1px; border-radius: 3px; cursor: pointer; transition: all 0.1s; user-select: none;'
-                            + (wd >= 5 ? ' opacity: 0.5;' : '');
-                        el.style.color = color || (wd >= 5 ? 'var(--muted)' : 'var(--text)');
-                    }
+                    el.setAttribute('aria-pressed', selectedDates.has(date) || parentalDates.has(date) ? 'true' : 'false');
+                    el.className = 'vacation-day-cell';
+                    el.classList.toggle('is-weekend', wd >= 5);
+                    el.classList.toggle('is-vacation', selectedDates.has(date));
+                    el.classList.toggle('is-parental', parentalDates.has(date));
+                    el.style.color = (!selectedDates.has(date) && !parentalDates.has(date) && color) ? color : '';
                 }
 
                 if (isOffDay) {
-                    cell.style.cssText = 'text-align: center; padding: 3px 1px; border-radius: 3px; cursor: not-allowed; user-select: none; opacity: 0.35; text-decoration: line-through;';
+                    cell.disabled = true;
+                    cell.setAttribute('aria-disabled', 'true');
+                    cell.setAttribute('aria-pressed', 'false');
+                    cell.className = 'vacation-day-cell';
                     if (shiftColor) cell.style.color = shiftColor;
                 } else {
                     applyCellStyle(cell, iso);

--- a/app/templates/week.html
+++ b/app/templates/week.html
@@ -48,7 +48,7 @@
                 {% set is_today = today is defined and day.date == today %}
 
                 <td class="calendar-day {% if is_today %}today-cell{% endif %}"
-                    style="border-top: 4px solid {% if day.shift %}{{ day.shift.color }}{% else %}#333{% endif %};">
+                    data-border-top="{% if day.shift %}{{ day.shift.color }}{% else %}#333{% endif %}">
 
                     <div class="calendar-day-content">
                         <div class="calendar-day-header">
@@ -57,9 +57,9 @@
                                 {{ day.date.day }}/{{ day.date.month }}
                             </a>
                             {% if storhelg_dates is defined and day.date in storhelg_dates %}
-                                <span class="badge badge-ob5" style="font-size:0.6rem;padding:1px 4px;">S</span>
+                                <span class="badge badge-ob5 badge-calendar-marker">S</span>
                             {% elif holiday_dates is defined and day.date in holiday_dates %}
-                                <span class="badge badge-ob4" style="font-size:0.6rem;padding:1px 4px;">H</span>
+                                <span class="badge badge-ob4 badge-calendar-marker">H</span>
                             {% endif %}
                             {# Show rotation week on each day for easy reference #}
                             {% if day.date.weekday() == 6 %}
@@ -75,7 +75,7 @@
                         <div class="calendar-day-body">
                             {% if day.shift %}
                                 <span class="badge calendar-badge"
-                                      style="background: {{ day.shift.color }}; color: {{ day.shift.color | contrast }};">
+                                      data-bg="{{ day.shift.color }}" data-fg="{{ day.shift.color | contrast }}">
                                     {{ day.shift.code }}
                                 </span>
                             {% else %}

--- a/app/templates/week_all.html
+++ b/app/templates/week_all.html
@@ -15,7 +15,7 @@
     </div>
 
     <div class="page-header-right">
-        <button id="orig-toggle-btn" onclick="toggleOriginalMode()" class="btn secondary" style="font-size:0.85rem;">
+        <button id="orig-toggle-btn" onclick="toggleOriginalMode()" class="btn secondary btn-sm">
             {% if t.html_lang == 'en' %}Show rotation{% else %}Visa rotation{% endif %}
         </button>
         {# Visa bara länk till egen week-sida, eller alla om admin #}
@@ -46,9 +46,9 @@
                         <div>
                             {{ weekday_names_short[day.date.weekday()] }}
                             {% if storhelg_dates is defined and day.date in storhelg_dates %}
-                                <span class="badge badge-ob5" style="font-size:0.55rem;padding:1px 3px;">S</span>
+                                <span class="badge badge-ob5 badge-marker-xs">S</span>
                             {% elif holiday_dates is defined and day.date in holiday_dates %}
-                                <span class="badge badge-ob4" style="font-size:0.55rem;padding:1px 3px;">H</span>
+                                <span class="badge badge-ob4 badge-marker-xs">H</span>
                             {% endif %}
                         </div>
                         <div class="date-small">{{ day.date.day }}/{{ day.date.month }}</div>
@@ -117,25 +117,24 @@
                             data-orig-color="{{ w_orig_color }}"
                             data-orig-code="{{ w_orig_code }}"
                             data-changed="{{ '1' if w_is_changed else '0' }}"
-                            style="border-left: 4px solid {% if wp and wp.shift %}{{ wp.shift.color }}{% else %}#ddd{% endif %};">
+                            data-border-left="{% if wp and wp.shift %}{{ wp.shift.color }}{% else %}#ddd{% endif %}">
 
                             {% if wp and wp.shift %}
                                 {# Länka till day-sida bara om admin eller egen (ej vikarier, de saknar dagsida) #}
                                 {% if not person_entry.is_substitute and user and (user.role.value == 'admin' or user.id == person_id) %}
                                     <a href="/day/{{ person_id }}/{{ day.date.year }}/{{ day.date.month }}/{{ day.date.day }}"
-                                       class="shift-link"
-                                       style="color: var(--text); text-decoration: none;">
+                                       class="shift-link">
                                 {% endif %}
 
                                 <div class="js-sb shift-name"
                                      data-act-label="{{ w_act_label }}"
-                                     style="color: {{ wp.shift.color }}; font-weight: 500; font-size: 0.85rem;">
-                                    {{ w_act_label }}{% if w_is_changed %}<sup class="orig-asterisk" style="display:none;">*</sup>{% endif %}
+                                     data-fg="{{ wp.shift.color }}">
+                                    {{ w_act_label }}{% if w_is_changed %}<sup class="orig-asterisk">*</sup>{% endif %}
                                 </div>
 
                                 {# Show times for OT shifts #}
                                 {% if wp.shift.code == 'OT' and wp.start and wp.end %}
-                                    <div class="shift-time" style="color: var(--muted); font-size: 0.7rem; margin-top: 2px;">
+                                    <div class="shift-time week-shift-time">
                                         {{ wp.start | time_format }}-{{ wp.end | time_format }}
                                     </div>
                                 {% endif %}
@@ -144,9 +143,8 @@
                                     </a>
                                 {% endif %}
                             {% else %}
-                                <div class="js-sb shift-name"
-                                     data-act-label="{{ t.week_shift_off }}"
-                                     style="color: var(--muted); font-size: 0.85rem;">{{ t.week_shift_off }}</div>
+                                <div class="js-sb shift-name shift-name--off"
+                                     data-act-label="{{ t.week_shift_off }}">{{ t.week_shift_off }}</div>
                             {% endif %}
                         </td>
                     {% endfor %}
@@ -190,7 +188,7 @@ function applyShiftMode() {
             // Replace text node only (preserve the <sup> child if present)
             var textNode = badge.childNodes[0];
             if (textNode && textNode.nodeType === 3) textNode.nodeValue = origCode;
-            if (asterisk) asterisk.style.display = changed ? '' : 'none';
+            if (asterisk) asterisk.style.display = changed ? 'inline' : 'none';
         } else {
             var actColor = td.dataset.actColor || '#ddd';
             td.style.borderLeftColor = actColor;

--- a/app/templates/year.html
+++ b/app/templates/year.html
@@ -34,7 +34,7 @@
     <!-- 1. Monthly summary (2 wide) -->
     <div class="year-monthly">
         <h2 class="page-title">{{ t.year_monthly_summary.replace('{year}', year|string).replace('{name}', person_name) }}</h2>
-        <p style="font-style: italic; color: #666; margin-bottom: 16px;">
+        <p class="year-intro">
             {{ t.year_table_note.replace('{y1}', (year - 1)|string).replace('{y2}', year|string) }}
         </p>
 
@@ -55,7 +55,7 @@
                 <th class="th_right" rowspan="2">{{ t.year_oncall }}</th>
                 <th class="th_right" rowspan="2">{{ t.year_ot_pay }}</th>
                 {% if has_sick_ob %}
-                <th class="th_center" colspan="3" style="border-bottom: 1px solid var(--border); font-size: 0.8rem; color: var(--muted);">{{ t.year_absence }}</th>
+                <th class="th_center year-th-group" colspan="3">{{ t.year_absence }}</th>
                 {% else %}
                 <th class="th_right" rowspan="2">{{ t.year_absence }}</th>
                 {% endif %}
@@ -64,9 +64,9 @@
             </tr>
             <tr>
                 {% if show_salary and has_sick_ob %}
-                <th class="th_right" style="font-size: 0.7rem; color: var(--muted); padding: 2px 4px;">{{ t.year_absence_salary }}</th>
-                <th class="th_right" style="font-size: 0.7rem; color: var(--ob-sick); padding: 2px 4px;">{{ t.year_absence_ob_lost }}</th>
-                <th class="th_right" style="font-size: 0.7rem; color: var(--success); padding: 2px 4px;">{{ t.year_absence_ob_comp }}</th>
+                <th class="th_right year-th-sm text-muted">{{ t.year_absence_salary }}</th>
+                <th class="th_right year-th-sm text-ob-sick">{{ t.year_absence_ob_lost }}</th>
+                <th class="th_right year-th-sm text-success">{{ t.year_absence_ob_comp }}</th>
                 {% endif %}
             </tr>
             </thead>
@@ -101,22 +101,22 @@
                     {% if has_sick_ob %}
                     {% set _ob_sick = m.sick_total_ob and m.sick_total_ob > 0 %}
                     {% set _ob_pay = m.sick_ob_pay and m.sick_ob_pay > 0 %}
-                    <td style="font-size: 0.8rem; padding: 4px 4px; text-align: {% if _aded %}right{% else %}center{% endif %}; color: var(--danger);" data-label="{{ t.year_absence_salary }}">
-                        {% if _aded %}-{{ "%.0f"|format(m.absence_deduction) }}{% else %}<span style="color: var(--muted);">0</span>{% endif %}
+                    <td class="year-cell {% if _aded %}text-right{% else %}text-center{% endif %} text-danger" data-label="{{ t.year_absence_salary }}">
+                        {% if _aded %}-{{ "%.0f"|format(m.absence_deduction) }}{% else %}<span class="text-muted">0</span>{% endif %}
                     </td>
-                    <td style="font-size: 0.8rem; padding: 4px 4px; text-align: {% if _ob_sick %}right{% else %}center{% endif %}; color: var(--ob-sick);" data-label="{{ t.year_absence_ob_lost }}">
-                        {% if _ob_sick %}-{{ "%.0f"|format(m.sick_total_ob) }}{% else %}<span style="color: var(--muted);">–</span>{% endif %}
+                    <td class="year-cell {% if _ob_sick %}text-right{% else %}text-center{% endif %} text-ob-sick" data-label="{{ t.year_absence_ob_lost }}">
+                        {% if _ob_sick %}-{{ "%.0f"|format(m.sick_total_ob) }}{% else %}<span class="text-muted">–</span>{% endif %}
                     </td>
-                    <td style="font-size: 0.8rem; padding: 4px 4px; text-align: {% if _ob_pay %}right{% else %}center{% endif %}; color: var(--success);" data-label="{{ t.year_absence_ob_comp }}">
-                        {% if _ob_pay %}+{{ "%.0f"|format(m.sick_ob_pay) }}{% else %}<span style="color: var(--muted);">–</span>{% endif %}
+                    <td class="year-cell {% if _ob_pay %}text-right{% else %}text-center{% endif %} text-success" data-label="{{ t.year_absence_ob_comp }}">
+                        {% if _ob_pay %}+{{ "%.0f"|format(m.sick_ob_pay) }}{% else %}<span class="text-muted">–</span>{% endif %}
                     </td>
                     {% else %}
-                    <td class="td_right num" style="color: {% if _aded %}var(--danger){% endif %};" data-label="{{ t.year_absence }}">
+                    <td class="td_right num {% if _aded %}text-danger{% endif %}" data-label="{{ t.year_absence }}">
                         {% if _aded %}-{{ "%.0f"|format(m.absence_deduction) }}{% else %}0{% endif %}
                     </td>
                     {% endif %}
                     {% if vacation_pay %}
-                    <td class="td_right num" data-label="{{ t.year_sem_vacation_col }}" style="{% if m.vacation_supplement %}color: var(--accent-2);{% endif %}">
+                    <td class="td_right num {% if m.vacation_supplement %}text-accent2{% endif %}" data-label="{{ t.year_sem_vacation_col }}">
                         {% if m.vacation_supplement %}{{ "%.0f"|format(m.vacation_supplement) }}{% else %}0{% endif %}
                     </td>
                     {% endif %}
@@ -142,22 +142,22 @@
                 {% if has_sick_ob %}
                 {% set _ttob = year_summary.total_sick_total_ob and year_summary.total_sick_total_ob > 0 %}
                 {% set _top = year_summary.total_sick_ob_pay and year_summary.total_sick_ob_pay > 0 %}
-                <td style="font-size: 0.8rem; padding: 4px 4px; text-align: {% if _tded %}right{% else %}center{% endif %}; color: var(--danger);" data-label="{{ t.year_absence_salary }}">
-                    <strong>{% if _tded %}-{{ "%.0f"|format(year_summary.total_absence_deduction) }}{% else %}<span style="color: var(--muted);">0</span>{% endif %}</strong>
+                <td class="year-cell {% if _tded %}text-right{% else %}text-center{% endif %} text-danger" data-label="{{ t.year_absence_salary }}">
+                    <strong>{% if _tded %}-{{ "%.0f"|format(year_summary.total_absence_deduction) }}{% else %}<span class="text-muted">0</span>{% endif %}</strong>
                 </td>
-                <td style="font-size: 0.8rem; padding: 4px 4px; text-align: {% if _ttob %}right{% else %}center{% endif %}; color: var(--ob-sick);" data-label="{{ t.year_absence_ob_lost }}">
-                    <strong>{% if _ttob %}-{{ "%.0f"|format(year_summary.total_sick_total_ob) }}{% else %}<span style="color: var(--muted);">–</span>{% endif %}</strong>
+                <td class="year-cell {% if _ttob %}text-right{% else %}text-center{% endif %} text-ob-sick" data-label="{{ t.year_absence_ob_lost }}">
+                    <strong>{% if _ttob %}-{{ "%.0f"|format(year_summary.total_sick_total_ob) }}{% else %}<span class="text-muted">–</span>{% endif %}</strong>
                 </td>
-                <td style="font-size: 0.8rem; padding: 4px 4px; text-align: {% if _top %}right{% else %}center{% endif %}; color: var(--success);" data-label="{{ t.year_absence_ob_comp }}">
-                    <strong>{% if _top %}+{{ "%.0f"|format(year_summary.total_sick_ob_pay) }}{% else %}<span style="color: var(--muted);">–</span>{% endif %}</strong>
+                <td class="year-cell {% if _top %}text-right{% else %}text-center{% endif %} text-success" data-label="{{ t.year_absence_ob_comp }}">
+                    <strong>{% if _top %}+{{ "%.0f"|format(year_summary.total_sick_ob_pay) }}{% else %}<span class="text-muted">–</span>{% endif %}</strong>
                 </td>
                 {% else %}
-                <td class="td_right foot_right num" style="color: {% if _tded %}var(--danger){% endif %};" data-label="{{ t.year_absence }}">
+                <td class="td_right foot_right num {% if _tded %}text-danger{% endif %}" data-label="{{ t.year_absence }}">
                     <strong>{% if _tded %}-{{ "%.0f"|format(year_summary.total_absence_deduction) }}{% else %}0{% endif %}</strong>
                 </td>
                 {% endif %}
                 {% if vacation_pay %}
-                <td class="td_right foot_right num" data-label="{{ t.year_sem_vacation_col }}" style="color: var(--accent-2);">{{ "%.0f"|format(year_summary.total_vacation_supplement or 0) }}</td>
+                <td class="td_right foot_right num text-accent2" data-label="{{ t.year_sem_vacation_col }}">{{ "%.0f"|format(year_summary.total_vacation_supplement or 0) }}</td>
                 {% endif %}
                 {% endif %}
             </tr>
@@ -178,29 +178,29 @@
                 {% if has_sick_ob %}
                 {% set _asto = year_summary.avg_sick_total_ob and year_summary.avg_sick_total_ob > 0 %}
                 {% set _asop = year_summary.avg_sick_ob_pay and year_summary.avg_sick_ob_pay > 0 %}
-                <td style="font-size: 0.8rem; padding: 4px 4px; text-align: {% if _aed %}right{% else %}center{% endif %}; color: var(--danger);" data-label="{{ t.year_absence_salary }}">
-                    {% if _aed %}-{{ "%.0f"|format(year_summary.avg_absence_deduction) }}{% else %}<span style="color: var(--muted);">0</span>{% endif %}
+                <td class="year-cell {% if _aed %}text-right{% else %}text-center{% endif %} text-danger" data-label="{{ t.year_absence_salary }}">
+                    {% if _aed %}-{{ "%.0f"|format(year_summary.avg_absence_deduction) }}{% else %}<span class="text-muted">0</span>{% endif %}
                 </td>
-                <td style="font-size: 0.8rem; padding: 4px 4px; text-align: {% if _asto %}right{% else %}center{% endif %}; color: var(--ob-sick);" data-label="{{ t.year_absence_ob_lost }}">
-                    {% if _asto %}-{{ "%.0f"|format(year_summary.avg_sick_total_ob) }}{% else %}<span style="color: var(--muted);">–</span>{% endif %}
+                <td class="year-cell {% if _asto %}text-right{% else %}text-center{% endif %} text-ob-sick" data-label="{{ t.year_absence_ob_lost }}">
+                    {% if _asto %}-{{ "%.0f"|format(year_summary.avg_sick_total_ob) }}{% else %}<span class="text-muted">–</span>{% endif %}
                 </td>
-                <td style="font-size: 0.8rem; padding: 4px 4px; text-align: {% if _asop %}right{% else %}center{% endif %}; color: var(--success);" data-label="{{ t.year_absence_ob_comp }}">
-                    {% if _asop %}+{{ "%.0f"|format(year_summary.avg_sick_ob_pay) }}{% else %}<span style="color: var(--muted);">–</span>{% endif %}
+                <td class="year-cell {% if _asop %}text-right{% else %}text-center{% endif %} text-success" data-label="{{ t.year_absence_ob_comp }}">
+                    {% if _asop %}+{{ "%.0f"|format(year_summary.avg_sick_ob_pay) }}{% else %}<span class="text-muted">–</span>{% endif %}
                 </td>
                 {% else %}
-                <td class="td_right foot_right num" style="color: {% if _aed %}var(--danger){% endif %};" data-label="{{ t.year_absence }}">
+                <td class="td_right foot_right num {% if _aed %}text-danger{% endif %}" data-label="{{ t.year_absence }}">
                     {% if _aed %}-{{ "%.0f"|format(year_summary.avg_absence_deduction) }}{% else %}0{% endif %}
                 </td>
                 {% endif %}
                 {% if vacation_pay %}
-                <td class="td_right foot_right num" data-label="{{ t.year_sem_vacation_col }}" style="color: var(--accent-2);">{{ "%.0f"|format(year_summary.avg_vacation_supplement or 0) }}</td>
+                <td class="td_right foot_right num text-accent2" data-label="{{ t.year_sem_vacation_col }}">{{ "%.0f"|format(year_summary.avg_vacation_supplement or 0) }}</td>
                 {% endif %}
                 {% endif %}
             </tr>
             </tfoot>
         </table>
         {% if show_salary and has_sick_ob %}
-        <p style="font-size: 0.75rem; color: var(--muted); margin-top: 6px;">{{ t.year_absence_ob_sick_note }}</p>
+        <p class="year-note">{{ t.year_absence_ob_sick_note }}</p>
         {% endif %}
     </div>
 
@@ -310,48 +310,48 @@
                     <td class="td_left" data-label="{{ t.year_type_col }}">{{ t.year_sick_leave }}</td>
                     <td class="td_right num" data-label="{{ t.year_days_col }}">{{ year_summary.total_sick_days or 0 }}</td>
                     <td class="td_right num" data-label="{{ t.year_hours_col }}">{{ "%.1f"|format(year_summary.total_sick_hours or 0) }}</td>
-                    <td class="td_right num" data-label="{{ t.year_deduction_col }}" style="color: var(--danger);">-{{ "%.0f"|format(year_summary.sick_deduction or 0) }} kr</td>
+                    <td class="td_right num text-danger" data-label="{{ t.year_deduction_col }}">-{{ "%.0f"|format(year_summary.sick_deduction or 0) }} kr</td>
                 </tr>
                 {% if year_summary.total_sick_ob_lost and year_summary.total_sick_ob_lost > 0 %}
                 <tr class="shift-row">
-                    <td class="td_left" data-label="{{ t.year_type_col }}" style="color: var(--ob-sick); padding-left: 1.5rem; font-size: 0.85rem;">&#x21B3; {{ t.year_sick_ob_lost_label }}</td>
+                    <td class="td_left year-type-cell text-ob-sick" data-label="{{ t.year_type_col }}">&#x21B3; {{ t.year_sick_ob_lost_label }}</td>
                     <td class="td_right num"></td>
                     <td class="td_right num"></td>
-                    <td class="td_right num" style="color: var(--ob-sick);">-{{ "%.0f"|format(year_summary.total_sick_ob_lost) }} kr</td>
+                    <td class="td_right num text-ob-sick">-{{ "%.0f"|format(year_summary.total_sick_ob_lost) }} kr</td>
                 </tr>
                 {% endif %}
                 {% if year_summary.total_sick_ob_pay and year_summary.total_sick_ob_pay > 0 %}
                 <tr class="shift-row">
-                    <td class="td_left" data-label="{{ t.year_type_col }}" style="color: var(--success); padding-left: 1.5rem; font-size: 0.85rem;">&#x21B3; {{ t.year_sick_ob_label }}</td>
+                    <td class="td_left year-type-cell text-success" data-label="{{ t.year_type_col }}">&#x21B3; {{ t.year_sick_ob_label }}</td>
                     <td class="td_right num"></td>
                     <td class="td_right num"></td>
-                    <td class="td_right num" style="color: var(--success);">+{{ "%.0f"|format(year_summary.total_sick_ob_pay) }} kr</td>
+                    <td class="td_right num text-success">+{{ "%.0f"|format(year_summary.total_sick_ob_pay) }} kr</td>
                 </tr>
                 {% endif %}
                 <tr class="shift-row">
                     <td class="td_left" data-label="{{ t.year_type_col }}">{{ t.year_vab_label }}</td>
                     <td class="td_right num" data-label="{{ t.year_days_col }}">{{ year_summary.total_vab_days or 0 }}</td>
                     <td class="td_right num" data-label="{{ t.year_hours_col }}">{{ "%.1f"|format(year_summary.total_vab_hours or 0) }}</td>
-                    <td class="td_right num" data-label="{{ t.year_deduction_col }}" style="color: var(--ob-sick);">-{{ "%.0f"|format(year_summary.vab_deduction or 0) }} kr</td>
+                    <td class="td_right num text-ob-sick" data-label="{{ t.year_deduction_col }}">-{{ "%.0f"|format(year_summary.vab_deduction or 0) }} kr</td>
                 </tr>
                 <tr class="shift-row">
                     <td class="td_left" data-label="{{ t.year_type_col }}">{{ t.year_leave_label }}</td>
                     <td class="td_right num" data-label="{{ t.year_days_col }}">{{ year_summary.total_leave_days or 0 }}</td>
                     <td class="td_right num" data-label="{{ t.year_hours_col }}">{{ "%.1f"|format(year_summary.total_leave_hours or 0) }}</td>
-                    <td class="td_right num" data-label="{{ t.year_deduction_col }}" style="color: var(--ob5);">-{{ "%.0f"|format(year_summary.leave_deduction or 0) }} kr</td>
+                    <td class="td_right num text-ob5" data-label="{{ t.year_deduction_col }}">-{{ "%.0f"|format(year_summary.leave_deduction or 0) }} kr</td>
                 </tr>
                 <tr class="shift-row">
                     <td class="td_left" data-label="{{ t.year_type_col }}">{{ t.year_off_label }}</td>
                     <td class="td_right num" data-label="{{ t.year_days_col }}">{{ year_summary.total_off_days or 0 }}</td>
                     <td class="td_right num" data-label="{{ t.year_hours_col }}">{{ "%.1f"|format(year_summary.total_off_hours or 0) }}</td>
-                    <td class="td_right num" data-label="{{ t.year_deduction_col }}" style="color: #888888;">{{ "%.0f"|format(year_summary.off_deduction or 0) }} kr</td>
+                    <td class="td_right num text-gray" data-label="{{ t.year_deduction_col }}">{{ "%.0f"|format(year_summary.off_deduction or 0) }} kr</td>
                 </tr>
                 {% if year_summary.total_parental_days %}
                 <tr class="shift-row">
                     <td class="td_left" data-label="{{ t.year_type_col }}">{{ t.year_parental_label }}</td>
                     <td class="td_right num" data-label="{{ t.year_days_col }}">{{ year_summary.total_parental_days or 0 }}</td>
                     <td class="td_right num" data-label="{{ t.year_hours_col }}">{{ "%.1f"|format(year_summary.total_parental_hours or 0) }}</td>
-                    <td class="td_right num" data-label="{{ t.year_deduction_col }}" style="color: var(--blue);">{{ "%.0f"|format(0) }} kr</td>
+                    <td class="td_right num text-blue" data-label="{{ t.year_deduction_col }}">{{ "%.0f"|format(0) }} kr</td>
                 </tr>
                 {% endif %}
             </tbody>
@@ -360,7 +360,7 @@
                     <td class="td_left foot_left" data-label="{{ t.year_type_col }}"><strong>{{ t.year_total }}</strong></td>
                     <td class="td_right foot_right num" data-label="{{ t.year_days_col }}"><strong>{{ (year_summary.total_sick_days or 0) + (year_summary.total_vab_days or 0) + (year_summary.total_leave_days or 0) + (year_summary.total_off_days or 0) + (year_summary.total_parental_days or 0) }}</strong></td>
                     <td class="td_right foot_right num" data-label="{{ t.year_hours_col }}"><strong>{{ "%.1f"|format((year_summary.total_sick_hours or 0) + (year_summary.total_vab_hours or 0) + (year_summary.total_leave_hours or 0) + (year_summary.total_off_hours or 0) + (year_summary.total_parental_hours or 0)) }}</strong></td>
-                    <td class="td_right foot_right num" data-label="{{ t.year_deduction_col }}" style="color: var(--danger);">
+                    <td class="td_right foot_right num text-danger" data-label="{{ t.year_deduction_col }}">
                         <strong>-{{ "%.0f"|format(year_summary.total_absence_deduction or 0) }} kr</strong>
                     </td>
                 </tr>
@@ -396,11 +396,11 @@
                 <tr>
                     <td class="td_left foot_left" data-label="{{ t.year_type_col }}"><strong>{{ t.year_supplement_row }}</strong></td>
                     <td class="td_right foot_right num" data-label="{{ t.year_per_day_col }}"><strong>{{ "%.0f"|format(vacation_pay.pay.supplement_per_day) }} kr</strong></td>
-                    <td class="td_right foot_right num" data-label="{{ t.year_amount_col }}" style="color: var(--accent-2);"><strong>{{ "%.0f"|format(vacation_pay.pay.supplement_per_day * vacation_pay.used_days) }} kr</strong></td>
+                    <td class="td_right foot_right num text-accent2" data-label="{{ t.year_amount_col }}"><strong>{{ "%.0f"|format(vacation_pay.pay.supplement_per_day * vacation_pay.used_days) }} kr</strong></td>
                 </tr>
             </tfoot>
         </table>
-        <div style="margin-top: 8px; font-size: 0.8rem; color: var(--muted);">
+        <div class="year-foot-note">
             {{ t.year_vacation_balance_note.replace('{entitled}', vacation_pay.entitled_days|string).replace('{used}', vacation_pay.used_days|string).replace('{remaining}', vacation_pay.remaining_days|string).replace('{start}', vacation_pay.year_start | date_format).replace('{end}', vacation_pay.year_end | date_format) }}
         </div>
     </div>
@@ -410,7 +410,7 @@
     <div class="year-cowork">
         <h2 class="page-title">
             {{ t.year_cowork_title.replace('{year}', year|string).replace('{name}', person_name) }}
-            <a href="/cowork/{{ person_id }}?year={{ year }}" class="btn secondary" style="font-size: 0.8em; margin-left: 0.75rem;">{{ t.year_cowork_detailed }}</a>
+            <a href="/cowork/{{ person_id }}?year={{ year }}" class="btn secondary year-cowork-link">{{ t.year_cowork_detailed }}</a>
         </h2>
 
         <table class="summary">

--- a/app/templates/year_all.html
+++ b/app/templates/year_all.html
@@ -31,18 +31,18 @@
 
 <h2 class="page-title">{{ t.year_all_title.replace('{year}', year|string) }}</h2>
 
-    <div style="display:flex;flex-wrap:wrap;gap:0.5rem;margin-bottom:0.75rem;padding:0.5rem 0.75rem;background:var(--panel);border-radius:var(--radius);border:1px solid var(--border);align-items:center;">
-        <button onclick="setAllPersonCols(true)" class="btn secondary" style="font-size:0.8rem;padding:2px 8px;">Markera alla</button>
-        <button onclick="setAllPersonCols(false)" class="btn secondary" style="font-size:0.8rem;padding:2px 8px;">Avmarkera alla</button>
-        <span style="color:var(--border);margin:0 0.25rem;">|</span>
+    <div class="col-toggle-bar">
+        <button onclick="setAllPersonCols(true)" class="btn secondary btn-xs">Markera alla</button>
+        <button onclick="setAllPersonCols(false)" class="btn secondary btn-xs">Avmarkera alla</button>
+        <span class="col-sep">|</span>
         {% for p in person_headers %}
-        <label style="display:flex;align-items:center;gap:0.3rem;cursor:pointer;font-size:0.85rem;user-select:none;">
-            <input type="checkbox" checked onchange="togglePersonCol({{ p.person_id }}, this.checked)" style="cursor:pointer;">
+        <label class="col-toggle-label">
+            <input type="checkbox" checked onchange="togglePersonCol({{ p.person_id }}, this.checked)" class="cursor-pointer">
             {{ p.person_name }}
         </label>
         {% endfor %}
-        <span style="color:var(--border);margin:0 0.25rem;">|</span>
-        <button id="orig-toggle-btn" onclick="toggleOriginalMode()" class="btn secondary" style="font-size:0.8rem;padding:2px 8px;">
+        <span class="col-sep">|</span>
+        <button id="orig-toggle-btn" onclick="toggleOriginalMode()" class="btn secondary btn-xs">
             {% if t.html_lang == 'en' %}Show rotation{% else %}Visa rotation{% endif %}
         </button>
     </div>
@@ -57,7 +57,7 @@
                         <th></th>
                         {% for p in person_headers %}
                             <th class="num" id="total-{{ p.person_id }}" data-person="{{ p.person_id }}">
-                                <span class="loading-spinner" style="color: #999; font-size: 0.9em;">...</span>
+                                <span class="loading-spinner">...</span>
                             </th>
                         {% endfor %}
                     </tr>
@@ -91,9 +91,9 @@
                                 <a href="/week?year={{ day.date.isocalendar()[0] }}&week={{ day.date.isocalendar()[1] }}" class="rotation-week-small">v{{ day.date.isocalendar()[1] }}</a>
                             {% endif %}
                             {% if storhelg_dates is defined and day.date in storhelg_dates %}
-                                <span class="badge badge-ob5" style="font-size:0.55rem;padding:1px 3px;">S</span>
+                                <span class="badge badge-ob5 badge-marker-xs">S</span>
                             {% elif holiday_dates is defined and day.date in holiday_dates %}
-                                <span class="badge badge-ob4" style="font-size:0.55rem;padding:1px 3px;">H</span>
+                                <span class="badge badge-ob4 badge-marker-xs">H</span>
                             {% endif %}
                         </td>
                         {% for person in day.persons %}
@@ -105,28 +105,28 @@
                                 data-orig-color="{{ orig_color }}"
                                 data-orig-code="{{ orig_code }}"
                                 data-changed="{{ '1' if is_changed else '0' }}"
-                                style="border-left:6px solid {% if person.shift %}{{ person.shift.color }}{% else %}transparent{% endif %}; padding-left:8px;">
+                                data-border-left="{% if person.shift %}{{ person.shift.color }}{% else %}transparent{% endif %}">
                                 {% if person.shift %}
                                     {# Länka till day-sida bara om admin eller egen #}
                                     {% if user and (user.role.value == 'admin' or user.rotation_person_id == person.person_id) %}
                                         {% set link_id = user.id if user.rotation_person_id == person.person_id else person.person_id %}
                                         <a href="/day/{{ link_id }}/{{ day.date.year }}/{{ day.date.month }}/{{ day.date.day }}"
-                                           style="text-decoration:none;">
+                                           class="plain-link">
                                     {% endif %}
                                         {% if person.shift.code == 'SEM' %}
                                             <span class="badge badge-sem js-sb"
                                                   title="{{ t.month_shift_sem_title }}"
                                                   data-act-label="SEM"
-                                                  style="background: {{ person.shift.color }}; color: {{ person.shift.color | contrast }};">SEM</span>{% if is_changed %}<sup class="orig-asterisk" style="display:none;">*</sup>{% endif %}
+                                                  data-bg="{{ person.shift.color }}" data-fg="{{ person.shift.color | contrast }}">SEM</span>{% if is_changed %}<sup class="orig-asterisk">*</sup>{% endif %}
                                         {% elif person.shift.code == 'OT' %}
                                             <span class="badge js-sb"
                                                   {% if person.start and person.end %}title="{{ t.month_shift_ot_title.replace('{start}', person.start | time_format).replace('{end}', person.end | time_format) }}"{% endif %}
                                                   data-act-label="OT"
-                                                  style="background: {{ person.shift.color }}; color: {{ person.shift.color | contrast }};">OT</span>{% if is_changed %}<sup class="orig-asterisk" style="display:none;">*</sup>{% endif %}
+                                                  data-bg="{{ person.shift.color }}" data-fg="{{ person.shift.color | contrast }}">OT</span>{% if is_changed %}<sup class="orig-asterisk">*</sup>{% endif %}
                                         {% else %}
                                             <span class="badge js-sb"
                                                   data-act-label="{{ person.shift.code }}"
-                                                  style="background: {{ person.shift.color }}; color: {{ person.shift.color | contrast }};">{{ person.shift.code }}</span>{% if is_changed %}<sup class="orig-asterisk" style="display:none;">*</sup>{% endif %}
+                                                  data-bg="{{ person.shift.color }}" data-fg="{{ person.shift.color | contrast }}">{{ person.shift.code }}</span>{% if is_changed %}<sup class="orig-asterisk">*</sup>{% endif %}
                                         {% endif %}
                                     {% if user and (user.role.value == 'admin' or user.rotation_person_id == person.person_id) %}
                                         </a>
@@ -233,7 +233,7 @@ function applyShiftMode() {
             badge.style.background = origColor;
             badge.style.color = _contrast(origColor);
             badge.textContent = origCode;
-            if (asterisk) asterisk.style.display = changed ? '' : 'none';
+            if (asterisk) asterisk.style.display = changed ? 'inline' : 'none';
         } else {
             var actColor = td.dataset.actColor || 'transparent';
             td.style.borderLeftColor = actColor;
@@ -316,7 +316,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 console.error(`[Year View] Error loading total for person ${personId}:`, error);
                 const totalCell = document.getElementById(`total-${personId}`);
                 if (totalCell) {
-                    totalCell.innerHTML = '<span style="color: var(--danger);">✗</span>';
+                    totalCell.innerHTML = '<span class="text-danger">✗</span>';
                 }
             });
     });

--- a/docs/design-system-plan.md
+++ b/docs/design-system-plan.md
@@ -71,12 +71,12 @@ empty void). Stat cards become an instrument cluster of monospace readouts.
 
 ## Critique vs templated defaults
 
-The three current AI-default looks are: cream + serif + terracotta; near-black +
-one loud accent; broadsheet hairlines. This plan sits near #2 but **inverts** it:
-it removes the single loud accent and makes the chrome near-colourless so the
-data is the only chromatic event. The monospace instrument numerals and the
-board framing are subject-specific. It avoids the default by turning it inside
-out, not by accidentally resembling it.
+Common templated product looks lean on cream + serif + terracotta, near-black +
+one loud accent, or broadsheet hairlines. This plan sits near the dark product
+category but **inverts** it: it removes the single loud accent and makes the
+chrome near-colourless so the data is the only chromatic event. The monospace
+instrument numerals and the board framing are subject-specific. It avoids the
+default by turning it inside out, not by accidentally resembling it.
 
 ## Implementation order
 


### PR DESCRIPTION
## Summary

Removes inline `style="..."` attributes from every Jinja template, moving
them into shared and page-scoped CSS classes and `data-*` attributes. The
whole template set now carries **zero inline style attributes**, with no
intended visual or behavioural change.

This builds on the in-progress design-hardening work (focus rings, 44px touch
targets, ARIA state on the nav, dialog and popover patterns) and completes the
style-attribute side of it across the app.

## What changed

- **Inline styles to classes:** every template's `style="..."` attributes are
  now classes in `components.css` / `calendar.css` or small page-scoped
  `<style>` blocks.
- **Data-driven shift colours:** admin-configured shift colours (which can't
  live in static CSS) are emitted as `data-bg` / `data-fg` / `data-border-*`
  attributes and applied by a new `static/js/shift-colors.js`, loaded once from
  `base.html`. The week/month/year "original rotation" toggles now route through
  the same mechanism.
- **Toggle logic:** edit/breakdown/pay-override toggles switched from reading
  inline `style.display` to `hidden` attributes / class switches and
  `getComputedStyle`, so they keep working now that defaults live in CSS.
- **Docs:** adds `PRODUCT.md` capturing product register, users, brand
  personality, design principles and accessibility goals.

## Testing

- Every page returns 200 when logged in (schedule week/month/year individual
  and all-team, dashboard, statistics, profile, vacation, day, and all admin
  pages).
- Spot-checked rendering against the previous version: visually identical, with
  shift colours, charts and interactive toggles (pay override, dialogs,
  popovers, column toggles, day calendars) all intact.

## Out of scope

A strict `Content-Security-Policy` (dropping `'unsafe-inline'`) is not enabled
here: inline `<style>`/`<script>` blocks and `onclick` handlers remain, which
would need externalising or nonces first. This PR only removes inline style
attributes.