### PR TITLE
Link the header wordmark to the dashboard

### DIFF
--- a/app/static/css/layout.css
+++ b/app/static/css/layout.css
@@ -73,6 +73,13 @@ footer {
 .app-header-row { justify-content: space-between; }
 .app-brand { flex: none; }
 .app-title { margin: 0; font-size: 1.375rem; }
+/* The wordmark links home. Inherit rather than take the global accent link
+   colour: the title is chrome, and a teal heading would read as the page's
+   one chromatic event, which belongs to the shift pills. Accent on hover only,
+   matching how .nav-link signals interactivity. */
+.app-title-link { color: inherit; text-decoration: none; }
+.app-title-link:hover { color: var(--accent); }
+.app-title-link:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius: 3px; }
 .app-subtitle { color: var(--muted); font-size: 0.8125rem; margin-top: 2px; }
 .app-footer {
   display: flex;

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -26,7 +26,7 @@
         <header>
             <div class="row app-header-row">
                 <div class="col app-brand">
-                    <h1 class="app-title">Periodical</h1>
+                    <h1 class="app-title"><a href="/" class="app-title-link">Periodical</a></h1>
                     <div class="app-subtitle">
                         {{ t.app_subtitle }}
                     </div>

--- a/tests/test_base_layout.py
+++ b/tests/test_base_layout.py
@@ -1,0 +1,16 @@
+"""Tests for shared chrome in base.html."""
+
+import pytest
+
+
+@pytest.mark.parametrize("path", ["/login", "/changelog"])
+def test_wordmark_links_home(test_client, path):
+    """The header wordmark is the way back to the dashboard from anywhere.
+
+    Asserted rather than eyeballed because a template change that drops the
+    anchor produces no error: the heading still renders, it just stops being
+    clickable.
+    """
+    response = test_client.get(path)
+    assert response.status_code == 200
+    assert '<a href="/" class="app-title-link">Periodical</a>' in response.text


### PR DESCRIPTION
## Why

The "Periodical" wordmark in the header was inert. Clicking a site's logo to get
home is a convention users bring with them, so an unclickable one costs a small
amount of friction on every page: the only route back to the dashboard was the
Overview nav item.

## What changed

`base.html` wraps the wordmark in an anchor to `/`.

The CSS is the part worth reviewing. The global `a { color: var(--accent) }`
rule in `base.css` would have painted the heading teal, and a teal wordmark
competes with the shift pills for being the page's one chromatic event: the
opposite of the design principle in PRODUCT.md, where colour belongs to the
data and the chrome stays near-colourless. `.app-title-link` inherits `--text`
instead, so the wordmark looks exactly as it did before, and shows the accent
on hover only. That matches how `.nav-link` already signals interactivity.

A `:focus-visible` outline is included: a clickable heading with no visible
keyboard focus is an accessibility gap.

## Note

While logged out, `/` redirects to `/login`, so for an anonymous visitor the
wordmark points back at the page they are already on. Harmless, and cheaper
than conditioning the link on authentication.

## Testing

- 647 passed, 0 failed
- `tests/test_base_layout.py` asserts the anchor renders, on both a logged-out
  page and an authenticated one. Asserted rather than eyeballed because a
  template change that drops the anchor produces no error: the heading still
  renders, it just stops being clickable
