### PR TITLE
Add 1.1.0 release notes for the breakdown CSV export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ developers. User-facing release notes are separate and bilingual: they live in
 `VERSIONS` in `app/routes/changelog.py`, which renders in the language the user
 has selected. Add both when a change is worth telling users about.
 
+## [1.1.0] - 2026-07-21
+
+### Added
+- CSV export of the detailed breakdown in the personal month view, available to everyone who can see their own pay data (the Excel export for positions 6 and 8 is unchanged). The export is produced in the browser from the rows currently visible, so it always matches the per-shift / per-calendar-day mode on screen and cannot drift from the view. Column labels reuse the wage codes of the Excel export (`REPORT_COL_HEADERS` in `app/routes/excel_shared.py`), including its mapping of OB3 and OB4 onto code 152. Weekday, shift type and the total row are omitted as display aids; calendar-day mode additionally drops start, end and normal hours, which belong to the shift and are always blank there. Comma separated with decimal points (RFC 4180) and a UTF-8 BOM
+
 ## [1.0.0] - 2026-07-19
 
 The first 1.0.0. The version number is earned by the security work and the pay

--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -16,6 +16,17 @@ router = APIRouter()
 
 VERSIONS = [
     {
+        "version": "1.1.0",
+        "date": "2026-07-21",
+        "entries": [
+            {
+                "type": "nyhet",
+                "sv": "Den detaljerade sammanställningen i månadsvyn kan nu laddas ner som en CSV-fil, så du slipper skriva av siffrorna för hand. Filen innehåller exakt de rader du ser: växlar du mellan OB per pass och OB per kalenderdag följer exporten med. Kolumnerna heter samma sak som lönekoderna (150, 151, 152, 153 och beredskapskoderna), och filen kan öppnas i Excel eller Google Kalkylark",
+                "en": "The detailed breakdown in the month view can now be downloaded as a CSV file, so you no longer have to copy the numbers by hand. The file contains exactly the rows you see: switching between OB per shift and OB per calendar day changes the export with it. The columns are named after the wage codes (150, 151, 152, 153 and the on-call codes), and the file opens in Excel or Google Sheets",
+            },
+        ],
+    },
+    {
         "version": "1.0.0",
         "date": "2026-07-19",
         "entries": [


### PR DESCRIPTION
Follow-up to #303, which shipped without release notes.

Adds 1.1.0 to both places: `CHANGELOG.md` for developers and `VERSIONS` in `app/routes/changelog.py` for the bilingual user-facing notes. The app version shown in the UI comes from `VERSIONS[0]`, so this also bumps the displayed version and triggers the unread-notes marker.

Minor rather than patch, since the export is a new user-facing feature.