### PR TITLE
Close a vacation year on its own days, keep earlier saved days

### DIFF
--- a/app/core/schedule/vacation.py
+++ b/app/core/schedule/vacation.py
@@ -335,18 +335,22 @@ def get_saved_days_balance(user, target_year: int) -> dict:
     return {"total_saved": total, "breakdown": breakdown}
 
 
-def close_vacation_year(user, target_year: int, remaining_total: int, pay: dict, db) -> dict:
+def close_vacation_year(user, target_year: int, remaining_own: int, pay: dict, db) -> dict:
     """
-    Close a vacation year by saving up to 5 days and calculating payout for the rest.
+    Close a vacation year: save up to 5 of the year's own remaining days and pay out the rest.
 
-    Semesterersättning per Handelns avtal §9.5:
+    Semesterersattning per Handelns avtal 9.5:
       4.6% of monthly salary + 0.8% of monthly salary + 0.5% of variable per day
       = 5.4% of monthly salary + 0.5% of variable per day
+
+    Days saved in earlier years are not part of the close: they stay saved (valid
+    for five years, semesterlagen paragraph 18) unless the year used more than its
+    own entitlement, in which case the overuse consumes saved days oldest year first.
 
     Args:
         user: User ORM object
         target_year: The vacation year to close
-        remaining_total: Total remaining days (entitled + saved - used)
+        remaining_own: The year's own remaining days (entitled - used); may be negative
         pay: Result dict from calculate_vacation_pay()
         db: Database session
 
@@ -362,12 +366,28 @@ def close_vacation_year(user, target_year: int, remaining_total: int, pay: dict,
     # Vacation compensation = payout_pct base + vacation supplement
     payout_per_day = round(monthly_salary * payout_pct + supplement_per_day, 2)
 
-    if remaining_total <= 0:
+    saved = dict(user.vacation_saved or {})
+
+    if remaining_own <= 0:
         days_saved = 0
         days_paid_out = 0
+        # Overuse beyond the year's own entitlement consumes previously saved
+        # days, oldest year first.
+        overuse = -remaining_own
+        if overuse > 0:
+            for y in sorted((k for k in saved if str(k).isdigit() and int(k) < target_year), key=int):
+                entry = dict(saved[y])
+                available = entry.get("saved", 0)
+                take = min(available, overuse)
+                if take > 0:
+                    entry["saved"] = available - take
+                    saved[y] = entry
+                    overuse -= take
+                if overuse <= 0:
+                    break
     else:
-        days_saved = min(remaining_total, 5)
-        days_paid_out = max(remaining_total - 5, 0)
+        days_saved = min(remaining_own, 5)
+        days_paid_out = max(remaining_own - 5, 0)
 
     payout_amount = round(days_paid_out * payout_per_day, 2)
 
@@ -378,7 +398,6 @@ def close_vacation_year(user, target_year: int, remaining_total: int, pay: dict,
         "payout_per_day": payout_per_day,
     }
 
-    saved = dict(user.vacation_saved or {})
     saved[str(target_year)] = closed_data
     user.vacation_saved = saved
     flag_modified(user, "vacation_saved")
@@ -497,6 +516,9 @@ def calculate_vacation_balance(user, target_year: int, db, off_dates: set[dateti
 
     total_available = entitled_days + saved_from_previous
     remaining_total = total_available - used["total"]
+    # The closing year's own remaining days; saved days from earlier years are
+    # handled separately and must not be swept into a close or payout.
+    remaining_own = entitled_days - used["total"]
 
     # Auto-close past years / show projection for open years
     today = datetime.date.today()
@@ -510,7 +532,7 @@ def calculate_vacation_balance(user, target_year: int, db, off_dates: set[dateti
         if year_key in vacation_saved:
             closed = vacation_saved[year_key]
         else:
-            closed = close_vacation_year(user, target_year, remaining_total, pay, db)
+            closed = close_vacation_year(user, target_year, remaining_own, pay, db)
     else:
         # Year is open — show projection of what will happen at year-end
         monthly_salary = pay.get("monthly_salary", 0)
@@ -518,8 +540,8 @@ def calculate_vacation_balance(user, target_year: int, db, off_dates: set[dateti
         payout_pct = pay.get("payout_pct", 0.046)
         payout_per_day = round(monthly_salary * payout_pct + supplement_per_day, 2)
 
-        days_to_save = min(max(remaining_total, 0), 5)
-        days_to_pay_out = max(remaining_total - 5, 0)
+        days_to_save = min(max(remaining_own, 0), 5)
+        days_to_pay_out = max(remaining_own - 5, 0)
 
         projection = {
             "days_to_save": days_to_save,

--- a/app/core/schedule/vacation.py
+++ b/app/core/schedule/vacation.py
@@ -375,7 +375,11 @@ def close_vacation_year(user, target_year: int, remaining_own: int, pay: dict, d
         # days, oldest year first.
         overuse = -remaining_own
         if overuse > 0:
-            for y in sorted((k for k in saved if str(k).isdigit() and int(k) < target_year), key=int):
+            # Only years inside the five-year validity window count as available
+            # (matching get_saved_days_balance); expired entries are not consumed.
+            for y in sorted(
+                (k for k in saved if str(k).isdigit() and target_year - 5 <= int(k) < target_year), key=int
+            ):
                 entry = dict(saved[y])
                 available = entry.get("saved", 0)
                 take = min(available, overuse)

--- a/scripts/audit_vacation_saved.py
+++ b/scripts/audit_vacation_saved.py
@@ -1,0 +1,50 @@
+"""Read-only audit: list users whose closed vacation years may have paid out
+previously saved days (bug fixed on branch fix/vacation-year-close).
+
+A close is suspect when a year was closed with paid_out > 0 while saved days
+from an earlier year existed. The script only prints; it never writes. Run it
+against a BACKUP COPY of the production database and review the output with
+the domain owner before any manual correction.
+
+Usage: python3 scripts/audit_vacation_saved.py [path/to/schedule.db]
+"""
+
+import json
+import sqlite3
+import sys
+
+
+def main() -> None:
+    db_path = sys.argv[1] if len(sys.argv) > 1 else "app/database/schedule.db"
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    rows = conn.execute("SELECT id, name, vacation_saved FROM users WHERE vacation_saved IS NOT NULL").fetchall()
+
+    suspects = 0
+    for uid, name, raw in rows:
+        try:
+            data = json.loads(raw) if raw else {}
+        except (TypeError, ValueError):
+            print(f"user {uid} ({name}): unparseable vacation_saved: {raw!r}")
+            continue
+        years = sorted((y for y in data if str(y).isdigit()), key=int)
+        for y in years:
+            entry = data.get(y) or {}
+            if entry.get("paid_out", 0) > 0:
+                earlier = {
+                    e: (data.get(e) or {}).get("saved", 0)
+                    for e in years
+                    if int(e) < int(y) and (data.get(e) or {}).get("saved", 0) > 0
+                }
+                if earlier:
+                    suspects += 1
+                    print(
+                        f"user {uid} ({name}): year {y} closed with paid_out="
+                        f"{entry['paid_out']} ({entry.get('payout_amount', 0)} kr) "
+                        f"while earlier saved days existed: {earlier}"
+                    )
+    conn.close()
+    print(f"\n{suspects} suspect close(s) found across {len(rows)} user(s) with saved data.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/audit_vacation_saved.py
+++ b/scripts/audit_vacation_saved.py
@@ -6,6 +6,11 @@ from an earlier year existed. The script only prints; it never writes. Run it
 against a BACKUP COPY of the production database and review the output with
 the domain owner before any manual correction.
 
+This heuristic is only meaningful for data written before the fix on this
+branch: after the fix, paid_out > 0 with earlier saved days present is the
+correct state, so this script is a one-time pre-fix sweep, not a recurring
+monitor.
+
 Usage: python3 scripts/audit_vacation_saved.py [path/to/schedule.db]
 """
 

