### PR TITLE
Add --notag mode to release.sh for tag-free deploys

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,12 +1,29 @@
 #!/bin/bash
 set -e
 
-TAG=$1
-if [ -z "$TAG" ]; then
-    echo "Usage: ./release.sh <tag>  (e.g. ./release.sh v0.12.1)"
+MODE=$1
+if [ -z "$MODE" ]; then
+    echo "Usage:"
+    echo "  ./release.sh <tag>     Tag main and deploy (e.g. ./release.sh v0.28.0)"
+    echo "  ./release.sh --notag   Deploy current main without creating a tag"
     exit 1
 fi
 
+# Tag-free deploy: trigger the deploy workflow against main. The displayed app
+# version (from changelog.py) is unchanged; this only ships the latest main.
+if [ "$MODE" = "--notag" ]; then
+    if ! command -v gh >/dev/null 2>&1; then
+        echo "Error: gh (GitHub CLI) is required for --notag deploys." >&2
+        exit 1
+    fi
+    echo "Triggering deploy of main (no tag)..."
+    gh workflow run deploy.yml --ref main
+    echo "Deploy triggered. Follow it with: gh run watch"
+    exit 0
+fi
+
+# Versioned release: tag main and push the tag, which triggers the deploy.
+TAG="$MODE"
 git checkout main
 git pull
 git tag "$TAG"


### PR DESCRIPTION
## Summary

Adds a `--notag` mode to `scripts/release.sh` so production can be deployed
without creating a version tag. Follows up #270, which added the
`workflow_dispatch` trigger that this relies on.

## Usage

- **Tag release (unchanged):** `./scripts/release.sh v0.28.0` tags main and
  deploys.
- **Tag-free deploy:** `./scripts/release.sh --notag` triggers the deploy
  workflow against main (equivalent to `gh workflow run deploy.yml --ref main`).

Requires the GitHub CLI (`gh`) on the machine running the script. The displayed
app version comes from changelog.py and stays decoupled from deploys.