### PR TITLE
Scope cowork and handover stats to the viewed user's employment window

### DIFF
--- a/app/core/schedule/cowork.py
+++ b/app/core/schedule/cowork.py
@@ -17,6 +17,43 @@ def _get_persons():
     return _persons
 
 
+def _viewer_active_ranges(session, employment_user_id, position_id: int, year: int):
+    """Return the date ranges the viewed user held a position during the year.
+
+    Returns None when no employment-window masking should apply: either the
+    caller supplied no session/user, or the position has no PersonHistory at all
+    (legacy positions keep the current-holder-for-all-dates behavior). Otherwise
+    returns a list of (from_date, to_date) tuples clamped to the year, covering
+    only the segments belonging to employment_user_id. The list may be empty when
+    the user held the position in no part of the year, which masks every day.
+    """
+    if session is None or employment_user_id is None:
+        return None
+
+    from app.core.schedule.person_history import (
+        get_position_holder_segments,
+        has_position_history,
+    )
+
+    if not has_position_history(session, position_id):
+        return None
+
+    year_start = datetime.date(year, 1, 1)
+    year_end = datetime.date(year, 12, 31)
+    return [
+        (seg["from_date"], seg["to_date"])
+        for seg in get_position_holder_segments(session, position_id, year_start, year_end)
+        if seg["user_id"] == employment_user_id
+    ]
+
+
+def _date_in_ranges(day_date, ranges) -> bool:
+    """True if masking is disabled (ranges is None) or day_date falls in a range."""
+    if ranges is None:
+        return True
+    return any(lo <= day_date <= hi for lo, hi in ranges)
+
+
 def _get_person_name_from_db(person_id: int) -> str:
     """Get current person name from database (respects person_id field)."""
     from app.database.database import SessionLocal, User
@@ -37,7 +74,12 @@ def _get_person_name_from_db(person_id: int) -> str:
         db.close()
 
 
-def build_cowork_stats(year: int, target_person_id: int) -> list[dict]:
+def build_cowork_stats(
+    year: int,
+    target_person_id: int,
+    session=None,
+    employment_user_id: int | None = None,
+) -> list[dict]:
     """
     Räknar hur många pass target_person_id jobbar tillsammans
     med varje annan person, samt beräknar överlämnings- och månadsstatistik.
@@ -52,13 +94,21 @@ def build_cowork_stats(year: int, target_person_id: int) -> list[dict]:
 
     Args:
         year: År att analysera
-        target_person_id: Person att analysera
+        target_person_id: Position (rotation person_id) att analysera
+        session: Optional DB session used to scope the stats to the viewed user's
+            own employment window at target_person_id.
+        employment_user_id: Optional user id of the viewed person. When given
+            together with session, days outside that user's PersonHistory
+            segment(s) for target_person_id are treated as OFF so a successor's
+            interactions are not attributed to a departed holder. Positions
+            without any history keep the legacy whole-year behavior.
 
     Returns:
         Lista med statistik per medarbetare, sorterad på person-ID
     """
     today = datetime.date.today()
     days_in_year = generate_year_data(year, person_id=None)
+    active_ranges = _viewer_active_ranges(session, employment_user_id, target_person_id, year)
 
     total_target_work_days = 0
 
@@ -88,11 +138,20 @@ def build_cowork_stats(year: int, target_person_id: int) -> list[dict]:
 
     for day in days_in_year:
         persons_today = day.get("persons", [])
+        date_val = day["date"]
 
         # Bygg dagens skiftkarta
         current_day_shifts: dict[int, str] = {
             p["person_id"]: (p["shift"].code if p.get("shift") else "OFF") for p in persons_today
         }
+
+        # Days outside the viewed user's tenure at this position belong to a
+        # different holder. Treat the target as OFF and carry that forward so no
+        # coworking or handover is attributed to the viewed user for those days.
+        if not _date_in_ranges(date_val, active_ranges):
+            current_day_shifts[target_person_id] = "OFF"
+            prev_day_shifts = current_day_shifts
+            continue
 
         target_prev = prev_day_shifts.get(target_person_id, "OFF")
 
@@ -102,7 +161,6 @@ def build_cowork_stats(year: int, target_person_id: int) -> list[dict]:
         if target and target.get("shift"):
             target_code = target["shift"].code
 
-        date_val = day["date"]
         month = date_val.month
         weekday = date_val.weekday()
 
