### PR TITLE
fix(rates): include boundary day in rate history lookup

### DIFF
--- a/app/core/rates.py
+++ b/app/core/rates.py
@@ -71,7 +71,10 @@ def get_user_rates(user, session=None, effective_date: datetime.date | None = No
             .filter(
                 RateHistory.user_id == user.id,
                 RateHistory.effective_from <= effective_date,
-                (RateHistory.effective_to.is_(None)) | (RateHistory.effective_to > effective_date),
+                # Either no end date (current rates) OR end date is on/after effective_date.
+                # effective_to is set by add_new_rates() as an INCLUSIVE last valid day
+                # (new_effective_from - 1 day), so this must be >= to cover that boundary day.
+                (RateHistory.effective_to.is_(None)) | (RateHistory.effective_to >= effective_date),
             )
             .order_by(RateHistory.effective_from.desc())
             .first()

--- a/tests/test_rates.py
+++ b/tests/test_rates.py
@@ -114,6 +114,28 @@ class TestGetUserRates:
         # No RateHistory rows exist, so it falls back to the User snapshot.
         assert get_user_rates(user, test_db, datetime.date(2026, 6, 1))["ot"] == 99
 
+    def test_boundary_day_returns_old_rate_not_bumped_snapshot(self, test_db):
+        """Regression test mirroring the wage boundary fix in PR #286.
+
+        add_new_rates() closes the previous record with
+        effective_to = new_effective_from - 1 day, meant as the INCLUSIVE last
+        valid day of the old rates. Querying get_user_rates() for that exact
+        boundary day must still return the OLD rates via RateHistory, not fall
+        through to User.custom_rates -- which add_new_rates() has already bumped
+        to the new value because the change is effective today.
+        """
+        user = _make_user(test_db, custom_rates={"ot": 40})
+        today = get_today()
+        boundary_day = today - datetime.timedelta(days=1)
+
+        add_new_rates(test_db, user.id, {"ot": 100}, today)
+        test_db.refresh(user)
+        # Snapshot already bumped since the new rate is effective today.
+        assert user.custom_rates == {"ot": 100}
+
+        # The day before must still resolve to the OLD rate through RateHistory.
+        assert get_user_rates(user, test_db, boundary_day)["ot"] == 40
+
 
 class TestAddNewRates:
     def test_seeds_initial_history_from_existing_custom_rates(self, test_db):


### PR DESCRIPTION
## Summary

`get_user_rates()` in `app/core/rates.py` queried `RateHistory` with a strict `effective_to > effective_date` comparison, while `add_new_rates()` closes the previous record with `effective_to = new_effective_from - 1 day`, meant as the *inclusive* last valid day of the old rates.

On that exact boundary day the two conventions disagreed: the closed record no longer matched (`effective_to` was not `>` that day), and the new record didn't match either (its `effective_from` is the day after). The lookup then fell through to the `User.custom_rates` snapshot, which `add_new_rates()` had already bumped to the new rates whenever `effective_from <= today`.

This is the same off-by-one fixed for `WageHistory` in PR #286 (`get_user_wage()` in `app/core/schedule/wages.py`); it was kept as a separate fix since `rates.py` was out of scope for that PR.

## Impact

Any rate-dependent calculation (OB rates, OT rates, on-call rates) evaluated for the boundary day of a rate change used the new rates instead of the rates actually in force that day. Backdated or same-day rate changes were affected; future-dated changes were not, since their boundary day had not yet been reached.

## Fix

Changed the comparison to `effective_to >= effective_date` so the closed record's inclusive last day is matched correctly. This is consistent with `get_rate_history()`'s status classification in the same file, which already treats `effective_to >= today` as current. Reviewed the remaining `RateHistory` queries in the file; no other occurrence of the strict pattern exists.

## Test

Added `tests/test_rates.py::TestGetUserRates::test_boundary_day_returns_old_rate_not_bumped_snapshot`, mirroring the regression test for the wage fix: record a rate change effective today via `add_new_rates()`, verify the snapshot was bumped, then assert that querying the boundary day (yesterday) still returns the old rates. The test fails on main and passes with this fix.

## Test plan

- [x] `pytest tests/test_rates.py` passes (24 tests)
- [x] Full suite: `pytest` (519 passed, 1 xfailed; the xfail is the wage boundary test resolved separately by PR #286)
- [x] `ruff check .` passes

Closes #287
