### PR TITLE
Allow manual production deploy without a new version tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch: {}
 
 jobs:
   deploy:
@@ -25,7 +26,7 @@ jobs:
           port: 2222
           script_stop: true
           script: |
-            GITEA_TOKEN=${{ secrets.GITEA_TOKEN }} bash ${{ secrets.PROD_APP_PATH }}/scripts/deploy.sh ${{ secrets.PROD_APP_PATH }} ${{ github.ref_name }}
+            GITEA_TOKEN=${{ secrets.GITEA_TOKEN }} bash ${{ secrets.PROD_APP_PATH }}/scripts/deploy.sh ${{ secrets.PROD_APP_PATH }} ${{ github.ref_type == 'tag' && github.ref_name || '' }}
 
       - name: Notify Success
         if: success()


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` trigger to the production deploy workflow so `main`
can be deployed on demand, without cutting a new version tag.

## Why

Deploy was only triggered by pushing a `v*` tag, which forced a version bump
for every deploy. The prod `deploy.sh` already supports both modes (checkout a
tag, or fast-forward `origin/main` when no tag is given); only the workflow
trigger required a tag.

## What changed

- `deploy.yml`: add `workflow_dispatch` trigger alongside the existing `v*` tag
  trigger.
- Pass the ref name to `deploy.sh` only for tag pushes
  (`github.ref_type == 'tag' && github.ref_name || ''`), so a manual run
  deploys the latest `main` via the existing ff-merge path.

## Result

- **Tag release (unchanged):** `./scripts/release.sh v0.28.0` tags and deploys,
  and sets the displayed version (via changelog.py).
- **Tag-free deploy:** `gh workflow run deploy.yml --ref main` (or the Run
  workflow button) deploys the latest main. The displayed version is unchanged
  since it is driven by changelog.py, not the deploy.

Note: the displayed app version stays decoupled from deploys; bump changelog.py
when you want the version number to change.