--- a/tests/test_vacation_balance.py
+++ b/tests/test_vacation_balance.py
@@ -185,7 +185,7 @@ class TestCloseVacationYear:
         user = _make_user(test_db, person_id=3, vacation_saved={})
         pay = {"monthly_salary": 30000, "supplement_per_day": 100, "payout_pct": 0.046}
         # 8 remaining -> save 5, pay out 3.
-        result = close_vacation_year(user, 2025, remaining_total=8, pay=pay, db=test_db)
+        result = close_vacation_year(user, 2025, remaining_own=8, pay=pay, db=test_db)
         assert result["saved"] == 5
         assert result["paid_out"] == 3
         # payout_per_day = 30000 * 0.046 + 100 = 1480.
@@ -198,7 +198,7 @@ class TestCloseVacationYear:
     def test_negative_remaining_saves_nothing(self, test_db):
         user = _make_user(test_db, person_id=4, vacation_saved={})
         pay = {"monthly_salary": 30000, "supplement_per_day": 0, "payout_pct": 0.046}
-        result = close_vacation_year(user, 2025, remaining_total=-2, pay=pay, db=test_db)
+        result = close_vacation_year(user, 2025, remaining_own=-2, pay=pay, db=test_db)
         assert result["saved"] == 0
         assert result["paid_out"] == 0
         assert result["payout_amount"] == 0

