### PR TITLE
Prepare changelog for 0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Vikarier kan kopplas till användarkonton (`substitutes.user_id`) och få en timlön (`substitutes.hourly_wage`). För en kopplad användare visas vikariepassen före anställningsstarten i de personliga vyerna (dag/vecka/månad/år/statistik), märkta som vikariepass, och räknas in i timmar, OB och lön – prissatta som timavlönade med samma beräkningar som befintliga timavlönade användare. Övertid prissätts med timlönen i personvyn medan `ot_pay` förblir 0 i databasen (lagvyns källa). Personbytesflödet har ett nytt läge "Befintlig vikarie" som skapar kontot, kopplar vikarien och startar anställningen i en transaktion, och vikarieadminsidan kan koppla retroaktivt och sätta timlön. Månadsrapporten döljer en kopplad vikaries redan attribuerade dagar så inget dubbelräknas
 
+### Fixed
+- Administratörens inställningssida visar nu felmeddelandet när sparandet misslyckas, till exempel vid en ogiltig månadslön. Tidigare försvann felet tyst och sidan visade bara ett tomt formulär
+- Semesterutbetalning vid ett anställningsbyte som registrerades på eller efter sitt eget ikraftträdandedatum kunde räknas på den nya direktlönen i stället för konsultens faktiska slutlön. Gränsdagen prissätts nu alltid med den lön som faktiskt gällde den dagen
+- OB-, övertids- och beredskapsrater på exakt den dag en ratändring träder i kraft kunde räknas med de nya raterna i stället för de som gällde den dagen. Gränsdagen prissätts nu alltid med de rater som faktiskt gällde
+- Dagvyn visar nu samma sak som vecko-, månads- och årsvyn: accepterade skiftbyten syns (visades tidigare inte alls), föräldraledighet och dagsemester visas som ledighet respektive semester, en heldags sjukfrånvaro maskar passkoden, och beredskap hanteras konsekvent i alla vyer
+
 ### Deployment
 - Kör migrationen `python migrations/migrate_substitute_account_link.py <db-path>` (lägger till `user_id` och `hourly_wage` på `substitutes`, idempotent). Ta backup av produktionsdatabasen först: `sqlite3 app/database/schedule.db ".backup app/database/schedule.db.bak"`
 

--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -15,6 +15,32 @@ router = APIRouter()
 
 VERSIONS = [
     {
+        "version": "0.29.0",
+        "date": "2026-07-17",
+        "entries": [
+            {
+                "type": "nyhet",
+                "sv": "Vikarier kan nu kopplas till användarkonton och få en timlön. För en kopplad användare visas vikariens pass före anställningsstarten i alla personliga vyer, märkta som vikariepass, och räknas in i timmar, OB och lön på samma sätt som för timavlönade användare. Personbytesflödet har ett nytt läge för att koppla en befintlig vikarie direkt vid anställningsstart, och vikarieadminsidan kan koppla och sätta timlön retroaktivt",
+                "en": "Substitutes can now be linked to user accounts and given an hourly wage. For a linked user, the substitute's shifts before the employment start date appear in every personal view, marked as substitute shifts, and count into hours, OB pay and wage the same way as for hourly-wage users. The person-change flow has a new mode for linking an existing substitute directly at the start of employment, and the substitute admin page can link and set the hourly wage retroactively",
+            },
+            {
+                "type": "fix",
+                "sv": "Administratörens inställningssida visar nu felmeddelandet när sparandet misslyckas, till exempel vid en ogiltig månadslön. Tidigare försvann felet tyst och sidan visade bara ett tomt formulär",
+                "en": "The admin settings page now shows the error message when saving fails, for example an invalid monthly salary. Previously the error disappeared silently and the page just showed a blank form",
+            },
+            {
+                "type": "fix",
+                "sv": "Semesterutbetalningar och OB-, övertids- och beredskapsrater som föll på exakt den dag en lön- eller ratändring trädde i kraft kunde räknas med de nya värdena i stället för de som faktiskt gällde den dagen. Gränsdagen prissätts nu alltid korrekt",
+                "en": "Vacation payouts and OB, overtime and on-call rates falling on the exact day a wage or rate change took effect could be calculated with the new values instead of the ones actually in force that day. The boundary day is now always priced correctly",
+            },
+            {
+                "type": "fix",
+                "sv": "Dagvyn visar nu samma sak som vecko-, månads- och årsvyn: accepterade skiftbyten syns (visades tidigare inte alls), föräldraledighet och dagsemester visas som ledighet respektive semester, en heldags sjukfrånvaro maskar passkoden, och beredskap hanteras konsekvent i alla vyer",
+                "en": "The day view now shows the same thing as the week, month and year views: accepted shift swaps appear (previously not shown at all), parental leave and day-level vacation show as leave and vacation respectively, a full-day sick absence masks the shift code, and on-call is handled consistently across every view",
+            },
+        ],
+    },
+    {
         "version": "0.28.1",
         "date": "2026-07-15",
         "entries": [


### PR DESCRIPTION
## Summary

Adds the 0.29.0 entries to both changelogs ahead of the release:

- **CHANGELOG.md**: new Fixed section under [Unreleased] covering the admin settings error display (#283), the wage and rate history boundary-day fixes (#286, #288), and the day view unification with the canonical calculation path (#289). The substitute account link feature entry from #291 is left as is.
- **app/routes/changelog.py**: new VERSIONS entry 0.29.0 (2026-07-17) with Swedish and English texts: the substitute account link feature (type nyhet), the admin settings error display fix, the wage/rate boundary-day fixes combined as one entry (same bug class), and the day view unification highlighting that accepted shift swaps now show in the day view.

The app version shown by /health and the templates derives from VERSIONS[0], so it becomes 0.29.0 automatically when this merges. No other version constants needed bumping (pyproject.toml and app/__init__.py have never been part of the release flow).

## Test

Full suite 576 passed, 1 xfailed. ruff check and ruff format clean.