@@ -165,24 +223,37 @@ def build_cowork_details(
     year: int,
     target_person_id: int,
     other_person_id: int,
+    session=None,
+    employment_user_id: int | None = None,
 ) -> list[dict]:
     """
     Returnerar alla dagar då två personer jobbar samma skift.
 
     Args:
         year: År att analysera
-        target_person_id: Första personen
-        other_person_id: Andra personen
+        target_person_id: Position (rotation person_id) för första personen
+        other_person_id: Position för andra personen
+        session: Optional DB session used to scope the details to the viewed
+            user's own employment window at target_person_id.
+        employment_user_id: Optional user id of the viewed person. When given
+            together with session, days outside that user's PersonHistory
+            segment(s) for target_person_id are skipped. Positions without any
+            history keep the legacy whole-year behavior.
 
     Returns:
         Lista med dagdetaljer, sorterad på datum
     """
     days_in_year = generate_year_data(year, person_id=None)
+    active_ranges = _viewer_active_ranges(session, employment_user_id, target_person_id, year)
     details: list[dict] = []
 
     for day in days_in_year:
         persons_today = day.get("persons", [])
         if not persons_today:
+            continue
+
+        # Skip days outside the viewed user's tenure at this position.
+        if not _date_in_ranges(day["date"], active_ranges):
             continue
 
         target = _find_person_in_day(persons_today, target_person_id)
@@ -227,6 +298,8 @@ def build_handover_details(
     year: int,
     target_person_id: int,
     other_person_id: int,
+    session=None,
+    employment_user_id: int | None = None,
 ) -> list[dict]:
     """
     Returnerar alla överlämningar mellan två personer under ett år.
@@ -243,13 +316,20 @@ def build_handover_details(
 
     Args:
         year: År att analysera
-        target_person_id: "Jag"-personen
-        other_person_id: Den andra personen
+        target_person_id: Position (rotation person_id) för "Jag"-personen
+        other_person_id: Position för den andra personen
+        session: Optional DB session used to scope the handovers to the viewed
+            user's own employment window at target_person_id.
+        employment_user_id: Optional user id of the viewed person. When given
+            together with session, handovers on dates outside that user's
+            PersonHistory segment(s) for target_person_id are dropped. Positions
+            without any history keep the legacy whole-year behavior.
 
     Returns:
         Lista med överlämningar, sorterad på datum
     """
     days_in_year = generate_year_data(year, person_id=None)
+    active_ranges = _viewer_active_ranges(session, employment_user_id, target_person_id, year)
     details: list[dict] = []
 
     _HANDOVER_PAIRS = {("N1", "N2"), ("N2", "N3")}