--- a/tests/test_vacation_year_close.py
+++ b/tests/test_vacation_year_close.py
@@ -109,3 +109,47 @@ def test_overuse_consumes_saved_days_oldest_first(db):
     saved = user.vacation_saved
     assert saved["2020"]["saved"] == 0, "oldest saved year consumed first"
     assert saved["2021"]["saved"] == 4, "remainder taken from the next year"
+
+
+def test_overuse_exceeding_available_saved_days_is_dropped_without_error(db):
+    user = _make_user(
+        db,
+        vacation_saved={
+            "2020": {"saved": 2, "paid_out": 0, "payout_amount": 0.0, "payout_per_day": 0.0},
+            "2021": {"saved": 3, "paid_out": 0, "payout_amount": 0.0, "payout_per_day": 0.0},
+        },
+    )
+    pay = {"monthly_salary": 30000, "supplement_per_day": 150.0, "payout_pct": 0.046}
+
+    # Used 10 more days than the year's own entitlement, far more than the 5
+    # days available across all in-window saved years.
+    closed = close_vacation_year(user, 2023, -10, pay, db)
+
+    assert closed["saved"] == 0
+    assert closed["paid_out"] == 0
+    assert closed["payout_amount"] == 0.0
+    saved = user.vacation_saved
+    assert saved["2020"]["saved"] == 0
+    assert saved["2021"]["saved"] == 0, "all in-window entries drained, residual overuse dropped"
+
+
+def test_expired_saved_entry_is_not_consumed_by_overuse(db):
+    # target_year 2023 -> five-year window is 2018-2022, so 2017 is expired
+    # and must not be touched even though it's numerically the oldest.
+    user = _make_user(
+        db,
+        vacation_saved={
+            "2017": {"saved": 3, "paid_out": 0, "payout_amount": 0.0, "payout_per_day": 0.0},
+            "2021": {"saved": 5, "paid_out": 0, "payout_amount": 0.0, "payout_per_day": 0.0},
+        },
+    )
+    pay = {"monthly_salary": 30000, "supplement_per_day": 150.0, "payout_pct": 0.046}
+
+    closed = close_vacation_year(user, 2023, -2, pay, db)
+
+    assert closed["saved"] == 0
+    assert closed["paid_out"] == 0
+    assert closed["payout_amount"] == 0.0
+    saved = user.vacation_saved
+    assert saved["2017"]["saved"] == 3, "expired entry outside the five-year window is untouched"
+    assert saved["2021"]["saved"] == 3, "in-window entry absorbs the overuse instead"

