### PR TITLE
Assemble shared template context in one place

### DIFF
--- a/app/core/helpers.py
+++ b/app/core/helpers.py
@@ -5,14 +5,9 @@ Shared helper functions for templates and route handlers.
 
 from datetime import date
 
-from fastapi import HTTPException, Request
-from fastapi.templating import Jinja2Templates
+from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
-from app.auth.csrf import get_csrf_token
-from app.core.news import has_unseen_news
-from app.core.translations import TRANSLATIONS
-from app.core.utils import get_today
 from app.database.database import User, UserRole
 
 
@@ -146,32 +141,3 @@ def strip_year_summary(summary: dict) -> dict:
     result["ob_pay_by_code"] = {}
     result["total_ob_hours"] = None
     return result
-
-
-def render_template(
-    templates: Jinja2Templates,
-    template_name: str,
-    request: Request,
-    context: dict,
-    user: User | None = None,
-):
-    """
-    Render template with user context and translations automatically included.
-    """
-    lang = "sv"
-    if user and hasattr(user, "language") and user.language:
-        lang = user.language
-    ctx = {
-        "request": request,
-        "user": user,
-        "now": get_today(),
-        "t": TRANSLATIONS.get(lang, TRANSLATIONS["sv"]),
-        # Every state-changing form needs the token published by CSRFMiddleware
-        "csrf_token": get_csrf_token(request),
-        # Kept in sync with routes.shared.render(): base.html reads has_news on
-        # every page, so both render paths must supply it or the nav entry
-        # silently disappears on whichever path forgets.
-        "has_news": has_unseen_news(user),
-    }
-    ctx.update(context)
-    return templates.TemplateResponse(request, template_name, ctx)

--- a/app/routes/dashboard.py
+++ b/app/routes/dashboard.py
@@ -11,7 +11,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from sqlalchemy.orm import Session
 
 from app.auth.auth import get_current_user_optional
-from app.core.helpers import can_see_salary, render_template
+from app.core.helpers import can_see_salary
 from app.core.logging_config import get_logger
 from app.core.oncall import _cached_oncall_rules, calculate_oncall_pay
 from app.core.rates import get_user_rates
@@ -39,7 +39,7 @@ from app.core.schedule.wages import (
 )
 from app.core.utils import get_safe_today, get_today
 from app.database.database import Absence, OnCallOverride, OnCallOverrideType, ShiftSwap, SwapStatus, User, get_db
-from app.routes.shared import templates
+from app.routes.shared import render
 
 router = APIRouter(tags=["dashboard"])
 logger = get_logger(__name__)
@@ -463,11 +463,11 @@ async def read_root(
         .count()
     )
 