@@ -268,6 +348,15 @@ def build_handover_details(
 
         date = day["date"]
         weekday_name = day["weekday_name"]
+
+        # Days outside the viewed user's tenure at this position belong to a
+        # different holder. Record no handover on such a date, and keep the
+        # target masked OFF in the carried-forward state so a boundary cross-day
+        # handover is not attributed across the tenure edge.
+        if not _date_in_ranges(date, active_ranges):
+            prev_target_code = "OFF"
+            prev_other_code = other_code
+            continue
 
         # Korsdag N3→N1: använder dagens datum (när N1 börjar)
         if prev_target_code == "N3" and other_code == "N1":

--- a/app/routes/schedule_personal.py
+++ b/app/routes/schedule_personal.py
@@ -1192,8 +1192,11 @@ async def year_view(
                 holder = db.query(User).filter(User.id == rotation_position).first()
                 person_name = holder.name if holder else person_list[rotation_position - 1].name
 
-    # Use rotation_position for schedule-related calculations
-    cowork_rows = build_cowork_stats(year, rotation_position)
+    # Use rotation_position for schedule-related calculations. Scope the cowork
+    # stats to the viewed user's own employment window so a successor's days at
+    # the same position are not attributed to a departed holder.
+    employment_user_id = target_user.id if target_user is not None else None
+    cowork_rows = build_cowork_stats(year, rotation_position, session=db, employment_user_id=employment_user_id)
     selected_other_id = None
     selected_other_name = None
     cowork_details: list[dict] = []
@@ -1202,7 +1205,9 @@ async def year_view(
         selected_other_id = with_person_id
         _other_row = next((r for r in cowork_rows if r["other_id"] == with_person_id), None)
         selected_other_name = _other_row["other_name"] if _other_row else str(with_person_id)
-        cowork_details = build_cowork_details(year, rotation_position, with_person_id)
+        cowork_details = build_cowork_details(
+            year, rotation_position, with_person_id, session=db, employment_user_id=employment_user_id
+        )
 
     # Use rotation_position for schedule, user_id_for_wages for wage lookup.
     # For user-scoped views (a User resolved) filter months to the viewed user's
@@ -1416,7 +1421,11 @@ async def cowork_view(
                 holder = db.query(User).filter(User.id == rotation_position).first()
                 person_name = holder.name if holder else person_list[rotation_position - 1].name
 
-    cowork_rows = build_cowork_stats(year, rotation_position)
+    # Scope the cowork stats to the viewed user's own employment window so a
+    # successor's days at the same position are not attributed to a departed
+    # holder.
+    employment_user_id = target_user.id if target_user is not None else None
+    cowork_rows = build_cowork_stats(year, rotation_position, session=db, employment_user_id=employment_user_id)
 
     selected_other_id = None
     selected_other_name = None
@@ -1428,8 +1437,12 @@ async def cowork_view(
         selected_other_id = with_person_id
         selected_cowork_row = next((r for r in cowork_rows if r["other_id"] == with_person_id), None)
         selected_other_name = selected_cowork_row["other_name"] if selected_cowork_row else str(with_person_id)
-        cowork_details = build_cowork_details(year, rotation_position, with_person_id)
-        handover_details = build_handover_details(year, rotation_position, with_person_id)
+        cowork_details = build_cowork_details(
+            year, rotation_position, with_person_id, session=db, employment_user_id=employment_user_id
+        )
+        handover_details = build_handover_details(
+            year, rotation_position, with_person_id, session=db, employment_user_id=employment_user_id
+        )
 
     return render_template(
         templates,

--- a/tests/test_cowork_employment_scoping.py
+++ b/tests/test_cowork_employment_scoping.py
@@ -1,0 +1,167 @@
+"""Employment-window scoping for the cowork/handover stat builders.
+
+`/cowork/<id>` statistics are built from a position's whole-year schedule. When a
+position changes hands mid-year, a departed holder's page must not include the
+successor's coworker interactions or handovers. These tests reproduce that leak
+and lock in the fix: the builders accept the viewed user's session and user id
+and mask days outside that user's own PersonHistory segment(s) for the position.
+
+The cowork builders read the rotation era through the global SessionLocal (not an
+injected session), so we reuse the rotation_session fixture, which monkeypatches
+SessionLocal onto an in-memory engine with a seeded rotation era. PersonHistory
+rows are seeded on that same session.
+"""
+
+import datetime
+
+from app.core.schedule.cowork import (
+    build_cowork_details,
+    build_cowork_stats,
+    build_handover_details,
+)
+from app.core.schedule.person_history import add_person_change, start_employment
+from app.database.database import User, UserRole, WageType
+
+# Anna held position 3 from rotation start; Bert took over on 2026-02-01, so
+# add_person_change closes Anna on 2026-01-31.
+POSITION = 3
+ANNA_ID = 11
+BERT_ID = 12
+ANNA_START = datetime.date(2026, 1, 2)
+ANNA_END = datetime.date(2026, 1, 31)
+BERT_START = datetime.date(2026, 2, 1)
+YEAR = 2026
+
+
+def _make_user(session, uid, username, name):
+    user = User(
+        id=uid,
+        username=username,
+        password_hash="x",
+        name=name,
+        role=UserRole.USER,
+        wage=30000,
+        wage_type=WageType.MONTHLY,
+        vacation={},
+        must_change_password=0,
+        is_active=0,
+    )
+    session.add(user)
+    session.commit()
+    return user
+
+
+def _seed_succession(session):
+    """Anna holds position 3 until 2026-01-31; Bert succeeds her on 2026-02-01."""
+    anna = _make_user(session, ANNA_ID, "anna1", "Anna")
+    bert = _make_user(session, BERT_ID, "bert1", "Bert")
+    start_employment(session, anna.id, POSITION, "Anna", "anna1", ANNA_START, created_by=1)
+    add_person_change(
+        session,
+        old_user_id=anna.id,
+        new_user_id=bert.id,
+        person_id=POSITION,
+        new_name="Bert",
+        new_username="bert1",
+        effective_from=BERT_START,
+        created_by=1,
+    )
+    return anna, bert
+
+
+def _all_cowork_dates(session, employment_user_id):
+    """Aggregate cowork detail dates across every other position."""
+    dates = []
+    for other in range(1, 11):
+        if other == POSITION:
+            continue
+        kwargs = {}
+        if employment_user_id is not None:
+            kwargs = {"session": session, "employment_user_id": employment_user_id}
+        dates += [r["date"] for r in build_cowork_details(YEAR, POSITION, other, **kwargs)]
+    return dates
+
+
+def _all_handover_dates(session, employment_user_id):
+    """Aggregate handover detail dates across every other position."""
+    dates = []
+    for other in range(1, 11):
+        if other == POSITION:
+            continue
+        kwargs = {}
+        if employment_user_id is not None:
+            kwargs = {"session": session, "employment_user_id": employment_user_id}
+        dates += [r["date"] for r in build_handover_details(YEAR, POSITION, other, **kwargs)]
+    return dates
+
+
+def test_cowork_details_leak_without_scoping_and_fixed_with_scoping(rotation_session):
+    """Departed Anna's cowork details must stay inside her tenure once scoped."""
+    session = rotation_session
+    anna, _bert = _seed_succession(session)
+
+    unscoped = _all_cowork_dates(session, employment_user_id=None)
+    scoped = _all_cowork_dates(session, employment_user_id=anna.id)
+
+    # The unscoped builder leaks the successor's post-departure coworking.
+    assert any(d > ANNA_END for d in unscoped), "expected the unscoped view to include post-departure days"
+    # Scoped to Anna's tenure, no day falls outside her employment window.
+    assert scoped, "Anna should still have coworking days within her tenure"
+    assert all(ANNA_START <= d <= ANNA_END for d in scoped)
+    # Scoping strictly removes the leaked days.
+    assert len(scoped) < len(unscoped)
+
+
+def test_handover_details_leak_without_scoping_and_fixed_with_scoping(rotation_session):
+    """Departed Anna's handover details must stay inside her tenure once scoped."""
+    session = rotation_session
+    anna, _bert = _seed_succession(session)
+
+    unscoped = _all_handover_dates(session, employment_user_id=None)
+    scoped = _all_handover_dates(session, employment_user_id=anna.id)
+
+    assert any(d > ANNA_END for d in unscoped), "expected the unscoped view to include post-departure handovers"
+    assert scoped, "Anna should still have handovers within her tenure"
+    assert all(ANNA_START <= d <= ANNA_END for d in scoped)
+    assert len(scoped) < len(unscoped)
+
+
+def test_cowork_stats_totals_scoped_to_tenure(rotation_session):
+    """Aggregate cowork and handover counts drop to Anna's own tenure."""
+    session = rotation_session
+    anna, _bert = _seed_succession(session)
+
+    unscoped = build_cowork_stats(YEAR, POSITION)
+    scoped = build_cowork_stats(YEAR, POSITION, session=session, employment_user_id=anna.id)
+
+    unscoped_cowork = sum(r["total"] for r in unscoped)
+    scoped_cowork = sum(r["total"] for r in scoped)
+    unscoped_handovers = sum(r["handovers"] for r in unscoped)
+    scoped_handovers = sum(r["handovers"] for r in scoped)
+
+    # Anna held the position for only January, so her scoped counts must be a
+    # strict subset of the full-year totals the unscoped builder produced.
+    assert scoped_cowork > 0
+    assert scoped_cowork < unscoped_cowork
+    assert scoped_handovers > 0
+    assert scoped_handovers < unscoped_handovers
+
+
+def test_position_without_history_is_unaffected(rotation_session):
+    """A position with no PersonHistory keeps the legacy whole-year behavior.
+
+    Position 1 has a User but no PersonHistory rows, so passing a session and
+    employment_user_id must not mask anything (legacy fallback), matching the
+    plain call exactly.
+    """
+    session = rotation_session
+
+    plain = build_cowork_stats(YEAR, 1)
+    with_args = build_cowork_stats(YEAR, 1, session=session, employment_user_id=1)
+
+    assert [r["total"] for r in plain] == [r["total"] for r in with_args]
+    assert [r["handovers"] for r in plain] == [r["handovers"] for r in with_args]
+
+    plain_details = build_cowork_details(YEAR, 1, 2)
+    scoped_details = build_cowork_details(YEAR, 1, 2, session=session, employment_user_id=1)
+    assert [r["date"] for r in plain_details] == [r["date"] for r in scoped_details]


### PR DESCRIPTION
## Summary

Fixes #275.

`build_cowork_stats`, `build_cowork_details` and `build_handover_details` iterated the whole calendar year with no employment-window awareness, so a departed or swapped-out holder's cowork/handover page attributed the successor's coworking and handover days to them.

- The three builders take optional `session` / `employment_user_id` parameters and mask days outside the viewed user's own PersonHistory segment(s) at the displayed position, mirroring the `mask_days_to_employment` pattern from the day/week/month personal views (commit 313a7df).
- On a masked day the target is treated as OFF and the carried-forward day state is reset, so a cross-day handover at the tenure boundary is not attributed across the edge.
- Positions with no PersonHistory rows keep the legacy current-holder-for-all-dates behavior.
- Both callers (`/year/{id}` and `/cowork/{id}` in `app/routes/schedule_personal.py`) now pass the viewed user's id.

## Testing

Four new tests in `tests/test_cowork_employment_scoping.py` covering the leak in details, handovers and totals plus the no-history fallback; confirmed failing before the fix. Full suite 460 passed, ruff clean.