### PR TITLE
Fix mobile layout for schedule matrix, week/day views, and dashboard hero

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -125,6 +125,22 @@ from app.routes.shared import templates as _templates  # noqa: E402
 
 _templates.env.globals["app_version"] = _VERSIONS[0]["version"]
 
+
+def _compute_static_version() -> str:
+    """Hash the CSS files' contents so the cache-busting query string changes
+    whenever a stylesheet actually changes, independent of the changelog version
+    (which is bumped manually and not always updated for CSS-only releases)."""
+    import hashlib
+
+    css_dir = Path("app/static/css")
+    digest = hashlib.sha256()
+    for css_file in sorted(css_dir.glob("*.css")):
+        digest.update(css_file.read_bytes())
+    return digest.hexdigest()[:10]
+
+
+_templates.env.globals["static_version"] = _compute_static_version()
+
 app = FastAPI(
     title="Periodical",
     description="Employee shift scheduling and OB pay calculation system",

--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -15,6 +15,27 @@ router = APIRouter()
 
 VERSIONS = [
     {
+        "version": "0.27.1",
+        "date": "2026-07-04",
+        "entries": [
+            {
+                "type": "fix",
+                "sv": "Månads- och årsvyn (alla): schemat går nu att läsa på mobilen. Veckodag- och datumkolumnerna fryses medan personernas kolumner rullar under, och raderna är kompaktare så fler personer syns innan du behöver scrolla i sidled",
+                "en": "Month and year view (all): the schedule is now readable on mobile. The weekday and date columns freeze while the people columns scroll underneath, and rows are more compact so more people fit before you need to scroll sideways",
+            },
+            {
+                "type": "fix",
+                "sv": "Veckovyn (alla) behåller sin scrollbara tabell med fryst namnkolumn på mobilen i stället för att kollapsa till en oläslig stapel. Din egen vecka, månad och årssammanställning visas nu som riktiga listor och tabeller i stället för smala kort med tomt utrymme",
+                "en": "Team week view keeps its scrollable table with a frozen name column on mobile instead of collapsing into an unreadable stack. Your own week, month and year summary now render as proper lists and tables instead of narrow cards with empty space",
+            },
+            {
+                "type": "fix",
+                "sv": "Dagvyn på mobilen: skiftbytes- och övertidsformulären, tabellerna (vem jobbar, OB-timmar, OB-lön) och dagnavigeringen är nu ryddiga i stället för att klippas eller radbrytas fult. Startsidans avläsning för nästa pass och nettolön får också mer plats på smala skärmar",
+                "en": "Day view on mobile: the shift-swap and overtime forms, the tables (who is working, OB hours, OB pay) and the day navigation are now tidy instead of clipping or wrapping raggedly. The dashboard's next-shift and net-pay readout also gets more room on narrow screens",
+            },
+        ],
+    },
+    {
         "version": "0.27.0",
         "date": "2026-06-27",
         "entries": [

--- a/app/static/css/base.css
+++ b/app/static/css/base.css
@@ -51,6 +51,14 @@
 
   --radius: 0.5rem;
 
+  /* Stacking order. These names are referenced across tables.css and
+     navigation.css; without a definition they resolved to z-index:auto, leaving
+     sticky headers/columns and the mobile nav to fall back on paint order.
+     sticky (table chrome) < modal (nav panel) < tooltip (toggle above panel). */
+  --z-sticky: 5;
+  --z-modal: 50;
+  --z-tooltip: 60;
+
   /* Back-compat aliases (existing names kept, same resolved values) */
   --background: var(--bg);
   --accent-2: var(--success);

--- a/app/static/css/calendar.css
+++ b/app/static/css/calendar.css
@@ -114,3 +114,17 @@ a.rotation-week-small:hover { color: var(--text); }
   .week-grid-all .person-name-cell { min-width: 80px; font-size: 0.8rem; padding: 8px; }
   .week-grid-all .shift-cell { padding: 6px 4px; }
 }
+
+/* Personal week/month calendars: on mobile the generic card rule stacks each day
+   into a block. Make those blocks full width and content-height so they read as a
+   tidy day list instead of narrow, fixed-height cards with empty space to the
+   right. (The team week grid .week-grid-all is excluded from the card rule in
+   tables.css and keeps its horizontal-scroll table layout instead.) */
+@media (max-width: 800px) {
+  .week-grid-single .calendar-day,
+  .calendar-grid tbody td {
+    width: 100%;
+    height: auto;
+  }
+  .calendar-day-content { height: auto; }
+}

--- a/app/static/css/components.css
+++ b/app/static/css/components.css
@@ -211,10 +211,20 @@ input, select {
   button, .btn { padding: 0.625rem 1rem; font-size: 0.95rem; }
   .card { padding: 0.75rem; margin-bottom: 1rem; }
   input, select { padding: 0.625rem 0.75rem; font-size: 1rem; }
+
+  /* Multi-field form rows (shift swap, overtime) stack so the second select
+     stops clipping off the right edge. */
+  .ot-form .form-row { flex-direction: column; gap: 0.75rem; margin-bottom: 0.75rem; }
+
+  /* Day navigation: stack into full-width rows; the three step buttons share a
+     row and the date picker drops to its own line, so nothing wraps raggedly. */
+  .day-buttons-bar { flex-direction: column; align-items: stretch; }
+  .day-buttons-left, .day-buttons-right { width: 100%; }
+  .day-buttons-left .btn { flex: 1 1 0; text-align: center; }
+  .day-buttons-left .date-picker-input { flex: 1 0 100%; width: 100%; }
 }
 
 @media (max-width: 700px) {
-  .day-buttons-bar { flex-direction: column; align-items: flex-start; }
   .page-header-left .btn, .page-header-right .btn { flex: 1; }
   .badge { font-size: 0.75rem; padding: 3px 7px; }
 }
@@ -394,8 +404,9 @@ input, select {
 .dash-hero-trend { margin-top: 10px; font-size: 13px; }
 .dash-hero-trendlabel { color: var(--muted); font-family: var(--font-mono); font-size: 12px; margin-left: 4px; }
 .dash-hero-foot { color: var(--faint); font-family: var(--font-mono); font-size: 12px; margin-top: 8px; }
-@media (max-width: 768px) {
+@media (max-width: 800px) {
   .dash-hero { flex-direction: column; }
+  .dash-hero-cell { padding: 16px 18px; }
   .dash-hero-cell + .dash-hero-cell { border-left: 0; border-top: 1px solid var(--line-strong); }
 }
 

--- a/app/static/css/layout.css
+++ b/app/static/css/layout.css
@@ -37,6 +37,31 @@ main {
   min-width: calc(min(100vw, 1175px) - 2.5rem);
 }
 
+/* Mobile: the desktop model above scrolls the whole DOCUMENT horizontally. That
+   breaks on real phones (and Firefox responsive mode): when content is wider
+   than the viewport with width=device-width, the browser expands the LAYOUT
+   viewport to the content width and lets you pan the visual viewport instead of
+   scrolling the document. position:sticky then pins to the (offscreen) layout
+   viewport edge, so the frozen Day/Date columns drift away when you swipe.
+   Fix: make the matrix its own scroll container so the overflow is contained and
+   sticky pins to the container, which stays put. A max-height turns it into a
+   pane so the sticky header (top) pins here too, not just the columns (left). */
+@media (max-width: 800px) {
+  .month-grid {
+    margin-left: 0;
+    margin-right: 0;
+    display: block;
+    overflow: auto;
+    max-height: 80vh;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior: contain;
+  }
+  .month-schedule {
+    width: max-content;
+    min-width: 0;
+  }
+}
+
 footer {
   margin-top: 1.75rem;
   color: var(--muted);

--- a/app/static/css/tables.css
+++ b/app/static/css/tables.css
@@ -143,6 +143,24 @@ td.num, th.num { font-family: var(--font-mono); }
   }
 }
 
+/* Opt a simple label/value table out of the mobile card layout so it stays a
+   tight two-column table instead of a stack of tall bordered cards. Used on the
+   day view (who is working, OB hours, OB pay) where the card treatment wasted a
+   lot of vertical space. */
+@media (max-width: 800px) {
+  table.keep-table thead { display: table-header-group; }
+  table.keep-table tbody td { display: table-cell; width: auto; }
+  table.keep-table tbody td::before { display: none; }
+  table.keep-table tbody tr {
+    display: table-row;
+    margin: 0;
+    background: none;
+    border-radius: 0;
+    padding: 0;
+  }
+  table.keep-table td, table.keep-table th { padding: 0.35rem 0.5rem; }
+}
+
 /* ===== Schedule matrix on mobile (month_all / year_all) =====
    The matrix is days x people; it is always wider than a phone and is built to
    scroll horizontally. The generic card rule above would collapse it into

--- a/app/static/css/tables.css
+++ b/app/static/css/tables.css
@@ -52,6 +52,10 @@ td.num, th.num { font-family: var(--font-mono); }
    ISO date must not wrap (its hyphens are break points) and the size is trimmed
    so the column does not grow taller/wider than it did before. */
 .month-schedule .date-cell { font-family: var(--font-mono); white-space: nowrap; font-size: 0.82rem; }
+/* The date column carries a full ISO date on desktop and a short MM-DD on mobile
+   (toggled in the max-width:800px block) so the frozen area stays narrow and more
+   people fit before scrolling. */
+.date-short { display: none; }
 
 .coworkers-row {
   background: rgba(255,255,255,0.02);
@@ -137,4 +141,105 @@ td.num, th.num { font-family: var(--font-mono); }
     border-radius: 0;
     padding: 0;
   }
+}
+
+/* ===== Schedule matrix on mobile (month_all / year_all) =====
+   The matrix is days x people; it is always wider than a phone and is built to
+   scroll horizontally. The generic card rule above would collapse it into
+   unlabelled blocks, so we opt it out (like .breakdown-table) and instead freeze
+   the two leading columns (weekday + date) so the row stays identifiable while
+   the shift columns scroll under them. One rule covers both templates even though
+   they use different width utility classes, because column 1 gets an explicit
+   width here and column 2 offsets from it. */
+@media (max-width: 800px) {
+  .month-schedule { --frozen-col1: 3.75rem; }
+
+  /* Stay a real table, not cards */
+  .month-schedule thead { display: table-header-group; }
+  .month-schedule tbody td { display: table-cell; width: auto; }
+  .month-schedule tbody td::before { display: none; }
+  .month-schedule tbody tr {
+    display: table-row;
+    margin: 0;
+    border-bottom: none;
+    background: none;
+    border-radius: 0;
+    padding: 0;
+  }
+
+  /* Both leading columns freeze. z-index values are LITERAL here, not
+     var(--z-sticky): the freeze layering must not depend on base.css being
+     cache-fresh. A stale base.css (heuristically cached, no Cache-Control)
+     without the token makes var(--z-sticky) resolve to `auto`, which lets the
+     sticky-top scrolling header cells paint over the frozen columns -> the
+     column looks like it does not freeze. Self-contained literals in this file
+     stay cache-coherent with the sticky rules. Layering, low to high:
+     scrolling body (auto) < frozen body (2) < scrolling header (3) < frozen corner (4). */
+  .month-schedule thead th { z-index: 3; }
+  .month-schedule thead th:nth-child(1),
+  .month-schedule thead th:nth-child(2),
+  .month-schedule tbody td:nth-child(1),
+  .month-schedule tbody td:nth-child(2) {
+    position: sticky;
+    background: var(--panel);
+  }
+  .month-schedule tbody td:nth-child(1),
+  .month-schedule tbody td:nth-child(2) { z-index: 2; }
+
+  /* Column 1 (weekday): pinned to the edge with a deterministic width so the
+     date column's offset is exact. Reduced font keeps the longest weekday on
+     one line inside the fixed width. */
+  .month-schedule thead th:nth-child(1),
+  .month-schedule tbody td:nth-child(1) {
+    left: 0;
+    width: var(--frozen-col1);
+    min-width: var(--frozen-col1);
+    max-width: var(--frozen-col1);
+    overflow: hidden;
+    white-space: nowrap;
+    font-size: 0.72rem;
+    padding-left: 0.4rem;
+    padding-right: 0.25rem;
+  }
+
+  /* Column 2 (date): pinned just right of column 1; its right edge marks the
+     boundary of the frozen area and hints at scrollable content beyond. */
+  .month-schedule thead th:nth-child(2),
+  .month-schedule tbody td:nth-child(2) {
+    left: var(--frozen-col1);
+    border-right: 2px solid var(--line-strong);
+  }
+
+  /* Header corner cells win the top-left intersection (vertical + horizontal
+     sticky) over both the frozen body cells and the scrolling header cells. */
+  .month-schedule thead th:nth-child(1),
+  .month-schedule thead th:nth-child(2) {
+    z-index: 4;
+  }
+
+  /* The today row keeps its teal top/bottom rule across the board; the frozen
+     cells override the row tint with a solid panel fill so scrolling shift pills
+     do not bleed through behind them. */
+  .month-schedule tr.today-row td:nth-child(1),
+  .month-schedule tr.today-row td:nth-child(2) {
+    background: var(--panel);
+  }
+
+  /* Compact the matrix on mobile: tighter rows, smaller pills and thinner shift
+     colour rails so more people fit before you have to scroll sideways. */
+  .month-schedule tbody td { padding-top: 0.28rem; padding-bottom: 0.28rem; padding-right: 0.4rem; }
+  .month-schedule tbody td.day-cell[data-person] {
+    padding-left: 5px !important;
+    border-left-width: 4px !important;
+  }
+  .month-schedule .badge { font-size: 0.66rem; padding: 1px 5px; }
+  .month-schedule thead th { padding-top: 0.35rem; padding-bottom: 0.35rem; }
+  .month-schedule .person-header { font-size: 0.72rem; }
+  .month-schedule .date-cell { font-size: 0.74rem; }
+
+  /* Short date (MM-DD) on mobile, and let the date column shrink to it: the
+     header carries a w-md/w-lg min-width that would otherwise keep it wide. */
+  .month-schedule .date-full { display: none; }
+  .month-schedule .date-short { display: inline; }
+  .month-schedule thead th:nth-child(2) { min-width: 0; }
 }

--- a/app/static/css/tables.css
+++ b/app/static/css/tables.css
@@ -143,15 +143,28 @@ td.num, th.num { font-family: var(--font-mono); }
   }
 }
 
-/* Opt a simple label/value table out of the mobile card layout so it stays a
-   tight two-column table instead of a stack of tall bordered cards. Used on the
-   day view (who is working, OB hours, OB pay) where the card treatment wasted a
-   lot of vertical space. */
+/* Opt a table out of the mobile card layout so it stays a real table instead of
+   a stack of tall bordered cards. .keep-table is the opt-in class (day view: who
+   is working, OB hours, OB pay). The team week grid (.week-grid-all) and the year
+   summary tables (.year-layout .summary) are opted out too: the week grid already
+   has its own sticky/scroll wrapper, and the year tables read as tiny unlabelled
+   cards otherwise. Wide ones scroll inside their existing overflow containers. */
 @media (max-width: 800px) {
-  table.keep-table thead { display: table-header-group; }
-  table.keep-table tbody td { display: table-cell; width: auto; }
-  table.keep-table tbody td::before { display: none; }
-  table.keep-table tbody tr {
+  table.keep-table thead,
+  .week-grid-all thead,
+  .year-layout .summary thead { display: table-header-group; }
+
+  table.keep-table tbody td,
+  .week-grid-all tbody td,
+  .year-layout .summary tbody td { display: table-cell; width: auto; }
+
+  table.keep-table tbody td::before,
+  .week-grid-all tbody td::before,
+  .year-layout .summary tbody td::before { display: none; }
+
+  table.keep-table tbody tr,
+  .week-grid-all tbody tr,
+  .year-layout .summary tbody tr {
     display: table-row;
     margin: 0;
     background: none;

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -5,13 +5,18 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>{% block title %}Periodical{% endblock %}</title>
-        <link rel="stylesheet" href="/static/css/fonts.css">
-        <link rel="stylesheet" href="/static/css/base.css">
-        <link rel="stylesheet" href="/static/css/layout.css">
-        <link rel="stylesheet" href="/static/css/components.css">
-        <link rel="stylesheet" href="/static/css/tables.css">
-        <link rel="stylesheet" href="/static/css/navigation.css">
-        <link rel="stylesheet" href="/static/css/calendar.css">
+        {# Version query busts the browser cache on every release so all CSS
+           refetch together. Without it, files with different Last-Modified times
+           (no Cache-Control is set) can skew in cache: e.g. a stale base.css
+           without a token that a fresh tables.css depends on, which silently
+           breaks the frozen-column sticky layering on mobile. #}
+        <link rel="stylesheet" href="/static/css/fonts.css?v={{ app_version }}">
+        <link rel="stylesheet" href="/static/css/base.css?v={{ app_version }}">
+        <link rel="stylesheet" href="/static/css/layout.css?v={{ app_version }}">
+        <link rel="stylesheet" href="/static/css/components.css?v={{ app_version }}">
+        <link rel="stylesheet" href="/static/css/tables.css?v={{ app_version }}">
+        <link rel="stylesheet" href="/static/css/navigation.css?v={{ app_version }}">
+        <link rel="stylesheet" href="/static/css/calendar.css?v={{ app_version }}">
     </head>
     <body>
         {% set path = request.url.path %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -5,18 +5,20 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>{% block title %}Periodical{% endblock %}</title>
-        {# Version query busts the browser cache on every release so all CSS
-           refetch together. Without it, files with different Last-Modified times
-           (no Cache-Control is set) can skew in cache: e.g. a stale base.css
-           without a token that a fresh tables.css depends on, which silently
-           breaks the frozen-column sticky layering on mobile. #}
-        <link rel="stylesheet" href="/static/css/fonts.css?v={{ app_version }}">
-        <link rel="stylesheet" href="/static/css/base.css?v={{ app_version }}">
-        <link rel="stylesheet" href="/static/css/layout.css?v={{ app_version }}">
-        <link rel="stylesheet" href="/static/css/components.css?v={{ app_version }}">
-        <link rel="stylesheet" href="/static/css/tables.css?v={{ app_version }}">
-        <link rel="stylesheet" href="/static/css/navigation.css?v={{ app_version }}">
-        <link rel="stylesheet" href="/static/css/calendar.css?v={{ app_version }}">
+        {# static_version is a hash of the CSS files' contents (computed at startup,
+           see app/main.py), not the changelog version, so the cache-busting query
+           string changes on every CSS edit even when a release has no changelog
+           entry. Without it, files with different Last-Modified times (no
+           Cache-Control is set) can skew in cache: e.g. a stale base.css without
+           a token that a fresh tables.css depends on, which silently breaks the
+           frozen-column sticky layering on mobile. #}
+        <link rel="stylesheet" href="/static/css/fonts.css?v={{ static_version }}">
+        <link rel="stylesheet" href="/static/css/base.css?v={{ static_version }}">
+        <link rel="stylesheet" href="/static/css/layout.css?v={{ static_version }}">
+        <link rel="stylesheet" href="/static/css/components.css?v={{ static_version }}">
+        <link rel="stylesheet" href="/static/css/tables.css?v={{ static_version }}">
+        <link rel="stylesheet" href="/static/css/navigation.css?v={{ static_version }}">
+        <link rel="stylesheet" href="/static/css/calendar.css?v={{ static_version }}">
     </head>
     <body>
         {% set path = request.url.path %}

--- a/app/templates/day.html
+++ b/app/templates/day.html
@@ -602,7 +602,7 @@
 
         <h3>{{ t.day_all_working }}</h3>
         {% if all_working_persons and all_working_persons|length > 0 %}
-            <table>
+            <table class="keep-table">
                 <thead>
                     <tr>
                         <th>{{ t.day_col_name }}</th>
@@ -761,7 +761,7 @@
                             {% set _ = ob_labels.update({rule.code: rule.label}) %}
                         {% endif %}
                     {% endfor %}
-                    <table>
+                    <table class="keep-table">
                         <thead>
                             <tr>
                                 <th>{{ t.day_ob_type }}</th>
@@ -804,7 +804,7 @@
                         {% set _ = ob_labels.update({rule.code: rule.label}) %}
                     {% endif %}
                 {% endfor %}
-                <table>
+                <table class="keep-table">
                     <thead>
                         <tr>
                             <th class="th_left">{{ t.day_ob_type }}</th>

--- a/app/templates/day.html
+++ b/app/templates/day.html
@@ -832,7 +832,7 @@
 
             <h3>{{ t.day_ob_rules_title }}</h3>
             {% if active_special_rules and active_special_rules|length > 0 %}
-                <table>
+                <table class="keep-table">
                     <thead>
                         <tr>
                             <th class="th_left">{{ t.day_ob_code }}</th>

--- a/app/templates/month_all.html
+++ b/app/templates/month_all.html
@@ -113,7 +113,7 @@
                     <tr class="shift-row {% if today is defined and day.date == today %}today-row{% endif %}">
                         <td class="day-cell">{{ weekday_names_full[day.date.weekday()] }}</td>
                         <td class="date-cell">
-                            {{ day.date }}
+                            <span class="date-full">{{ day.date }}</span><span class="date-short">{{ day.date.strftime('%m-%d') }}</span>
                             {% if day.date.weekday() == 0 %}
                                 <a href="/week?year={{ day.date.isocalendar()[0] }}&week={{ day.date.isocalendar()[1] }}" class="rotation-week-small">v{{ day.date.isocalendar()[1] }}</a>
                             {% endif %}

--- a/app/templates/year_all.html
+++ b/app/templates/year_all.html
@@ -100,7 +100,7 @@
                             {% set orig_code = person.original_shift.code if person.original_shift else (person.shift.code if person.shift else 'OFF') %}
                             {% set orig_color = person.original_shift.color if person.original_shift else (person.shift.color if person.shift else 'transparent') %}
                             {% set is_changed = person.shift and person.original_shift and person.shift.code != person.original_shift.code %}
-                            <td data-person="{{ person.person_id }}"
+                            <td class="day-cell" data-person="{{ person.person_id }}"
                                 data-act-color="{{ person.shift.color if person.shift else 'transparent' }}"
                                 data-orig-color="{{ orig_color }}"
                                 data-orig-code="{{ orig_code }}"

--- a/app/templates/year_all.html
+++ b/app/templates/year_all.html
@@ -86,7 +86,7 @@
                     <tr class="shift-row {% if today is defined and day.date == today %}today-row{% elif today is defined and day.date < today %}past-row{% endif %}">
                         <td class="day-cell">{{ weekday_names_full[day.date.weekday()] }}</td>
                         <td class="date-cell">
-                            {{ day.date }}
+                            <span class="date-full">{{ day.date }}</span><span class="date-short">{{ day.date.strftime('%m-%d') }}</span>
                             {% if day.date.weekday() == 0 %}
                                 <a href="/week?year={{ day.date.isocalendar()[0] }}&week={{ day.date.isocalendar()[1] }}" class="rotation-week-small">v{{ day.date.isocalendar()[1] }}</a>
                             {% endif %}

--- a/docs/superpowers/specs/2026-06-30-mobile-schedule-matrix-design.md
+++ b/docs/superpowers/specs/2026-06-30-mobile-schedule-matrix-design.md
@@ -1,0 +1,94 @@
+# Mobile schedule matrix: frozen date column (Phase 1)
+
+Date: 2026-06-30
+Branch: `fix/mobile-schedule-matrix`
+
+## Problem
+
+The team schedule matrices (`month_all.html`, `year_all.html`) render days as rows
+and people as columns. On a phone the matrix is far wider than the viewport, so it
+is unreadable. Two concrete defects:
+
+1. A global responsive rule in `tables.css` (`@media (max-width: 800px)`) turns
+   *every* table into a card-stacked layout (`thead` hidden, each `td` becomes a
+   labelled block). The matrix is built for horizontal scroll, so this rule
+   collapses it into a broken hybrid. Only `.breakdown-table` is currently exempt.
+2. The leading day/date columns never freeze on mobile, so when you scroll sideways
+   you lose the row's identity (which day a shift belongs to).
+
+## Decision
+
+Keep the matrix intact and make the leading columns freeze on horizontal scroll
+(user-selected direction: "frozen date column + scroll"). This respects the product
+principle that colour belongs to the data: we touch navigation, not the shift pills.
+
+## Approach (CSS-only)
+
+All changes are scoped to `.month-schedule`, so both matrix templates are covered by
+one rule despite using different width utility classes (`w-sm`/`w-md` in month_all,
+`w-md`/`w-lg` in year_all).
+
+1. **Exempt the matrix from the card rule** at `max-width: 800px`: restore
+   `display: table-header-group` / `table-cell` / `table-row` for `.month-schedule`,
+   the same way `.breakdown-table` is already exempted.
+2. **Freeze the two leading columns** (weekday + date) with `position: sticky`:
+   - Column 1 (`nth-child(1)`): `left: 0`, an explicit deterministic width
+     (`--frozen-col1: 3.75rem`), reduced font so the longest weekday ("Torsdag")
+     fits without wrapping. The explicit width is required so column 2's offset is
+     exact regardless of which width class the template used.
+   - Column 2 (`nth-child(2)`): `left: var(--frozen-col1)`, with a strong right
+     border (`--line-strong`) marking the boundary between frozen and scrolling
+     area, which also signals "more content to the right".
+   - Header corner cells get the highest sticky z so they win at the top-left
+     intersection of vertical (thead) and horizontal (column) sticky.
+3. **Keep body-level horizontal scroll** (the existing `.month-grid` viewport
+   breakout). This is a deliberate existing choice that preserves the vertical
+   sticky `thead`; wrapping the table in an `overflow-x` container would clip it.
+
+## Latent bug fixed along the way
+
+`--z-sticky`, `--z-modal`, `--z-tooltip` are referenced across `tables.css` and
+`navigation.css` but never defined in `:root`, so they resolve to `z-index: auto`.
+Define them (sticky < modal < tooltip) so sticky stacking is correct and the new
+frozen columns stack above the scrolling shift cells. App-wide improvement, no visual
+change to existing working surfaces.
+
+## Out of scope (Phase 2)
+
+`day.html` and `dashboard.html` polish. Specced separately after Phase 1 is verified
+in the browser.
+
+## Verification
+
+Render `/month` (team) and `/year` (team) at 375px width via the browse tool.
+Confirm: matrix is a scrollable table (not cards); weekday + date columns stay pinned
+while shift columns scroll under them; sticky `thead` still pins on vertical scroll;
+the "today" row still reads across; desktop layout is unchanged at >800px.
+
+## Final implementation (shipped, supersedes point 3 above)
+
+Point 3 ("keep body-level horizontal scroll") was wrong and was caught in testing.
+On real phones and in Firefox responsive mode, when content is wider than the viewport
+with `width=device-width`, the browser expands the LAYOUT viewport to the content width
+and lets you pan the visual viewport instead of scrolling the document. `position:
+sticky; left:0` then pins to the offscreen layout-viewport edge, so the frozen columns
+drift away. Plain headless Chromium document-scrolls, so this was invisible until
+reproduced with CDP mobile emulation (`Emulation.setDeviceMetricsOverride ... mobile:true`).
+
+Shipped fix (`layout.css`, `@media max-width:800px`): the matrix scrolls inside its own
+container. `.month-grid { display:block; overflow:auto; max-height:80vh }` and
+`.month-schedule { width:max-content; min-width:0 }`. Sticky then pins to the container,
+which stays put; `max-height` makes it a pane so the sticky `thead` (top) also pins here.
+Desktop keeps the flex/full-bleed model.
+
+Also shipped:
+- Frozen-column `z-index` uses LITERAL values in `tables.css` (2 body, 3 scrolling
+  header, 4 frozen corner), not `var(--z-sticky)`, so a cache-skewed stale `base.css`
+  cannot break the layering.
+- Cache-busting: `base.html` links CSS with `?v={{ app_version }}` so files refetch
+  together per release (the skew above was a real mixed-cache failure a user hit).
+- Compact mobile matrix: tighter rows, smaller pills, thinner shift-colour rails.
+- Short date on mobile: the date cell renders `<span class="date-full">` (full ISO,
+  desktop) and `<span class="date-short">` (MM-DD via `strftime`, mobile) so the frozen
+  area is narrow enough that ~4 people show before scrolling. `month_all.html` and
+  `year_all.html` both updated.


### PR DESCRIPTION
## Summary
- Team month/year matrix stays a real table on mobile: the weekday and date columns freeze in their own scroll pane while the people columns scroll underneath, with compacted rows/pills so more people fit before scrolling.
- Team week view and personal week/month/year views get proper mobile layouts instead of collapsing into unreadable card stacks (week keeps its frozen name column; personal views render as full-width lists/tables).
- Day view and dashboard hero cleanup on mobile: shift-swap/overtime form rows stack, day tables stay compact via a `.keep-table` opt-out, day navigation stops wrapping raggedly, and the dashboard answer band gets more room.
- CSS cache-busting is now a content hash of the stylesheets (`static_version`), computed at startup, instead of the manually bumped changelog version, so CSS-only changes always bust the cache.
- Year view's per-person shift cells now carry the same `day-cell` class as month view, so the mobile compaction rules actually apply there too.
- Added a 0.27.1 changelog entry covering the above.

## Test plan
- [x] `pytest tests/` (313 passed)
- [x] `ruff` / `ruff format` via pre-commit hooks on every commit
- [x] Manual check of `/month`, `/year`, `/week` (team) and `/day` at a phone-width viewport, in English and Swedish, admin and non-admin