-    return render_template(
-        templates,
+    return render(
         "dashboard.html",
-        request,
         {
+            "request": request,
+            "user": current_user,
             "next_shift": next_shift,
             "next_oncall_shift": next_oncall_shift,
             "week_summary": week_summary,
@@ -485,5 +485,4 @@ async def read_root(
             "view_iso_week": view_iso_week,
             "view_iso_year_w": view_iso_year_w,
         },
-        user=current_user,
     )

--- a/app/routes/reports.py
+++ b/app/routes/reports.py
@@ -17,12 +17,11 @@ from fastapi.responses import HTMLResponse, RedirectResponse, StreamingResponse
 from sqlalchemy.orm import Session
 
 from app.auth.auth import get_current_user_optional
-from app.core.helpers import render_template
 from app.core.schedule import build_month_report, rotation_start_date
 from app.core.utils import get_safe_today
 from app.core.validators import validate_date_params
 from app.database.database import User, UserRole, get_db
-from app.routes.shared import templates
+from app.routes.shared import render
 
 router = APIRouter(tags=["reports"])
 
@@ -123,11 +122,11 @@ async def admin_report(
     is_admin = current_user is not None and current_user.role == UserRole.ADMIN
     share_token = REPORT_TOKEN if is_admin else ""
 
-    return render_template(
-        templates,
+    return render(
         "admin_report.html",
-        request,
         {
+            "request": request,
+            "user": current_user,
             "year": year,
             "month": month,
             "month_name": MONTH_NAMES_SV[month - 1],
@@ -142,7 +141,6 @@ async def admin_report(
             "share_token": share_token,
             "is_admin": is_admin,
         },
-        user=current_user,
     )
 
 

--- a/app/routes/schedule_all.py
+++ b/app/routes/schedule_all.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import Session
 
 from app.auth.auth import get_current_user_optional
 from app.core.constants import WEEKDAY_NAMES
-from app.core.helpers import can_see_salary, render_template, strip_salary_data
+from app.core.helpers import can_see_salary, strip_salary_data
 from app.core.holidays import get_holiday_dates_for_year
 from app.core.logging_config import get_logger
 from app.core.oncall import _get_storhelg_dates_for_year
@@ -33,7 +33,7 @@ from app.core.schedule.summary import _calculate_tax
 from app.core.utils import get_navigation_dates, get_safe_today, get_today
 from app.core.validators import validate_date_params
 from app.database.database import User, UserRole, WageType, get_db
-from app.routes.shared import templates
+from app.routes.shared import render
 
 logger = get_logger(__name__)
 
@@ -392,11 +392,11 @@ async def show_week_all(
     storhelg_dates = _get_storhelg_dates_for_year(year)
     holiday_dates = get_holiday_dates_for_year(year)
 
-    return render_template(
-        templates,
+    return render(
         "week_all.html",
-        request,
         {
+            "request": request,
+            "user": current_user,
             "year": year,
             "week": week,
             "days": days_in_week,
@@ -406,7 +406,6 @@ async def show_week_all(
             "holiday_dates": holiday_dates,
             **nav,
         },
-        user=current_user,
     )
 
 
@@ -555,11 +554,11 @@ async def show_month_all(
     storhelg_dates = _get_storhelg_dates_for_year(year)
     holiday_dates = get_holiday_dates_for_year(year)
 
-    return render_template(
-        templates,
+    return render(
         "month_all.html",
-        request,
         {
+            "request": request,
+            "user": current_user,
             "year": year,
             "month": month,
             "persons": persons,
@@ -568,7 +567,6 @@ async def show_month_all(
             "holiday_dates": holiday_dates,
             "today": get_today(),
         },
-        user=current_user,
     )
 
 
@@ -738,11 +736,11 @@ async def show_year_all(
     storhelg_dates = _get_storhelg_dates_for_year(year)
     holiday_dates = get_holiday_dates_for_year(year)
 
-    return render_template(
-        templates,
+    return render(
         "year_all.html",
-        request,
         {
+            "request": request,
+            "user": current_user,
             "year": year,
             "days": days_in_year,
             "person_ob_totals": person_ob_totals,
@@ -752,7 +750,6 @@ async def show_year_all(
             "holiday_dates": holiday_dates,
             "today": real_today,
         },
-        user=current_user,
     )
 
 
@@ -806,11 +803,11 @@ async def show_handover(
                 else:
                     code_to_group["N1"]["persons"].append(name)
 
-    return render_template(
-        templates,
+    return render(
         "handover.html",
-        request,
         {
+            "request": request,
+            "user": current_user,
             "date": target_date,
             "weekday_name": WEEKDAY_NAMES[target_date.weekday()],
             "shift_groups": shift_groups,
@@ -818,5 +815,4 @@ async def show_handover(
             "next_date": target_date + timedelta(days=1),
             "today": today,
         },
-        user=current_user,
     )

--- a/app/routes/schedule_personal.py
+++ b/app/routes/schedule_personal.py
@@ -11,7 +11,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse, StreamingResponse
 from sqlalchemy.orm import Session
 
 from app.auth.auth import get_current_user_optional
-from app.core.helpers import can_see_salary, render_template, strip_salary_data
+from app.core.helpers import can_see_salary, strip_salary_data
 from app.core.holidays import get_holiday_dates_for_year
 from app.core.logging_config import get_logger
 from app.core.oncall import (
@@ -57,7 +57,7 @@ from app.database.database import (
     UserRole,
     get_db,
 )
-from app.routes.shared import _resolve_person_param, build_position_nav, redirect_if_not_own_data, templates
+from app.routes.shared import _resolve_person_param, build_position_nav, redirect_if_not_own_data, render
 
 logger = get_logger(__name__)
 
@@ -440,11 +440,11 @@ async def show_day_for_person(
     if not is_vacation_day:
         is_vacation_day = absence is not None and absence.absence_type == AbsenceType.VACATION
 
-    return render_template(
-        templates,
+    return render(
         "day.html",
-        request,
         {
+            "request": request,
+            "user": current_user,
             "person_id": person_id,
             "person_name": person_name,
             "person_nav": build_position_nav(db) if current_user.role == UserRole.ADMIN else None,
@@ -498,7 +498,6 @@ async def show_day_for_person(
             "all_oncall_types": all_oncall_types,
             **nav,
         },
-        user=current_user,
     )
 
 
@@ -587,11 +586,11 @@ async def show_week_for_person(
     storhelg_dates = _get_storhelg_dates_for_year(year)
     holiday_dates = get_holiday_dates_for_year(year)
 
-    return render_template(
-        templates,
+    return render(
         "week.html",
-        request,
         {
+            "request": request,
+            "user": current_user,
             "year": year,
             "week": week,
             "days": days_in_week,
@@ -603,7 +602,6 @@ async def show_week_for_person(
             "holiday_dates": holiday_dates,
             **nav,
         },
-        user=current_user,
     )
 
 
@@ -704,11 +702,11 @@ async def show_range_for_person(
         storhelg_dates |= _get_storhelg_dates_for_year(yr)
         holiday_dates |= get_holiday_dates_for_year(yr)
 
-    return render_template(
-        templates,
+    return render(
         "range.html",
-        request,
         {
+            "request": request,
+            "user": current_user,
             "person_id": person_id,
             "person_name": person_name,
             "start_date": start,
@@ -724,7 +722,6 @@ async def show_range_for_person(
             "storhelg_dates": storhelg_dates,
             "holiday_dates": holiday_dates,
         },
-        user=current_user,
     )
 
 
@@ -972,11 +969,11 @@ async def show_month_for_person(
                 **_sjuklon_info,
             }
 
-    return render_template(
-        templates,
+    return render(
         "month.html",
-        request,
         {
+            "request": request,
+            "user": current_user,
             "year": year,
             "month": month,
             "person_id": person_id,
@@ -991,7 +988,6 @@ async def show_month_for_person(
             "hourly_breakdown": hourly_breakdown,
             "today": get_today(),
         },
-        user=current_user,
     )
 
 
@@ -1330,11 +1326,11 @@ async def year_view(
         },
     )
 
-    return render_template(
-        templates,
+    return render(
         "year.html",
-        request,
         {
+            "request": request,
+            "user": current_user,
             "year": year,
             "person_id": person_id,
             "person_name": person_name,
@@ -1348,7 +1344,6 @@ async def year_view(
             "ob_rules": combined_rules,  # All OB rules for label lookup
             "vacation_pay": vacation_pay,
         },
-        user=current_user,
     )
 
 
@@ -1418,11 +1413,11 @@ async def cowork_view(
             year, rotation_position, with_person_id, session=db, employment_user_id=employment_user_id
         )
 
-    return render_template(
-        templates,
+    return render(
         "cowork.html",
-        request,
         {
+            "request": request,
+            "user": current_user,
             "year": year,
             "person_id": person_id,
             "person_name": person_name,
@@ -1433,5 +1428,4 @@ async def cowork_view(
             "selected_other_name": selected_other_name,
             "selected_cowork_row": selected_cowork_row,
         },
-        user=current_user,
     )

--- a/app/routes/shared.py
+++ b/app/routes/shared.py
@@ -29,17 +29,23 @@ templates.env.filters["time_format"] = lambda v: v.strftime("%H:%M") if v else "
 # JSON parse filter – use {{ t.some_json_key | from_json }} in templates
 templates.env.filters["from_json"] = _json.loads
 
-# Add now (today's date) as a global for templates
-# Note: This is set once at module load. For dynamic "today", use get_today() in routes.
-templates.env.globals["now"] = get_today()
-
 # Expose person/rotation constants so templates don't need to hardcode range(1, 11)
 templates.env.globals["person_ids"] = PERSON_IDS
 templates.env.globals["max_persons"] = MAX_PERSONS
 
 
 def render(template_name: str, context: dict, status_code: int = 200, headers: dict | None = None):
-    """Render a template, injecting the correct translation dict based on user.language."""
+    """Render a template, adding the context every page needs.
+
+    This is the only place shared template context is assembled. It used to be
+    two places: this function and core.helpers.render_template(), each building
+    its own dict for the same base.html. Anything base.html read had to be added
+    to both by hand, and forgetting one failed silently, because Jinja renders an
+    undefined name as falsy without warning. Add new shared context here, and
+    nowhere else.
+
+    The caller may override any of these by putting the key in `context`.
+    """
     user = context.get("user")
     lang = "sv"
     if user and hasattr(user, "language") and user.language:
@@ -48,11 +54,12 @@ def render(template_name: str, context: dict, status_code: int = 200, headers: d
     request = context.get("request")
     # Every state-changing form needs the CSRF token published by CSRFMiddleware
     context.setdefault("csrf_token", get_csrf_token(request))
-    # Drives the "what's new" nav entry, which is rendered only when unread
-    # release notes exist. Kept in sync with core.helpers.render_template():
-    # base.html reads has_news on every page, so both render paths must supply
-    # it or the nav entry silently disappears on whichever path forgets.
+    # Drives the "what's new" nav entry, rendered only when release notes are unread
     context.setdefault("has_news", has_unseen_news(user))
+    # Resolved per request, not once at import: base.html builds the "My day"
+    # link from it, and a module-level value freezes at process start, leaving
+    # the link pointing at the day the server booted.
+    context.setdefault("now", get_today())
     return templates.TemplateResponse(request, template_name, context, status_code=status_code, headers=headers)
 
 

--- a/app/routes/shift_swap.py
+++ b/app/routes/shift_swap.py
@@ -9,12 +9,11 @@ from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from sqlalchemy.orm import Session
 
 from app.auth.auth import get_current_user
-from app.core.helpers import render_template
 from app.core.schedule import build_week_data, calculate_shift_hours, clear_schedule_cache
 from app.core.schedule.core import determine_shift_for_date
 from app.core.utils import get_today
 from app.database.database import ShiftSwap, SwapStatus, User, get_db, utcnow
-from app.routes.shared import templates
+from app.routes.shared import render
 
 router = APIRouter(prefix="/swaps", tags=["shift_swaps"])
 
@@ -376,12 +375,15 @@ async def list_swaps(
 
     pending_count = sum(1 for s in received if s.status == SwapStatus.PENDING)
 
-    return render_template(
-        templates,
+    return render(
         "shift_swaps.html",
-        request,
-        {"sent_swaps": sent, "received_swaps": received, "pending_count": pending_count},
-        user=current_user,
+        {
+            "request": request,
+            "user": current_user,
+            "sent_swaps": sent,
+            "received_swaps": received,
+            "pending_count": pending_count,
+        },
     )
 
 

--- a/app/routes/statistics.py
+++ b/app/routes/statistics.py
@@ -6,7 +6,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from sqlalchemy.orm import Session
 
 from app.auth.auth import get_current_user_optional
-from app.core.helpers import can_see_salary, render_template, strip_salary_data
+from app.core.helpers import can_see_salary, strip_salary_data
 from app.core.schedule import (
     _cached_special_rules,
     ob_rules,
@@ -16,7 +16,7 @@ from app.core.schedule import persons as person_list
 from app.core.schedule.vacation import calculate_vacation_balance
 from app.core.utils import get_safe_today
 from app.database.database import User, UserRole, get_db
-from app.routes.shared import _resolve_person_param, templates
+from app.routes.shared import _resolve_person_param, render
 
 router = APIRouter(prefix="/statistics", tags=["statistics"])
 
@@ -180,11 +180,11 @@ async def statistics_view(
     if current_user.role == UserRole.ADMIN:
         all_persons = db.query(User).filter(User.is_active == 1, User.role != UserRole.ADMIN).order_by(User.name).all()
 
-    return render_template(
-        templates,
+    return render(
         "statistics.html",
-        request,
         {
+            "request": request,
+            "user": current_user,
             "year": year,
             "person_id": person_id,
             "person_name": person_name,
@@ -201,5 +201,4 @@ async def statistics_view(
             "absence_data": absence_data,
             "all_persons": all_persons,
         },
-        user=current_user,
     )

--- a/tests/test_base_layout.py
+++ b/tests/test_base_layout.py
@@ -1,6 +1,14 @@
-"""Tests for shared chrome in base.html."""
+"""Tests for shared chrome in base.html and the single render path behind it."""
 
 import pytest
+
+from app.auth.auth import create_access_token
+from app.core.utils import get_today
+
+
+def _set_auth_cookie(client, user) -> None:
+    """Authenticate the test client as `user` (mirrors the app's cookie auth)."""
+    client.cookies.set("access_token", f"Bearer {create_access_token(data={'sub': str(user.id)})}")
 
 
 @pytest.mark.parametrize("path", ["/login", "/changelog"])
@@ -14,3 +22,36 @@ def test_wordmark_links_home(test_client, path):
     response = test_client.get(path)
     assert response.status_code == 200
     assert '<a href="/" class="app-title-link">Periodical</a>' in response.text
+
+
+@pytest.mark.parametrize("path", ["/", "/profile"])
+def test_my_day_link_points_at_today(test_client, test_user, path):
+    """`now` must be resolved per request, not once when the module is imported.
+
+    It used to be a Jinja global assigned at import time, so the "My day" link
+    froze on whatever day the process started and drifted further from today the
+    longer the server ran. Both pages are checked because they were served by
+    two different render paths before those were merged.
+    """
+    _set_auth_cookie(test_client, test_user)
+    today = get_today()
+
+    response = test_client.get(path)
+    assert response.status_code == 200
+    assert f"/day/{test_user.id}/{today.year}/{today.month}/{today.day}" in response.text
+
+
+def test_there_is_only_one_render_path():
+    """Shared template context is assembled in exactly one place.
+
+    Two render paths each building their own context for the same base.html is
+    what let a nav entry go missing on half the app without any error: Jinja
+    treats an undefined name as falsy and says nothing. If a second path is
+    reintroduced, every variable base.html reads has to be kept in sync by hand
+    again.
+    """
+    import app.core.helpers as helpers
+
+    assert not hasattr(helpers, "render_template"), (
+        "core.helpers.render_template is back; shared context belongs in routes.shared.render()"
+    )

--- a/tests/test_news_indicator.py
+++ b/tests/test_news_indicator.py
@@ -81,21 +81,16 @@ def logged_in_client(test_client, test_user):
     return test_client
 
 
-# The app renders through two independent paths that each build their own
-# template context: routes.shared.render() and core.helpers.render_template().
-# base.html reads has_news on every page, so both must supply it. Testing only
-# one of them is what let the indicator ship broken on every schedule view.
-@pytest.mark.parametrize(
-    ("path", "render_path"),
-    [
-        ("/profile", "routes.shared.render"),
-        ("/", "core.helpers.render_template"),
-    ],
-)
-def test_nav_shows_indicator_on_both_render_paths(logged_in_client, path, render_path):
+# These two pages were once served by separate render paths, each building its
+# own context, and the indicator shipped missing from the second because only
+# the first was tested. The paths have since been merged into
+# routes.shared.render(), so this now guards the merge rather than the split:
+# both pages must still get the flag.
+@pytest.mark.parametrize("path", ["/profile", "/"])
+def test_nav_shows_indicator_on_pages_from_both_former_render_paths(logged_in_client, path):
     response = logged_in_client.get(path)
     assert response.status_code == 200, f"{path} did not render"
-    assert "nav-link--news" in response.text, f"indicator missing on the {render_path} path"
+    assert "nav-link--news" in response.text, f"indicator missing on {path}"
 
 
 def test_visiting_the_changelog_clears_the_indicator(logged_in_client, test_db, test_user):

--- a/tests/test_schedule_views_person_change.py
+++ b/tests/test_schedule_views_person_change.py
@@ -2820,10 +2820,10 @@ def test_team_month_view_ot_pay_uses_custom_rate_not_generic_wage_fallback(month
 
     captured = {}
 
-    def _fake_render_template(templates, template_name, request, context, **kwargs):
+    def _fake_render(template_name, context, **kwargs):
         captured["persons"] = context["persons"]
 
-    monkeypatch.setattr(schedule_all_module, "render_template", _fake_render_template)
+    monkeypatch.setattr(schedule_all_module, "render", _fake_render)
 
     asyncio.run(schedule_all_module.show_month_all(request=None, year=2026, month=6, current_user=admin, db=session))
 
@@ -2907,10 +2907,10 @@ def test_team_month_view_resolves_each_successive_holders_own_rate(month_env, mo
 
     captured = {}
 
-    def _fake_render_template(templates, template_name, request, context, **kwargs):
+    def _fake_render(template_name, context, **kwargs):
         captured["persons"] = context["persons"]
 
-    monkeypatch.setattr(schedule_all_module, "render_template", _fake_render_template)
+    monkeypatch.setattr(schedule_all_module, "render", _fake_render)
 
     asyncio.run(schedule_all_module.show_month_all(request=None, year=2026, month=6, current_user=admin, db=session))
 


### PR DESCRIPTION
Closes #299.

## Problem

The app rendered through two independent paths that each built their own context
dict for the same `base.html`:

- `app/routes/shared.py::render()`, serving profile, admin, login and changelog
- `app/core/helpers.py::render_template()`, serving the dashboard, all schedule
  views, statistics, reports and swaps

Anything `base.html` read had to be added to both by hand, with nothing
enforcing it. The failure is silent: Jinja renders an undefined name as falsy
without warning, so a variable supplied in only one path produces no error, no
log line and no failing test.

This is not hypothetical. The unread-notes indicator (#298) was wired into
`render()` only and was invisible on the dashboard and every schedule view. It
was caught by hand, by looking at the running app. Its tests passed, because the
integration test happened to hit a page on the path that worked.

## What changed

All 14 call sites across the six affected modules move onto `render()`, and
`render_template` is deleted. `render()`'s docstring now states that shared
context belongs there and nowhere else, and why.

`now` is resolved per request rather than assigned to the Jinja environment once
at import. The practical effect is small and worth stating precisely, because an
earlier draft of this description overstated it: `render_template` already
passed a fresh date on every page it served, and the changelog page and error
handlers pass their own, so the frozen global only reached pages served by
`render()` without one. For a non-admin that is `/profile` and
`/profile/vacation`, where the "My day" link pointed at the day the process
started. Admins never render that link at all. No user-facing changelog entry is
warranted; it is included here because the merge is what makes a single fix
possible.

## Review notes

The interesting part is `render()`'s docstring and the structural test, not the
call-site churn, which is mechanical. Two things worth a look:

- Context keys are now spelled out at each call site (`"request"`, `"user"`)
  where `render_template` took them as parameters. Behaviour is identical:
  `render_template` also let a caller's context override them.
- `tests/test_base_layout.py::test_there_is_only_one_render_path` asserts
  `core.helpers` no longer exposes `render_template`. Unusual to test, but it is
  the invariant this refactor exists to protect.

## Testing

- 650 passed, 0 failed
- Three new tests in `tests/test_base_layout.py`: `now` is today on pages from
  both former paths, and no second render path exists. The `now` test was
  verified to fail with the fix removed, so it is not vacuous
- Two tests in `test_schedule_views_person_change.py` monkeypatched
  `schedule_all.render_template` to capture context and follow the rename. They
  broke on the symbol name, not on behaviour; the month view's overtime and rate
  resolution is unchanged and still covered