--- a/tests/test_vacation_year_close.py
+++ b/tests/test_vacation_year_close.py
@@ -1,0 +1,111 @@
+"""Closing a vacation year must only save/pay out the year's own remaining days.
+
+Previously the close was fed entitled + saved_from_previous - used, which swept
+earlier years' saved days (valid five years per semesterlagen paragraph 18) into
+the cash payout while leaving their vacation_saved entries in place, so the same
+days were both paid out and still counted as an available saved balance.
+"""
+
+import datetime
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.core.schedule.vacation import (
+    calculate_vacation_balance,
+    close_vacation_year,
+    get_saved_days_balance,
+)
+from app.database.database import Base, User, UserRole, WageType
+
+
+@pytest.fixture()
+def db():
+    eng = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(bind=eng)
+    session = sessionmaker(bind=eng)()
+    yield session
+    session.close()
+
+
+def _make_user(db, *, vacation_saved=None):
+    user = User(
+        id=99,
+        username="v",
+        password_hash="x",
+        name="V",
+        role=UserRole.USER,
+        wage=30000,
+        wage_type=WageType.MONTHLY,
+        vacation={},
+        must_change_password=0,
+        is_active=1,
+        person_id=None,
+        employment_start_date=datetime.date(2015, 1, 1),
+        vacation_year_start_month=4,
+        vacation_days_per_year=25,
+        vacation_saved=vacation_saved or {},
+    )
+    db.add(user)
+    db.commit()
+    return user
+
+
+_SAVED_2021 = {"2021": {"saved": 5, "paid_out": 0, "payout_amount": 0.0, "payout_per_day": 0.0}}
+
+
+def test_close_pays_out_only_the_years_own_days(db):
+    user = _make_user(db, vacation_saved=dict(_SAVED_2021))
+
+    bal = calculate_vacation_balance(user, 2023, db)
+    closed = bal["closed"]
+    assert closed is not None, "2023 is past its year-end and must auto-close"
+
+    # 25 entitled, 0 used: save 5, pay out 20. The 2021 saved days are untouched.
+    assert closed["saved"] == 5
+    assert closed["paid_out"] == 20
+    assert (user.vacation_saved or {}).get("2021", {}).get("saved") == 5
+
+
+def test_saved_days_are_not_double_counted_after_close(db):
+    user = _make_user(db, vacation_saved=dict(_SAVED_2021))
+
+    calculate_vacation_balance(user, 2023, db)
+
+    # 2021's 5 (still saved) plus 2023's newly saved 5.
+    assert get_saved_days_balance(user, 2024)["total_saved"] == 10
+
+
+def test_projection_for_open_year_uses_only_own_days(db):
+    user = _make_user(db, vacation_saved=dict(_SAVED_2021))
+
+    bal = calculate_vacation_balance(user, 2026, db)
+    projection = bal["projection"]
+    assert projection is not None, "2026 vacation year is open and must project"
+
+    # Projection must not sweep the 2021 saved days into the payout either.
+    assert projection["days_to_save"] == 5
+    assert projection["days_to_pay_out"] == 20
+
+
+def test_overuse_consumes_saved_days_oldest_first(db):
+    user = _make_user(
+        db,
+        vacation_saved={
+            "2020": {"saved": 2, "paid_out": 0, "payout_amount": 0.0, "payout_per_day": 0.0},
+            "2021": {"saved": 5, "paid_out": 0, "payout_amount": 0.0, "payout_per_day": 0.0},
+        },
+    )
+    pay = {"monthly_salary": 30000, "supplement_per_day": 150.0, "payout_pct": 0.046}
+
+    # Used 3 more days than the year's own entitlement.
+    closed = close_vacation_year(user, 2023, -3, pay, db)
+
+    assert closed["saved"] == 0
+    assert closed["paid_out"] == 0
+    assert closed["payout_amount"] == 0.0
+    saved = user.vacation_saved
+    assert saved["2020"]["saved"] == 0, "oldest saved year consumed first"
+    assert saved["2021"]["saved"] == 4, "remainder taken from the next year"


### PR DESCRIPTION
## Summary

Closing a vacation year was fed entitled + saved_from_previous - used, so days legitimately saved in earlier years (valid five years per semesterlagen paragraph 18) were swept into the year's cash payout, while their vacation_saved entries were never cleared and kept counting as an available balance in later years: the same days were both paid out and still reported as saved. Auto-close runs on plain GETs of the personal year/month views, so this wrote incorrect data.

- close_vacation_year now receives the year's own remaining days (entitled - used): it saves up to 5 and pays out the rest, leaving earlier saved days untouched.
- Overuse beyond the year's own entitlement consumes saved days oldest year first.
- The open-year projection uses the same own-days basis.
- scripts/audit_vacation_saved.py is a read-only script that lists potentially affected production rows for manual review (run against a backup copy).

## Testing

New tests in tests/test_vacation_year_close.py: correct payout at close, no double counting of saved days, projection basis, and oldest-first overuse consumption. Confirmed failing before the fix. Full suite green, ruff clean.