### PR TITLE
fix(wages): include boundary day in wage history lookup

### DIFF
--- a/app/core/schedule/wages.py
+++ b/app/core/schedule/wages.py
@@ -82,8 +82,10 @@ def get_user_wage(session, user_id: int, fallback: int | None = None, effective_
         .filter(
             WageHistory.user_id == user_id,
             WageHistory.effective_from <= effective_date,
-            # Either no end date (current wage) OR end date is after effective_date
-            (WageHistory.effective_to.is_(None)) | (WageHistory.effective_to > effective_date),
+            # Either no end date (current wage) OR end date is on/after effective_date.
+            # effective_to is set by add_new_wage() as an INCLUSIVE last valid day
+            # (new_effective_from - 1 day), so this must be >= to cover that boundary day.
+            (WageHistory.effective_to.is_(None)) | (WageHistory.effective_to >= effective_date),
         )
         .order_by(WageHistory.effective_from.desc())
         .first()

--- a/tests/test_transition_core.py
+++ b/tests/test_transition_core.py
@@ -13,8 +13,6 @@ they actually pin the arithmetic rather than just mirror it.
 import datetime
 from types import SimpleNamespace
 
-import pytest
-
 from app.core.schedule.transition import (
     calculate_consultant_vacation_days,
     calculate_consultant_vacation_payout,
@@ -405,48 +403,36 @@ class TestCalculateTransitionMonthSummary:
 
 
 class TestKnownBugWageBoundaryOnBackdatedTransition:
-    """Documents a wage-resolution boundary bug surfaced through transition.py.
+    """Regression test for a wage-resolution boundary bug surfaced through transition.py.
 
-    Root cause: app.core.schedule.wages.get_user_wage() queries WageHistory with
-    `effective_to > effective_date` (a strictly-greater comparison), while
+    Root cause (fixed): app.core.schedule.wages.get_user_wage() queried WageHistory
+    with `effective_to > effective_date` (a strictly-greater comparison), while
     add_new_wage() closes the previous record with
     `effective_to = new_effective_from - 1 day` (meant as the *last inclusive day*
-    of the old wage). Those two conventions disagree on that exact boundary day:
-    the closed record no longer matches (effective_to is not > that day), and the
-    new record doesn't match either (its effective_from is the day after). The
-    function then falls through to the `User.wage` snapshot -- which is correct
-    only if that snapshot hasn't already been bumped to the new wage.
+    of the old wage). Those two conventions disagreed on that exact boundary day:
+    the closed record no longer matched (effective_to was not > that day), and the
+    new record didn't match either (its effective_from is the day after). The
+    function then fell through to the `User.wage` snapshot -- which is only correct
+    if that snapshot hasn't already been bumped to the new wage.
 
     add_new_wage() bumps the snapshot immediately whenever effective_from <= today.
-    So the fallback silently returns the *new* wage instead of the old one whenever
-    a caller asks for the wage on the day before a raise that has already taken
-    effect (transition_date <= today) -- exactly what
+    So the fallback used to silently return the *new* wage instead of the old one
+    whenever a caller asked for the wage on the day before a raise that had already
+    taken effect (transition_date <= today) -- exactly what
     calculate_consultant_vacation_payout() and calculate_transition_month_summary()
     do for `last_consultant_day = transition.transition_date - 1 day`.
 
-    In practice this self-corrects for transitions scheduled in the future (the
-    common case -- see the tests above, which use future dates specifically to
-    avoid tripping this), but it silently pays the consultant's vacation payout
-    and trailing base salary using the *direct employer's new wage* instead of the
-    consultant's actual final wage whenever the transition is recorded on or after
-    its own effective date (e.g. entered on/after the employee's first direct day,
-    or backfilled after the fact). Root cause lives in app/core/schedule/wages.py
-    (out of this module's scope), so it is documented here rather than fixed.
+    This self-corrected for transitions scheduled in the future (the common case --
+    see the tests above, which use future dates), but it silently paid the
+    consultant's vacation payout and trailing base salary using the *direct
+    employer's new wage* instead of the consultant's actual final wage whenever the
+    transition was recorded on or after its own effective date (e.g. entered
+    on/after the employee's first direct day, or backfilled after the fact).
+
+    Fixed in app/core/schedule/wages.py by comparing `effective_to >= effective_date`
+    so the closed record's inclusive last day is matched correctly.
     """
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "get_user_wage() boundary bug (app/core/schedule/wages.py): querying the "
-            "wage for the day before a raise that has already taken effect (relative to "
-            "'today') returns the NEW wage instead of the OLD one, because the closed "
-            "WageHistory record's effective_to is excluded by a strict '>' comparison "
-            "and the fallback then reads the already-bumped User.wage snapshot. This "
-            "corrupts calculate_consultant_vacation_payout()'s monthly_salary (and thus "
-            "the whole payout) for any transition recorded on or after its own "
-            "effective date. See class docstring for the full trace."
-        ),
-    )
     def test_vacation_payout_uses_consultant_wage_not_new_direct_wage(self, test_db, monkeypatch):
         from app.core.schedule.wages import add_new_wage
 


### PR DESCRIPTION
## Summary

`get_user_wage()` in `app/core/schedule/wages.py` queried `WageHistory` with a strict `effective_to > effective_date` comparison, while `add_new_wage()` closes the previous wage record with `effective_to = new_effective_from - 1 day`, meant as the *inclusive* last valid day of the old wage.

On that exact boundary day the two conventions disagreed: the closed record no longer matched (`effective_to` was not `>` that day), and the new record didn't match either (its `effective_from` is the day after). The lookup then fell through to the `User.wage` snapshot, which `add_new_wage()` had already bumped to the new wage whenever `effective_from <= today`.

## Impact

This corrupted vacation payout calculations for consultant-to-direct employment transitions. `calculate_consultant_vacation_payout()` and `calculate_transition_month_summary()` price the consultant's final day using `last_consultant_day = transition.transition_date - 1 day`. Whenever a transition was recorded on or after its own effective date (entered the same day, or backfilled after the fact), that lookup silently returned the direct employer's new wage instead of the consultant's actual final wage, producing an incorrect vacation payout amount. Transitions entered ahead of time (the common case) were unaffected, since the boundary day had not yet been reached.

## Fix

Changed the comparison to `effective_to >= effective_date` so the closed record's inclusive last day is matched correctly. Reviewed the rest of `wages.py` for the same off-by-one pattern against `WageHistory`; no other occurrence exists in this file.

## Test

`tests/test_transition_core.py::TestKnownBugWageBoundaryOnBackdatedTransition::test_vacation_payout_uses_consultant_wage_not_new_direct_wage` was added in #284 as a `strict` `xfail` documenting this bug. The `xfail` marker is removed here so it now runs as a normal regression test, and the class docstring is updated to describe the fixed behavior instead of the bug.

## Test plan

- [x] `pytest tests/test_transition_core.py::TestKnownBugWageBoundaryOnBackdatedTransition` passes
- [x] Full suite: `pytest` — 519 passed
- [x] `ruff check .` — all checks passed