### PR TITLE
fix(admin): render validation errors on settings page

### DIFF
--- a/app/templates/admin_settings.html
+++ b/app/templates/admin_settings.html
@@ -7,6 +7,12 @@
 
 <h2 class="page-title">{{ t.admin_settings_title }}</h2>
 
+{% if error %}
+    <div class="alert alert--danger">
+        {{ error }}
+    </div>
+{% endif %}
+
 <div class="mb-3">
     <a href="/admin/rotation-eras" class="btn secondary inline-block">
         📅 {{ t.admin_settings_manage_eras }}

--- a/tests/test_admin_settings_routes.py
+++ b/tests/test_admin_settings_routes.py
@@ -1,0 +1,27 @@
+"""Integration tests for the admin settings update route.
+
+Covers the validation-error path of POST /admin/settings, which historically
+computed an "error" message but never rendered it in admin_settings.html,
+silently dropping the feedback from the user (found while triaging #89).
+"""
+
+
+def _login(client, username, password):
+    client.post("/login", data={"username": username, "password": password})
+
+
+class TestAdminSettingsUpdateErrorDisplay:
+    def test_invalid_monthly_salary_shows_error_message(self, test_client, test_db, admin_user):
+        _login(test_client, "admin", "adminpass123")
+
+        resp = test_client.post(
+            "/admin/settings",
+            data={
+                "monthly_salary": 500,  # below the allowed 1000-1000000 range
+                "person_wages": "{}",
+            },
+            follow_redirects=False,
+        )
+
+        assert resp.status_code == 400
+        assert "Ogiltig månads lön" in resp.text


### PR DESCRIPTION
## Summary

`POST /admin/settings` returns the settings template with an `error` context key on validation failures (invalid monthly salary, malformed wage JSON, config file problems), but `admin_settings.html` had no `{% if error %}` block, so the message was silently dropped and the admin saw a blank form with no feedback.

This adds the same alert banner pattern already used by `admin_user_edit.html` and `admin_rotation_eras.html` to `admin_settings.html`.

Fixes the silent error drop found while triaging #89. Field-level validation and the rest of #89's scope are intentionally left out; the issue stays open.

## Changes

- `app/templates/admin_settings.html`: render the `error` context value in an `alert alert--danger` banner below the page title.
- `tests/test_admin_settings_routes.py`: new integration test posting an out-of-range monthly salary as admin and asserting the 400 response contains the error message.

## Testing

- New test written first and confirmed failing before the template fix, passing after.
- Full suite: 474 passed.
- `ruff check`: clean.