### PR TITLE
Resolve absence shift times via the position held on the absence date

### DIFF
--- a/app/core/schedule/wages.py
+++ b/app/core/schedule/wages.py
@@ -287,13 +287,24 @@ def get_karens_consumed_before_date(session, user_id: int, sick_date: "date") ->
     return consumed
 
 
-def _get_rotation_position(session, user_id: int) -> int:
-    """Returns rotation_person_id for a user, falling back to user_id."""
+def _get_rotation_position(session, user_id: int, on_date: date | None = None) -> int:
+    """
+    Returns the rotation position (person_id) a user held on a given date.
+
+    Resolves via PersonHistory (get_user_person_id) so a mid-period rotation swap
+    or succession does not retroactively change the position used for a date
+    before the change. Positions without any PersonHistory rows fall back to the
+    current rotation_person_id snapshot, exactly as before this resolution existed.
+    """
     if session:
+        from app.core.schedule.person_history import get_user_person_id
         from app.database.database import User
 
         user = session.query(User).filter(User.id == user_id).first()
         if user:
+            position = get_user_person_id(session, user_id, on_date=on_date)
+            if position is not None:
+                return position
             return user.rotation_person_id
     return user_id
 
@@ -304,10 +315,14 @@ def get_shift_times_for_date(
     """
     Hämtar (hours, start_dt, end_dt) för skiftet en person skulle ha jobbat.
     Returnerar (8.5, None, None) som fallback.
+
+    Resolves the shift via the rotation position the user held on absence_date
+    (not their current position), so a rotation swap after absence_date does not
+    retroactively change how it is priced.
     """
     from app.core.schedule import calculate_shift_hours, determine_shift_for_date
 
-    rotation_position = _get_rotation_position(session, user_id)
+    rotation_position = _get_rotation_position(session, user_id, on_date=absence_date)
     result = determine_shift_for_date(absence_date, start_week=rotation_position)
     if result and result[0]:
         shift, _ = result

--- a/tests/test_absence_position_swap.py
+++ b/tests/test_absence_position_swap.py
@@ -1,0 +1,140 @@
+"""Regression tests: absence deductions must price shift times using the
+position the user held on the ABSENCE DATE, not their current position.
+
+Reproduces the bug documented in PR #276's known-follow-ups: after a mid-month
+rotation swap, get_shift_times_for_date resolved the shift for a past absence
+date via user.rotation_person_id -- the current denormalized position -- instead
+of the position actually held on that date (PersonHistory). A sick day recorded
+before the swap was therefore priced with the successor's shift times.
+"""
+
+import datetime
+
+import pytest
+
+from app.core.schedule.person_history import start_employment, swap_positions
+from app.core.schedule.wages import (
+    get_absence_deductions_for_month,
+    get_absent_hours_for_absence,
+    get_shift_times_for_date,
+)
+from app.database.database import Absence, AbsenceType, User, UserRole, WageType
+
+ERA_START = datetime.date(2026, 1, 2)
+SWAP_DATE = datetime.date(2026, 1, 20)
+ABSENCE_DATE = datetime.date(2026, 1, 7)  # before the swap
+
+
+def _make_user(session, uid, username, name):
+    user = User(
+        id=uid,
+        username=username,
+        password_hash="x",
+        name=name,
+        role=UserRole.USER,
+        wage=17333,
+        wage_type=WageType.MONTHLY,
+        vacation={},
+        must_change_password=0,
+        is_active=0,
+    )
+    session.add(user)
+    session.commit()
+    return user
+
+
+def _set_up_swap(session):
+    """Two holders start at positions 1 and 3, then swap positions mid-month.
+
+    Returns (holder_a, holder_b). holder_a held position 1 (shift N3 on
+    ABSENCE_DATE, 22:00 -> 06:30 next day) before the swap, and position 3
+    (shift N2, 14:00 -> 22:30) after it.
+    """
+    holder_a = _make_user(session, 10, "holder_a", "Holder A")
+    holder_b = _make_user(session, 11, "holder_b", "Holder B")
+
+    start_employment(session, holder_a.id, 1, holder_a.name, holder_a.username, ERA_START, created_by=1)
+    start_employment(session, holder_b.id, 3, holder_b.name, holder_b.username, ERA_START, created_by=1)
+
+    swap_positions(session, 1, 3, SWAP_DATE, created_by=1)
+    session.refresh(holder_a)
+    # Sanity check: the swap did move holder_a's CURRENT position to 3.
+    assert holder_a.person_id == 3
+
+    return holder_a, holder_b
+
+
+class TestShiftTimesFollowPositionHeldOnDate:
+    def test_pre_swap_absence_uses_old_position_shift(self, rotation_session):
+        session = rotation_session
+        holder_a, _ = _set_up_swap(session)
+
+        hours, start_dt, end_dt = get_shift_times_for_date(session, holder_a.id, ABSENCE_DATE)
+
+        # Position 1's shift on 2026-01-07 is N3 (22:00 -> 06:30 next day), NOT
+        # position 3's N2 (14:00 -> 22:30), which is holder_a's shift AFTER the swap.
+        assert start_dt == datetime.datetime(2026, 1, 7, 22, 0)
+        assert end_dt == datetime.datetime(2026, 1, 8, 6, 30)
+        assert hours == pytest.approx(8.5)
+
+    def test_post_swap_absence_uses_new_position_shift(self, rotation_session):
+        """Control case: an absence ON/AFTER the swap date must use the new position.
+
+        Position 1's shift on the swap date is OFF (fallback: 8.5h, no start/end).
+        Position 3's shift on the swap date is N3 (22:00 -> 06:30 next day). Getting
+        the real N3 times back (not the OFF fallback) confirms the swap date itself
+        already resolves to the new position, as it should.
+        """
+        session = rotation_session
+        holder_a, _ = _set_up_swap(session)
+
+        hours, start_dt, end_dt = get_shift_times_for_date(session, holder_a.id, SWAP_DATE)
+
+        assert start_dt == datetime.datetime(2026, 1, 20, 22, 0)
+        assert end_dt == datetime.datetime(2026, 1, 21, 6, 30)
+        assert hours == pytest.approx(8.5)
+
+    def test_pre_swap_partial_absence_hours_use_old_position_times(self, rotation_session):
+        """A left_at partial-day absence must be computed against the pre-swap
+        shift window, not the current (post-swap) one."""
+        session = rotation_session
+        holder_a, _ = _set_up_swap(session)
+
+        absence = Absence(user_id=holder_a.id, date=ABSENCE_DATE, absence_type=AbsenceType.SICK, left_at="02:00")
+
+        shift_hours, shift_start_dt, shift_end_dt = get_shift_times_for_date(session, holder_a.id, ABSENCE_DATE)
+        absent_hours = get_absent_hours_for_absence(absence, shift_start_dt, shift_end_dt, shift_hours)
+
+        # Left at 02:00 during the old position's N3 night shift (22:00 -> 06:30):
+        # 4.5h remained unworked. The bug (resolving position 3's N2 shift,
+        # 14:00 -> 22:30) would instead cap this at a full 8.5h day.
+        assert absent_hours == pytest.approx(4.5)
+
+    def test_pre_swap_month_deduction_reflects_old_position_hours(self, rotation_session):
+        """End-to-end: get_absence_deductions_for_month must total the
+        pre-swap partial-day hours, not the post-swap full-day hours."""
+        session = rotation_session
+        holder_a, _ = _set_up_swap(session)
+
+        session.add(Absence(user_id=holder_a.id, date=ABSENCE_DATE, absence_type=AbsenceType.SICK, left_at="02:00"))
+        session.commit()
+
+        result = get_absence_deductions_for_month(session, holder_a.id, 2026, 1, holder_a.wage)
+
+        assert result["sick_hours"] == pytest.approx(4.5)
+        assert result["total_hours"] == pytest.approx(4.5)
+
+
+class TestLegacyFallbackWithoutHistory:
+    """Positions without any PersonHistory rows must keep resolving via the
+    current rotation_person_id snapshot exactly as before this fix."""
+
+    def test_no_history_falls_back_to_rotation_person_id(self, rotation_session):
+        session = rotation_session
+        # rotation_session already seeds a User(id=1, person_id=1) with no
+        # PersonHistory rows at all.
+        hours, start_dt, end_dt = get_shift_times_for_date(session, 1, ABSENCE_DATE)
+
+        assert start_dt == datetime.datetime(2026, 1, 7, 22, 0)
+        assert end_dt == datetime.datetime(2026, 1, 8, 6, 30)
+        assert hours == pytest.approx(8.5)


### PR DESCRIPTION
## Summary

Follow-up from PR #276's known-issues list (wage module, out of scope there).

`get_shift_times_for_date` in `app/core/schedule/wages.py` resolved the rotation position from the user's current `rotation_person_id` snapshot regardless of the absence date. After a mid-month rotation swap or succession, an absence recorded before the change was priced with the new position's shift times, giving wrong deduction hours and amounts (e.g. a partial-day `left_at` absence capped at a full day because the wrong shift window was used).

- `_get_rotation_position` now takes an `on_date` parameter and resolves via PersonHistory (`get_user_person_id`), falling back to the current snapshot only when the user has no PersonHistory rows, preserving legacy behavior for positions without history.
- `get_shift_times_for_date` passes the absence date through, so downstream `get_shift_hours_for_date`, `get_absent_hours_for_absence` and `get_absence_deductions_for_month` all price against the position actually held on each date.

## Testing

Five new tests in `tests/test_absence_position_swap.py`: pre-swap absence uses the old position's shift, post-swap uses the new one, partial-day hours computed from the old position's shift window, end-to-end month deduction, and the no-history legacy fallback. Four confirmed failing before the fix. Full suite 461 passed, ruff clean.