### PR TITLE
Collapse duplicated logic in period, storage, on-call and the admin routers

### DIFF
--- a/app/core/oncall.py
+++ b/app/core/oncall.py
@@ -45,6 +45,7 @@ from .holidays import (
 )
 from .models import OnCallRule
 from .storage import load_oncall_rules
+from .time_utils import subtract_covered
 
 # Load base rules from JSON config
 oncall_rules_base = load_oncall_rules()
@@ -609,56 +610,6 @@ def _get_rule_intervals_for_shift(
     return intervals
 
 
-def _subtract_covered_oncall(
-    start: datetime.datetime,
-    end: datetime.datetime,
-    covered: list[tuple[datetime.datetime, datetime.datetime]],
-) -> list[tuple[datetime.datetime, datetime.datetime]]:
-    """
-    Find time segments NOT covered by higher priority rules.
-
-    This implements the REPLACEMENT logic: if a higher priority rule
-    covers a time segment, lower priority rules don't apply there.
-
-    Args:
-        start: Start of interval to check
-        end: End of interval to check
-        covered: List of (start, end) tuples already claimed by higher priority
-
-    Returns:
-        List of (start, end) tuples representing uncovered time
-    """
-    if not covered:
-        return [(start, end)]
-
-    # Sort covered intervals by start time
-    sorted_covered = sorted(covered, key=lambda x: x[0])
-
-    uncovered = []
-    cursor = start
-
-    for cov_start, cov_end in sorted_covered:
-        # Skip intervals that don't overlap
-        if cov_end <= cursor or cov_start >= end:
-            continue
-
-        # Add gap before this covered interval
-        if cov_start > cursor:
-            uncovered.append((cursor, min(cov_start, end)))
-
-        # Move cursor past this covered interval
-        cursor = max(cursor, cov_end)
-
-        if cursor >= end:
-            break
-
-    # Add remaining time after all covered intervals
-    if cursor < end:
-        uncovered.append((cursor, end))
-
-    return uncovered
-
-
 def calculate_oncall_pay(
     date: datetime.date,
     monthly_salary: int,
@@ -709,7 +660,7 @@ def calculate_oncall_pay(
 
         for interval_start, interval_end in intervals:
             # Find uncovered portions of this interval
-            uncovered = _subtract_covered_oncall(interval_start, interval_end, covered)
+            uncovered = subtract_covered(interval_start, interval_end, covered)
 
             for unc_start, unc_end in uncovered:
                 hours = (unc_end - unc_start).total_seconds() / 3600.0
@@ -849,7 +800,7 @@ def calculate_oncall_pay_for_period(
                 continue
 
             # Calculate uncovered portions
-            uncovered = _subtract_covered_oncall(interval_start, interval_end, covered_intervals)
+            uncovered = subtract_covered(interval_start, interval_end, covered_intervals)
 
             for uncov_start, uncov_end in uncovered:
                 # Calculate hours and pay for this segment

--- a/app/core/schedule/ob.py
+++ b/app/core/schedule/ob.py
@@ -6,6 +6,7 @@ from functools import lru_cache
 from app.core.constants import OB_PRIORITY_BY_CODE, OB_PRIORITY_DEFAULT
 from app.core.models import ObRule
 from app.core.storage import load_ob_rules
+from app.core.time_utils import subtract_covered
 
 _ob_rules: list[ObRule] | None = None
 
@@ -77,7 +78,7 @@ def calculate_ob_hours(
             if overlap_end <= overlap_start:
                 continue
 
-            uncovered = _subtract_covered(overlap_start, overlap_end, covered)
+            uncovered = subtract_covered(overlap_start, overlap_end, covered)
 
             for ustart, uend in uncovered:
                 hours = (uend - ustart).total_seconds() / 3600.0
@@ -136,7 +137,7 @@ def calculate_ob_hours_by_day(
             if overlap_end <= overlap_start:
                 continue
 
-            uncovered = _subtract_covered(overlap_start, overlap_end, covered)
+            uncovered = subtract_covered(overlap_start, overlap_end, covered)
             for ustart, uend in uncovered:
                 hours = (uend - ustart).total_seconds() / 3600.0
                 ob_totals[rule.code] += hours
@@ -244,28 +245,6 @@ def _rule_interval_for_day(
         ob_end = datetime.datetime(base_date.year, base_date.month, base_date.day, end_h, end_m)
 
     return ob_start, ob_end
-
-
-def _subtract_covered(
-    start: datetime.datetime,
-    end: datetime.datetime,
-    covered: list[tuple[datetime.datetime, datetime.datetime]],
-) -> list[tuple[datetime.datetime, datetime.datetime]]:
-    """Returns uncovered intervals after subtracting already-covered ones."""
-    result = []
-    cursor = start
-
-    for cov_start, cov_end in sorted(covered):
-        if cov_end <= cursor or cov_start >= end:
-            continue
-        if cov_start > cursor:
-            result.append((cursor, min(cov_start, end)))
-        cursor = max(cursor, cov_end)
-
-    if cursor < end:
-        result.append((cursor, end))
-
-    return result
 
 
 def apply_ob_hours_override(

--- a/app/core/schedule/period.py
+++ b/app/core/schedule/period.py
@@ -630,7 +630,7 @@ def _build_linked_substitute_day_fields(
         }
 
         if absence is not None:
-            code = _substitute_absence_shift_code(absence.absence_type)
+            code = _absence_shift_code(absence.absence_type)
             absence_shift = next((s for s in shift_types if s.code == code), None)
             if absence_shift is not None:
                 return {
@@ -720,10 +720,10 @@ def _fetch_substitute_shifts(
     return {(r.substitute_id, r.date): r for r in rows}
 
 
-def _substitute_absence_shift_code(absence_type) -> str:
-    """Map a substitute's absence type to the shift code used to render it.
+def _absence_shift_code(absence_type) -> str:
+    """Map an absence type to the shift code used to render it.
 
-    Mirrors the agent mapping: VACATION shows as SEM, PARENTAL falls back to LEAVE,
+    Shared by agents and substitutes: VACATION shows as SEM, PARENTAL falls back to LEAVE,
     everything else uses the absence type's own code (SICK, VAB, LEAVE, OFF).
     """
     from app.database.database import AbsenceType
@@ -758,7 +758,7 @@ def _build_substitute_day(
 
     absence = absence_map.get((sub.id, date)) if absence_map else None
     if absence is not None:
-        code = _substitute_absence_shift_code(absence.absence_type)
+        code = _absence_shift_code(absence.absence_type)
         absence_shift = next((s for s in shift_types if s.code == code), None)
         if absence_shift:
             return {
@@ -1183,6 +1183,68 @@ def build_substitute_month_summaries(
     return summaries
 
 
+def _resolve_fetch_user_ids(
+    person_ids: list[int],
+    rotation_to_user_id: dict[int, int] | None,
+    extra_user_ids: set[int] | None,
+) -> tuple[list[int], dict[int, int]]:
+    """Resolve the user_ids to query for a set of rotation positions.
+
+    Returns (user_ids, user_id_to_rotation). Actual user_ids may differ from the rotation
+    position. extra_user_ids adds every user who held a viewed position at any point in the
+    range, not just its current holder, so a single-position view on the far side of a swap
+    or succession still fetches the prior/future holder's rows.
+    """
+    if rotation_to_user_id:
+        user_ids = list({rotation_to_user_id.get(p, p) for p in person_ids})
+        user_id_to_rotation = {v: k for k, v in rotation_to_user_id.items()}
+    else:
+        user_ids = person_ids
+        user_id_to_rotation = {}
+
+    if extra_user_ids:
+        user_ids = list(set(user_ids) | set(extra_user_ids))
+
+    return user_ids, user_id_to_rotation
+
+
+def _batch_fetch_by_date(
+    session,
+    model,
+    person_ids: list[int],
+    start_date: datetime.date,
+    end_date: datetime.date,
+    rotation_to_user_id: dict[int, int] | None = None,
+    extra_user_ids: set[int] | None = None,
+    days_before: int = 0,
+) -> dict[tuple[int, datetime.date], object]:
+    """Batch-fetch rows of a user_id/date model for several persons and a period.
+
+    days_before extends the query that many days before start_date (used for overtime
+    shifts, where the previous day's row can cross midnight into the period).
+
+    Returns:
+        Dict with (rotation_position, date) -> row
+    """
+    if not session:
+        return {}
+
+    user_ids, user_id_to_rotation = _resolve_fetch_user_ids(person_ids, rotation_to_user_id, extra_user_ids)
+
+    rows = (
+        session.query(model)
+        .filter(
+            model.user_id.in_(user_ids),
+            model.date >= start_date - datetime.timedelta(days=days_before),
+            model.date <= end_date,
+        )
+        .all()
+    )
+
+    resolve_pos = _build_user_position_resolver(session, user_ids, user_id_to_rotation)
+    return {(resolve_pos(r.user_id, r.date), r.date): r for r in rows}
+
+
 def _batch_fetch_absences(
     session,
     person_ids: list[int],
@@ -1191,43 +1253,10 @@ def _batch_fetch_absences(
     rotation_to_user_id: dict[int, int] | None = None,
     extra_user_ids: set[int] | None = None,
 ) -> dict[tuple[int, datetime.date], object]:
-    """
-    Batch-hämtar frånvaro för flera personer och en period.
-
-    Returns:
-        Dict med (rotation_position, date) -> Absence
-    """
-    if not session:
-        return {}
-
+    """Batch-hämtar frånvaro för flera personer och en period."""
     from app.database.database import Absence
 
-    # Resolve actual user_ids (may differ from rotation position)
-    if rotation_to_user_id:
-        user_ids = list({rotation_to_user_id.get(p, p) for p in person_ids})
-        user_id_to_rotation = {v: k for k, v in rotation_to_user_id.items()}
-    else:
-        user_ids = person_ids
-        user_id_to_rotation = {}
-
-    # Include every user who held a viewed position at any point in the range, not
-    # just its current holder, so a single-position view on the far side of a swap
-    # or succession still fetches the prior/future holder's rows.
-    if extra_user_ids:
-        user_ids = list(set(user_ids) | set(extra_user_ids))
-
-    absences = (
-        session.query(Absence)
-        .filter(
-            Absence.user_id.in_(user_ids),
-            Absence.date >= start_date,
-            Absence.date <= end_date,
-        )
-        .all()
-    )
-
-    resolve_pos = _build_user_position_resolver(session, user_ids, user_id_to_rotation)
-    return {(resolve_pos(a.user_id, a.date), a.date): a for a in absences}
+    return _batch_fetch_by_date(session, Absence, person_ids, start_date, end_date, rotation_to_user_id, extra_user_ids)
 
 
 def _batch_fetch_ot_shifts(
@@ -1238,45 +1267,22 @@ def _batch_fetch_ot_shifts(
     rotation_to_user_id: dict[int, int] | None = None,
     extra_user_ids: set[int] | None = None,
 ) -> dict[tuple[int, datetime.date], object]:
-    """
-    Batch-hämtar övertidspass för flera personer och en period.
+    """Batch-hämtar övertidspass för flera personer och en period.
 
-    Returns:
-        Dict med (rotation_position, date) -> OvertimeShift
+    Fetches one extra day before start_date to catch OT shifts crossing midnight.
     """
-    if not session:
-        return {}
-
     from app.database.database import OvertimeShift
 
-    if rotation_to_user_id:
-        user_ids = list({rotation_to_user_id.get(p, p) for p in person_ids})
-        user_id_to_rotation = {v: k for k, v in rotation_to_user_id.items()}
-    else:
-        user_ids = person_ids
-        user_id_to_rotation = {}
-
-    # Include every user who held a viewed position at any point in the range, not
-    # just its current holder, so a single-position view on the far side of a swap
-    # or succession still fetches the prior/future holder's rows.
-    if extra_user_ids:
-        user_ids = list(set(user_ids) | set(extra_user_ids))
-
-    # Also fetch the day before start_date to catch OT shifts crossing midnight
-    fetch_start = start_date - datetime.timedelta(days=1)
-
-    ot_shifts = (
-        session.query(OvertimeShift)
-        .filter(
-            OvertimeShift.user_id.in_(user_ids),
-            OvertimeShift.date >= fetch_start,
-            OvertimeShift.date <= end_date,
-        )
-        .all()
+    return _batch_fetch_by_date(
+        session,
+        OvertimeShift,
+        person_ids,
+        start_date,
+        end_date,
+        rotation_to_user_id,
+        extra_user_ids,
+        days_before=1,
     )
-
-    resolve_pos = _build_user_position_resolver(session, user_ids, user_id_to_rotation)
-    return {(resolve_pos(s.user_id, s.date), s.date): s for s in ot_shifts}
 
 
 def _batch_fetch_oncall_overrides(
@@ -1287,42 +1293,12 @@ def _batch_fetch_oncall_overrides(
     rotation_to_user_id: dict[int, int] | None = None,
     extra_user_ids: set[int] | None = None,
 ) -> dict[tuple[int, datetime.date], object]:
-    """
-    Batch-hämtar on-call overrides för flera personer och en period.
-
-    Returns:
-        Dict med (rotation_position, date) -> OnCallOverride
-    """
-    if not session:
-        return {}
-
+    """Batch-hämtar on-call overrides för flera personer och en period."""
     from app.database.database import OnCallOverride
 
-    if rotation_to_user_id:
-        user_ids = list({rotation_to_user_id.get(p, p) for p in person_ids})
-        user_id_to_rotation = {v: k for k, v in rotation_to_user_id.items()}
-    else:
-        user_ids = person_ids
-        user_id_to_rotation = {}
-
-    # Include every user who held a viewed position at any point in the range, not
-    # just its current holder, so a single-position view on the far side of a swap
-    # or succession still fetches the prior/future holder's rows.
-    if extra_user_ids:
-        user_ids = list(set(user_ids) | set(extra_user_ids))
-
-    overrides = (
-        session.query(OnCallOverride)
-        .filter(
-            OnCallOverride.user_id.in_(user_ids),
-            OnCallOverride.date >= start_date,
-            OnCallOverride.date <= end_date,
-        )
-        .all()
+    return _batch_fetch_by_date(
+        session, OnCallOverride, person_ids, start_date, end_date, rotation_to_user_id, extra_user_ids
     )
-
-    resolve_pos = _build_user_position_resolver(session, user_ids, user_id_to_rotation)
-    return {(resolve_pos(o.user_id, o.date), o.date): o for o in overrides}
 
 
 def _batch_fetch_shift_overrides(
@@ -1333,41 +1309,12 @@ def _batch_fetch_shift_overrides(
     rotation_to_user_id: dict[int, int] | None = None,
     extra_user_ids: set[int] | None = None,
 ) -> dict[tuple[int, datetime.date], object]:
-    """Batch-fetches manual shift overrides for multiple persons and a period.
-
-    Returns:
-        Dict med (rotation_position, date) -> ShiftOverride
-    """
-    if not session:
-        return {}
-
+    """Batch-fetches manual shift overrides for multiple persons and a period."""
     from app.database.database import ShiftOverride
 
-    if rotation_to_user_id:
-        user_ids = list({rotation_to_user_id.get(p, p) for p in person_ids})
-        user_id_to_rotation = {v: k for k, v in rotation_to_user_id.items()}
-    else:
-        user_ids = person_ids
-        user_id_to_rotation = {}
-
-    # Include every user who held a viewed position at any point in the range, not
-    # just its current holder, so a single-position view on the far side of a swap
-    # or succession still fetches the prior/future holder's rows.
-    if extra_user_ids:
-        user_ids = list(set(user_ids) | set(extra_user_ids))
-
-    overrides = (
-        session.query(ShiftOverride)
-        .filter(
-            ShiftOverride.user_id.in_(user_ids),
-            ShiftOverride.date >= start_date,
-            ShiftOverride.date <= end_date,
-        )
-        .all()
+    return _batch_fetch_by_date(
+        session, ShiftOverride, person_ids, start_date, end_date, rotation_to_user_id, extra_user_ids
     )
-
-    resolve_pos = _build_user_position_resolver(session, user_ids, user_id_to_rotation)
-    return {(resolve_pos(o.user_id, o.date), o.date): o for o in overrides}
 
 
 def _batch_fetch_day_pay_overrides(
@@ -1378,41 +1325,12 @@ def _batch_fetch_day_pay_overrides(
     rotation_to_user_id: dict[int, int] | None = None,
     extra_user_ids: set[int] | None = None,
 ) -> dict[tuple[int, datetime.date], object]:
-    """Batch-fetches manual pay overrides (OB/oncall) for multiple persons and a period.
-
-    Returns:
-        Dict with (rotation_position, date) -> DayPayOverride
-    """
-    if not session:
-        return {}
-
+    """Batch-fetches manual pay overrides (OB/oncall) for multiple persons and a period."""
     from app.database.database import DayPayOverride
 
-    if rotation_to_user_id:
-        user_ids = list({rotation_to_user_id.get(p, p) for p in person_ids})
-        user_id_to_rotation = {v: k for k, v in rotation_to_user_id.items()}
-    else:
-        user_ids = person_ids
-        user_id_to_rotation = {}
-
-    # Include every user who held a viewed position at any point in the range, not
-    # just its current holder, so a single-position view on the far side of a swap
-    # or succession still fetches the prior/future holder's rows.
-    if extra_user_ids:
-        user_ids = list(set(user_ids) | set(extra_user_ids))
-
-    overrides = (
-        session.query(DayPayOverride)
-        .filter(
-            DayPayOverride.user_id.in_(user_ids),
-            DayPayOverride.date >= start_date,
-            DayPayOverride.date <= end_date,
-        )
-        .all()
+    return _batch_fetch_by_date(
+        session, DayPayOverride, person_ids, start_date, end_date, rotation_to_user_id, extra_user_ids
     )
-
-    resolve_pos = _build_user_position_resolver(session, user_ids, user_id_to_rotation)
-    return {(resolve_pos(o.user_id, o.date), o.date): o for o in overrides}
 
 
 def _batch_fetch_swap_map(
@@ -1438,18 +1356,7 @@ def _batch_fetch_swap_map(
 
     from app.database.database import ShiftSwap, SwapStatus, User
 
-    if rotation_to_user_id:
-        user_ids = list({rotation_to_user_id.get(p, p) for p in person_ids})
-        user_id_to_rotation = {v: k for k, v in rotation_to_user_id.items()}
-    else:
-        user_ids = person_ids
-        user_id_to_rotation = {}
-
-    # Include every user who held a viewed position at any point in the range, not
-    # just its current holder, so a single-position view on the far side of a swap
-    # or succession still fetches the prior/future holder's rows.
-    if extra_user_ids:
-        user_ids = list(set(user_ids) | set(extra_user_ids))
+    user_ids, user_id_to_rotation = _resolve_fetch_user_ids(person_ids, rotation_to_user_id, extra_user_ids)
 
     swaps = (
         session.query(ShiftSwap)
@@ -1598,14 +1505,10 @@ def _build_person_day_basic(
                     "partial_absence": absence,
                 }
 
-        # VACATION absences use the SEM shift (same as week-based vacation)
-        # PARENTAL falls back to LEAVE shift since no dedicated shift type exists
-        if absence.absence_type == AbsenceType.VACATION:
-            absence_shift = vacation_shift
-        elif absence.absence_type == AbsenceType.PARENTAL:
-            absence_shift = next((s for s in shift_types if s.code == "LEAVE"), None)
-        else:
-            absence_shift = next((s for s in shift_types if s.code == absence.absence_type.value), None)
+        # VACATION renders as the SEM shift (same object as week-based vacation), the rest
+        # resolve by code (see _absence_shift_code).
+        code = _absence_shift_code(absence.absence_type)
+        absence_shift = vacation_shift if code == "SEM" else next((s for s in shift_types if s.code == code), None)
         if absence_shift:
             result = determine_shift_for_date(date, person_id)
             original_shift, rotation_week = result if result else (None, None)
@@ -1907,14 +1810,10 @@ def _populate_absence_day(
             )
             return True
 
-    # VACATION absences use the SEM shift (same as week-based vacation)
-    # PARENTAL falls back to LEAVE shift since no dedicated shift type exists
-    if absence.absence_type == AbsenceType.VACATION:
-        absence_shift = vacation_shift
-    elif absence.absence_type == AbsenceType.PARENTAL:
-        absence_shift = next((s for s in shift_types if s.code == "LEAVE"), None)
-    else:
-        absence_shift = next((s for s in shift_types if s.code == absence.absence_type.value), None)
+    # VACATION renders as the SEM shift (same object as week-based vacation), the rest
+    # resolve by code (see _absence_shift_code).
+    code = _absence_shift_code(absence.absence_type)
+    absence_shift = vacation_shift if code == "SEM" else next((s for s in shift_types if s.code == code), None)
     if absence_shift:
         # Get original shift for coworker matching
         result = determine_shift_for_date(current_day, person_id)

--- a/app/core/storage.py
+++ b/app/core/storage.py
@@ -44,124 +44,68 @@ def _load_json(file_path: Path) -> list[Any] | dict[str, Any]:
         raise StorageError(f"Invalid JSON in file {file_path}: {e}") from e
 
 
-def load_shift_types() -> list[ShiftType]:
-    """
-    Load shift type definitions from data file.
-    Returns:
-        List of shift types
+def _load_list(filename: str, model, what: str) -> list:
+    """Load a JSON array from data/ and validate each item against a model.
+
     Raises:
-        StorageError: If file cannot be loaded or parsed
+        StorageError: If the file cannot be loaded, is not an array, or fails validation
     """
-    file_path = Path("data/shift_types.json")
+    file_path = Path("data") / filename
     data = _load_json(file_path)
     try:
         if not isinstance(data, list):
-            raise TypeError("Expected list of shift types")
-        shift_types = [ShiftType(**item) for item in data]
+            raise TypeError(f"Expected list of {what}")
+        return [model(**item) for item in data]
     except (TypeError, ValidationError) as e:
-        logger.exception("Failed to parse shift types from %s", file_path)
-        raise StorageError(f"Could not parse shift types from {file_path}: {e}") from e
-    return shift_types
+        logger.exception("Failed to parse %s from %s", what, file_path)
+        raise StorageError(f"Could not parse {what} from {file_path}: {e}") from e
+
+
+def _load_obj(filename: str, model, what: str):
+    """Load a JSON object from data/ and validate it against a model.
+
+    Raises:
+        StorageError: If the file cannot be loaded, is not an object, or fails validation
+    """
+    file_path = Path("data") / filename
+    data = _load_json(file_path)
+    try:
+        if not isinstance(data, dict):
+            raise TypeError(f"Expected {what} dict")
+        return model(**data)
+    except (TypeError, ValidationError) as e:
+        logger.exception("Failed to parse %s from %s", what, file_path)
+        raise StorageError(f"Could not parse {what} from {file_path}: {e}") from e
+
+
+def load_shift_types() -> list[ShiftType]:
+    """Load shift type definitions from data file."""
+    return _load_list("shift_types.json", ShiftType, "shift types")
 
 
 def load_rotation() -> Rotation:
-    """
-    Load rotation configuration from data file.
-    Returns:
-        Rotation configuration
-    Raises:
-        StorageError: If file cannot be loaded or parsed
-    """
-    file_path = Path("data/rotation.json")
-    data = _load_json(file_path)
-    try:
-        if not isinstance(data, dict):
-            raise TypeError("Expected rotation configuration dict")
-        rotation = Rotation(**data)
-    except (TypeError, ValidationError) as e:
-        logger.exception("Failed to parse rotation from %s", file_path)
-        raise StorageError(f"Could not parse rotation from {file_path}: {e}") from e
-    return rotation
+    """Load rotation configuration from data file."""
+    return _load_obj("rotation.json", Rotation, "rotation")
 
 
 def load_settings() -> Settings:
-    """
-    Load application settings from data file.
-    Returns:
-        Application settings
-    Raises:
-        StorageError: If file cannot be loaded or parsed
-    """
-    file_path = Path("data/settings.json")
-    data = _load_json(file_path)
-    try:
-        if not isinstance(data, dict):
-            raise TypeError("Expected settings dict")
-        settings = Settings(**data)
-    except (TypeError, ValidationError) as e:
-        logger.exception("Failed to parse settings from %s", file_path)
-        raise StorageError(f"Could not parse settings from {file_path}: {e}") from e
-    return settings
+    """Load application settings from data file."""
+    return _load_obj("settings.json", Settings, "settings")
 
 
 def load_ob_rules() -> list[ObRule]:
-    """
-    Load OB (unsocial hours) rules from data file.
-    Returns:
-        List of OB rules
-    Raises:
-        StorageError: If file cannot be loaded or parsed
-    """
-    file_path = Path("data/ob_rules.json")
-    data = _load_json(file_path)
-    try:
-        if not isinstance(data, list):
-            raise TypeError("Expected list of OB rules")
-        ob_rules = [ObRule(**item) for item in data]
-    except (TypeError, ValidationError) as e:
-        logger.exception("Failed to parse OB rules from %s", file_path)
-        raise StorageError(f"Could not parse OB rules from {file_path}: {e}") from e
-    return ob_rules
+    """Load OB (unsocial hours) rules from data file."""
+    return _load_list("ob_rules.json", ObRule, "OB rules")
 
 
 def load_oncall_rules() -> list[OnCallRule]:
-    """
-    Load on-call compensation rules from data file.
-    Returns:
-        List of on-call rules
-    Raises:
-        StorageError: If file cannot be loaded or parsed
-    """
-    file_path = Path("data/oncall_rules.json")
-    data = _load_json(file_path)
-    try:
-        if not isinstance(data, list):
-            raise TypeError("Expected list of on-call rules")
-        oncall_rules = [OnCallRule(**item) for item in data]
-    except (TypeError, ValidationError) as e:
-        logger.exception("Failed to parse on-call rules from %s", file_path)
-        raise StorageError(f"Could not parse on-call rules from {file_path}: {e}") from e
-    return oncall_rules
+    """Load on-call compensation rules from data file."""
+    return _load_list("oncall_rules.json", OnCallRule, "on-call rules")
 
 
 def load_tax_brackets() -> list[TaxBracket]:
-    """
-    Load tax bracket definitions from data file.
-    Returns:
-        List of tax brackets
-    Raises:
-        StorageError: If file cannot be loaded or parsed
-    """
-    file_path = Path("data/tax_brackets.json")
-    data = _load_json(file_path)
-    try:
-        if not isinstance(data, list):
-            raise TypeError("Expected list of tax brackets")
-        tax_brackets = [TaxBracket(**item) for item in data]
-    except (TypeError, ValidationError) as e:
-        logger.exception("Failed to parse tax brackets from %s", file_path)
-        raise StorageError(f"Could not parse tax brackets from {file_path}: {e}") from e
-    return tax_brackets
+    """Load tax bracket definitions from data file."""
+    return _load_list("tax_brackets.json", TaxBracket, "tax brackets")
 
 
 def calculate_tax_bracket(income: float, tax_brackets: list[TaxBracket]) -> float:
@@ -180,23 +124,8 @@ def calculate_tax_bracket(income: float, tax_brackets: list[TaxBracket]) -> floa
 
 
 def load_persons() -> list[Person]:
-    """
-    Load person definitions from data file.
-    Returns:
-        List of persons
-    Raises:
-        StorageError: If file cannot be loaded or parsed
-    """
-    file_path = Path("data/persons.json")
-    data = _load_json(file_path)
-    try:
-        if not isinstance(data, list):
-            raise TypeError("Expected list of persons")
-        persons = [Person(**item) for item in data]
-    except (TypeError, ValidationError) as e:
-        logger.exception("Failed to parse persons from %s", file_path)
-        raise StorageError(f"Could not parse persons from {file_path}: {e}") from e
-    return persons
+    """Load person definitions from data file."""
+    return _load_list("persons.json", Person, "persons")
 
 
 # Cache for tax table data - now per year

--- a/app/core/time_utils.py
+++ b/app/core/time_utils.py
@@ -61,3 +61,30 @@ def parse_ot_times(ot_shift: Any, date: datetime.date) -> tuple[datetime.datetim
         end_dt += datetime.timedelta(days=1)
 
     return start_dt, end_dt
+
+
+def subtract_covered(
+    start: datetime.datetime,
+    end: datetime.datetime,
+    covered: list[tuple[datetime.datetime, datetime.datetime]],
+) -> list[tuple[datetime.datetime, datetime.datetime]]:
+    """Return the parts of [start, end) not already claimed by a higher priority rule.
+
+    Both OB and on-call resolve overlapping rules by priority: the highest priority rule
+    claims an interval and lower ones only apply to what is left over. Shared by
+    app.core.schedule.ob and app.core.oncall so the two cannot drift apart.
+    """
+    result = []
+    cursor = start
+
+    for cov_start, cov_end in sorted(covered):
+        if cov_end <= cursor or cov_start >= end:
+            continue
+        if cov_start > cursor:
+            result.append((cursor, min(cov_start, end)))
+        cursor = max(cursor, cov_end)
+
+    if cursor < end:
+        result.append((cursor, end))
+
+    return result

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -15,7 +15,9 @@ from app.core.utils import get_today
 from app.database.database import Absence, AbsenceType, RotationEra, User, get_db
 from app.routes.shared import render
 
-router = APIRouter(prefix="/admin", tags=["admin"])
+# Every route on this router is admin-only, so the gate lives here and cannot be
+# forgotten on a new route. Handlers keep the parameter only when they read it.
+router = APIRouter(prefix="/admin", tags=["admin"], dependencies=[Depends(get_admin_user)])
 
 
 def write_json_safely(file_path: Path, data: dict | list) -> None:
@@ -574,7 +576,6 @@ async def admin_update_vacation_weeks(
     user_id: int,
     year: int = Form(...),
     weeks: str = Form(""),
-    current_user: User = Depends(get_admin_user),
     db: Session = Depends(get_db),
 ):
     """Admin: update week-based vacation for a user."""
@@ -614,7 +615,6 @@ async def admin_update_parental_weeks(
     user_id: int,
     year: int = Form(...),
     weeks: str = Form(""),
-    current_user: User = Depends(get_admin_user),
     db: Session = Depends(get_db),
 ):
     """Admin: update parental leave weeks for a user (stored in User.parental_leave JSON)."""
@@ -650,7 +650,6 @@ async def admin_update_parental_weeks(
 async def admin_add_vacation_day(
     user_id: int,
     vacation_date: str = Form(...),
-    current_user: User = Depends(get_admin_user),
     db: Session = Depends(get_db),
 ):
     """Admin: add a day-level vacation (VACATION absence)."""
@@ -699,7 +698,6 @@ async def admin_sync_vacation_days(
     year: int = Form(...),
     dates: str = Form(""),
     parental_dates: str = Form(""),
-    current_user: User = Depends(get_admin_user),
     db: Session = Depends(get_db),
 ):
     """Admin: sync day-level vacation and parental leave for a year."""
@@ -761,7 +759,6 @@ async def admin_sync_vacation_days(
 async def admin_delete_vacation_day(
     user_id: int,
     absence_id: int,
-    current_user: User = Depends(get_admin_user),
     db: Session = Depends(get_db),
 ):
     """Admin: remove a day-level vacation."""
@@ -792,7 +789,6 @@ async def admin_delete_vacation_day(
 async def admin_update_saved_days(
     request: Request,
     user_id: int,
-    current_user: User = Depends(get_admin_user),
     db: Session = Depends(get_db),
 ):
     """Admin: manually update saved vacation days for closed years."""
@@ -842,7 +838,6 @@ async def admin_update_vacation_settings(
     employment_start_date: str = Form(""),
     vacation_year_start_month: int = Form(4),
     vacation_days_per_year: int = Form(25),
-    current_user: User = Depends(get_admin_user),
     db: Session = Depends(get_db),
 ):
     """Admin: update vacation settings for a user."""

--- a/app/routes/admin_users.py
+++ b/app/routes/admin_users.py
@@ -19,7 +19,9 @@ from app.routes.shared import _parse_rates_form, render
 
 logger = get_logger(__name__)
 
-router = APIRouter(tags=["admin"])
+# All routes here live under /admin/, so the admin gate lives on the router and
+# cannot be forgotten on a new route. Handlers keep the parameter only when they read it.
+router = APIRouter(tags=["admin"], dependencies=[Depends(get_admin_user)])
 
 
 @router.get("/admin/users", response_class=HTMLResponse, name="admin_users")
@@ -254,7 +256,6 @@ async def admin_reset_password(
 async def admin_set_wage_type(
     user_id: int,
     wage_type: str = Form(...),
-    current_user: User = Depends(get_admin_user),
     db: Session = Depends(get_db),
 ):
     """Admin: change whether a user is on hourly or monthly wage."""
@@ -311,7 +312,6 @@ async def admin_edit_wage(
     user_id: int,
     wage_id: int,
     new_wage: int = Form(...),
-    current_user: User = Depends(get_admin_user),
     db: Session = Depends(get_db),
 ):
     """Admin: update the amount on an existing wage history entry for a user (dates unchanged)."""
@@ -334,7 +334,6 @@ async def admin_delete_wage(
     request: Request,
     user_id: int,
     wage_id: int,
-    current_user: User = Depends(get_admin_user),
     db: Session = Depends(get_db),
 ):
     """Admin: delete a wage history entry for any user."""
@@ -421,7 +420,6 @@ async def admin_edit_rate(
     request: Request,
     user_id: int,
     rate_id: int,
-    current_user: User = Depends(get_admin_user),
     db: Session = Depends(get_db),
 ):
     """Admin: update the rate values on an existing rate history entry (dates unchanged)."""
@@ -446,7 +444,6 @@ async def admin_edit_rate(
 async def admin_delete_rate(
     user_id: int,
     rate_id: int,
-    current_user: User = Depends(get_admin_user),
     db: Session = Depends(get_db),
 ):
     """Admin: delete a rate history entry for a user."""
@@ -623,7 +620,6 @@ async def admin_delete_employment(
     request: Request,
     user_id: int,
     history_id: int,
-    current_user: User = Depends(get_admin_user),
     db: Session = Depends(get_db),
 ):
     """Admin: delete a person history entry."""
@@ -786,7 +782,6 @@ async def admin_transition_delete(
     user_id: int,
     cleanup_wage: str = Form(""),
     cleanup_rates: str = Form(""),
-    current_user: User = Depends(get_admin_user),
     db: Session = Depends(get_db),
 ):
     """Admin: delete employment transition for a user."""
@@ -1204,7 +1199,6 @@ async def admin_person_change_history_edit(
 @router.post("/admin/person-change/history/{history_id}/delete", name="admin_person_change_history_delete")
 async def admin_person_change_history_delete(
     history_id: int,
-    current_user: User = Depends(get_admin_user),
     db: Session = Depends(get_db),
 ):
     """Admin: delete an employment record from the person change page. PRG redirect."""

--- a/app/routes/day_pay_override.py
+++ b/app/routes/day_pay_override.py
@@ -1,9 +1,9 @@
 # app/routes/day_pay_override.py
 """Routes for manual OB and on-call hour overrides on a specific day."""
 
-from datetime import datetime
+from datetime import date as date_cls
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, Form, HTTPException, Request
 from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 
@@ -18,17 +18,17 @@ router = APIRouter(prefix="/day-pay-override", tags=["day_pay_override"])
 @router.post("/set")
 async def set_day_pay_override(
     request: Request,
+    user_id: int = Form(...),
+    override_date: date_cls = Form(..., alias="date"),
+    reason: str = Form(default=""),
     session: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
+    # The request is still read raw below because ob_hours_*/oc_hours_* keys are dynamic.
     form = await request.form()
-    user_id = int(form["user_id"])
-    date_str = str(form["date"])
-    reason = str(form.get("reason", "")).strip() or None
+    reason_text = reason.strip() or None
 
     require_own_or_admin(current_user, user_id, "Du kan bara ange overrides for dig sjalv")
-
-    override_date = datetime.strptime(date_str, "%Y-%m-%d").date()
 
     # Collect ob_hours_* and oc_hours_* fields from the form
     ob_hours: dict[str, float] = {}
@@ -64,7 +64,7 @@ async def set_day_pay_override(
     if existing:
         existing.ob_hours_override = ob_json
         existing.oncall_hours_override = oncall_json
-        existing.reason = reason
+        existing.reason = reason_text
         existing.created_by = current_user.id
     else:
         session.add(
@@ -73,7 +73,7 @@ async def set_day_pay_override(
                 date=override_date,
                 ob_hours_override=ob_json,
                 oncall_hours_override=oncall_json,
-                reason=reason,
+                reason=reason_text,
                 created_by=current_user.id,
             )
         )

--- a/app/routes/oncall.py
+++ b/app/routes/oncall.py
@@ -3,7 +3,7 @@
 On-call override management routes - add and remove on-call shifts.
 """
 
-from datetime import datetime
+from datetime import date as date_cls
 
 from fastapi import APIRouter, Depends, Form, HTTPException
 from fastapi.responses import RedirectResponse
@@ -20,7 +20,7 @@ router = APIRouter(prefix="/oncall", tags=["oncall"])
 @router.post("/add")
 async def add_oncall_override(
     user_id: int = Form(...),
-    date: str = Form(...),
+    date: date_cls = Form(...),
     reason: str = Form(None),
     session: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
@@ -34,8 +34,7 @@ async def add_oncall_override(
     """
     require_own_or_admin(current_user, user_id, "Not authorized to add on-call for other users")
 
-    # Parse date
-    oc_date = datetime.strptime(date, "%Y-%m-%d").date()
+    oc_date = date
 
     # Check if override already exists for this date
     existing = (
@@ -69,7 +68,7 @@ async def add_oncall_override(
 @router.post("/remove")
 async def remove_oncall_override(
     user_id: int = Form(...),
-    date: str = Form(...),
+    date: date_cls = Form(...),
     reason: str = Form(None),
     session: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
@@ -84,8 +83,7 @@ async def remove_oncall_override(
     # Permission check
     require_own_or_admin(current_user, user_id, "Not authorized to remove on-call for other users")
 
-    # Parse date
-    oc_date = datetime.strptime(date, "%Y-%m-%d").date()
+    oc_date = date
 
     # Check if override already exists for this date
     existing = (

--- a/app/routes/overtime.py
+++ b/app/routes/overtime.py
@@ -3,7 +3,8 @@
 Overtime shift management routes - add and delete overtime shifts.
 """
 
-from datetime import datetime
+from datetime import date as date_cls
+from datetime import time as time_cls
 
 from fastapi import APIRouter, Depends, Form, HTTPException
 from fastapi.responses import RedirectResponse
@@ -25,9 +26,9 @@ router = APIRouter(prefix="/overtime", tags=["overtime"])
 @router.post("/add")
 async def add_overtime_shift(
     user_id: int = Form(...),
-    date: str = Form(...),
-    start_time: str = Form(...),
-    end_time: str = Form(...),
+    date: date_cls = Form(...),
+    start_time: time_cls = Form(...),
+    end_time: time_cls = Form(...),
     hours: float = Form(8.5),
     is_extension: bool = Form(False),
     session: Session = Depends(get_db),
@@ -42,8 +43,8 @@ async def add_overtime_shift(
     """
     require_own_or_admin(current_user, user_id, "Not authorized to add overtime for other users")
 
-    # Parse date first (needed for wage lookup)
-    ot_date = datetime.strptime(date, "%Y-%m-%d").date()
+    # Needed for the wage lookup below
+    ot_date = date
 
     # Get user's wage and rates for the specific date (temporal query)
     raw_wage = get_user_wage(session, user_id, effective_date=ot_date)
@@ -62,8 +63,8 @@ async def add_overtime_shift(
     ot_pay = calculate_overtime_pay(raw_wage, hours, ot_hourly_rate=_ot_rate)
 
     # Parse times
-    start_t = datetime.strptime(start_time, "%H:%M").time()
-    end_t = datetime.strptime(end_time, "%H:%M").time()
+    start_t = start_time
+    end_t = end_time
 
     existing_shifts = (
         session.query(OvertimeShift)

--- a/app/routes/shift_override.py
+++ b/app/routes/shift_override.py
@@ -1,7 +1,7 @@
 # app/routes/shift_override.py
 """Routes for manual shift overrides (adding/removing a regular shift for a day)."""
 
-from datetime import datetime
+from datetime import date as date_cls
 
 from fastapi import APIRouter, Depends, Form, HTTPException
 from fastapi.responses import RedirectResponse
@@ -20,7 +20,7 @@ _ALLOWED_CODES = {"N1", "N2", "N3"}
 @router.post("/add")
 async def add_shift_override(
     user_id: int = Form(...),
-    date: str = Form(...),
+    date: date_cls = Form(...),
     shift_code: str = Form(...),
     session: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
@@ -30,7 +30,7 @@ async def add_shift_override(
     if shift_code not in _ALLOWED_CODES:
         raise HTTPException(status_code=400, detail="Ogiltigt skiftkod, använd N1/N2/N3")
 
-    override_date = datetime.strptime(date, "%Y-%m-%d").date()
+    override_date = date
 
     existing = (
         session.query(ShiftOverride)

--- a/app/routes/shift_swap.py
+++ b/app/routes/shift_swap.py
@@ -1,6 +1,7 @@
 # app/routes/shift_swap.py
 """Shift swap management routes - propose, accept, reject, cancel swaps."""
 
+from datetime import date as date_cls
 from datetime import datetime, timedelta
 from datetime import time as dt_time
 
@@ -194,7 +195,7 @@ def _raise_if_swap_conflicts(
 async def get_user_shifts(
     user_id: int,
     offering: str = None,
-    ref_date: str = None,
+    ref_date: date_cls | None = None,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -207,7 +208,7 @@ async def get_user_shifts(
         return JSONResponse(content={"shifts": []})
 
     today = get_today()
-    center = datetime.strptime(ref_date, "%Y-%m-%d").date() if ref_date else today
+    center = ref_date or today
     target_pid = target.rotation_person_id
     my_pid = current_user.rotation_person_id
 
@@ -390,8 +391,8 @@ async def list_swaps(
 @router.post("/propose")
 async def propose_swap(
     target_id: int = Form(...),
-    requester_date: str = Form(...),
-    target_date: str = Form(...),
+    requester_date: date_cls = Form(...),
+    target_date: date_cls = Form(...),
     message: str = Form(None),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
@@ -400,8 +401,8 @@ async def propose_swap(
     if target_id == current_user.id:
         raise HTTPException(status_code=400, detail="Kan inte byta pass med dig själv")
 
-    req_date = datetime.strptime(requester_date, "%Y-%m-%d").date()
-    tgt_date = datetime.strptime(target_date, "%Y-%m-%d").date()
+    req_date = requester_date
+    tgt_date = target_date
     today = get_today()
 
     if req_date <= today or tgt_date <= today:

--- a/app/routes/substitutes.py
+++ b/app/routes/substitutes.py
@@ -8,6 +8,7 @@ all-person schedules.
 
 import calendar as _calendar
 from datetime import date as date_cls
+from datetime import time as time_cls
 from datetime import timedelta
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Request
@@ -28,7 +29,9 @@ from app.database.database import (
 )
 from app.routes.shared import render
 
-router = APIRouter(tags=["substitutes"])
+# All routes here live under /admin/substitutes, so the admin gate lives on the router
+# and cannot be forgotten on a new route. Handlers keep the parameter only when they read it.
+router = APIRouter(tags=["substitutes"], dependencies=[Depends(get_admin_user)])
 
 _ALLOWED_CODES = {"N1", "N2", "N3", "OC"}
 # Absence types selectable for substitutes (we only track days, no pay).
@@ -171,7 +174,6 @@ async def admin_substitute_manage_page(
 @router.post("/admin/substitutes/{substitute_id}/toggle", name="admin_substitute_toggle")
 async def admin_substitute_toggle(
     substitute_id: int,
-    current_user: User = Depends(get_admin_user),
     db: Session = Depends(get_db),
 ):
     """Admin: archive/restore a substitute (archived substitutes are hidden from schedules)."""
@@ -258,7 +260,6 @@ async def admin_substitute_link(
     substitute_id: int,
     user_id: str = Form(""),
     hourly_wage: str = Form(""),
-    current_user: User = Depends(get_admin_user),
     db: Session = Depends(get_db),
 ):
     """Admin: link/unlink a substitute to a user account and set the hourly wage.
@@ -301,9 +302,9 @@ async def admin_substitute_link(
 @router.post("/admin/substitutes/{substitute_id}/overtime/add", name="admin_substitute_overtime_add")
 async def admin_substitute_overtime_add(
     substitute_id: int,
-    date: str = Form(...),
-    start_time: str = Form(...),
-    end_time: str = Form(...),
+    date: date_cls = Form(...),
+    start_time: time_cls = Form(...),
+    end_time: time_cls = Form(...),
     hours: float = Form(...),
     current_user: User = Depends(get_admin_user),
     db: Session = Depends(get_db),
@@ -311,11 +312,9 @@ async def admin_substitute_overtime_add(
     """Add an overtime entry for a substitute (hours only; ot_pay is always 0)."""
     _require_substitute(db, substitute_id)
 
-    from datetime import datetime as _dt
-
-    ot_date = _dt.strptime(date, "%Y-%m-%d").date()
-    start_t = _dt.strptime(start_time, "%H:%M").time()
-    end_t = _dt.strptime(end_time, "%H:%M").time()
+    ot_date = date
+    start_t = start_time
+    end_t = end_time
 
     db.add(
         OvertimeShift(
@@ -341,7 +340,6 @@ async def admin_substitute_overtime_add(
 async def admin_substitute_overtime_delete(
     substitute_id: int,
     ot_id: int,
-    current_user: User = Depends(get_admin_user),
     db: Session = Depends(get_db),
 ):
     """Delete an overtime entry belonging to a substitute."""
@@ -359,9 +357,8 @@ async def admin_substitute_overtime_delete(
 @router.post("/admin/substitutes/{substitute_id}/absence/add", name="admin_substitute_absence_add")
 async def admin_substitute_absence_add(
     substitute_id: int,
-    date: str = Form(...),
+    date: date_cls = Form(...),
     absence_type: str = Form(...),
-    current_user: User = Depends(get_admin_user),
     db: Session = Depends(get_db),
 ):
     """Add an absence day for a substitute (day tracking only, no deduction)."""
@@ -370,9 +367,7 @@ async def admin_substitute_absence_add(
     if absence_type not in _ABSENCE_TYPES:
         raise HTTPException(status_code=400, detail="Invalid absence type")
 
-    from datetime import datetime as _dt
-
-    abs_date = _dt.strptime(date, "%Y-%m-%d").date()
+    abs_date = date
 
     existing = db.query(Absence).filter(Absence.substitute_id == substitute_id, Absence.date == abs_date).first()
     if existing:
@@ -397,7 +392,6 @@ async def admin_substitute_absence_add(
 async def admin_substitute_absence_delete(
     substitute_id: int,
     absence_id: int,
-    current_user: User = Depends(get_admin_user),
     db: Session = Depends(get_db),
 ):
     """Delete an absence day belonging to a substitute."""

--- a/tests/test_admin_router_gate.py
+++ b/tests/test_admin_router_gate.py
@@ -1,0 +1,36 @@
+"""The admin gate lives on the routers in admin.py, admin_users.py and substitutes.py.
+
+These routes no longer declare current_user themselves, so this asserts the
+router-level dependency still rejects a non-admin with 403 on every one of the
+three routers.
+"""
+
+import pytest
+
+
+def _login(client, username, password):
+    client.post("/login", data={"username": username, "password": password})
+
+
+@pytest.mark.parametrize(
+    "method,path,data",
+    [
+        # admin.py router (prefix /admin), handler no longer takes current_user
+        ("post", "/admin/vacation/1/weeks", {"year": "2026", "weeks": "1,2"}),
+        # admin_users.py router (no prefix, all paths under /admin/)
+        ("post", "/admin/users/1/delete-wage/1", {}),
+        # substitutes.py router (no prefix, all paths under /admin/substitutes)
+        ("post", "/admin/substitutes/1/toggle", {}),
+    ],
+)
+def test_non_admin_is_forbidden(test_client, test_user, method, path, data):
+    _login(test_client, "testuser", "testpass123")
+    resp = getattr(test_client, method)(path, data=data, follow_redirects=False)
+    assert resp.status_code == 403
+
+
+def test_admin_reaches_the_handler(test_client, admin_user):
+    """Sanity check: the gate lets an admin through (404 comes from the handler, not the gate)."""
+    _login(test_client, "admin", "adminpass123")
+    resp = test_client.post("/admin/substitutes/999/toggle", data={}, follow_redirects=False)
+    assert resp.status_code == 404

--- a/tests/test_malformed_date_forms.py
+++ b/tests/test_malformed_date_forms.py
@@ -1,0 +1,35 @@
+"""Malformed date/time form fields must be rejected by validation, not blow up.
+
+These routes used to call datetime.strptime on the raw form value with no guard,
+so a bad value raised ValueError and the request came back as 500.
+"""
+
+import pytest
+
+
+def _login(client, username, password):
+    client.post("/login", data={"username": username, "password": password})
+
+
+@pytest.mark.parametrize(
+    "path,data",
+    [
+        ("/shift-override/add", {"user_id": "1", "date": "not-a-date", "shift_code": "N1"}),
+        ("/oncall/add", {"user_id": "1", "date": "2026-13-45"}),
+        ("/oncall/remove", {"user_id": "1", "date": ""}),
+        (
+            "/overtime/add",
+            {"user_id": "1", "date": "15/01/2026", "start_time": "06:00", "end_time": "14:00"},
+        ),
+        (
+            "/overtime/add",
+            {"user_id": "1", "date": "2026-01-15", "start_time": "25:99", "end_time": "14:00"},
+        ),
+        ("/day-pay-override/set", {"user_id": "1", "date": "nope", "ob_hours_OB1": "2"}),
+        ("/swaps/propose", {"target_id": "2", "requester_date": "nope", "target_date": "2026-01-16"}),
+    ],
+)
+def test_malformed_date_returns_4xx_not_500(test_client, test_user, path, data):
+    _login(test_client, "testuser", "testpass123")
+    resp = test_client.post(path, data=data, follow_redirects=False)
+    assert 400 <= resp.status_code < 500, f"{path} -> {resp.status_code}"

--- a/tests/test_oncall_intervals.py
+++ b/tests/test_oncall_intervals.py
@@ -6,7 +6,7 @@ relies on:
 - _select_oncall_rules_for_date: weekday and specific-date matching
 - _get_rule_intervals_for_shift: clipping a rule onto a shift, incl. rules that
   span midnight or end at 24:00
-- _subtract_covered_oncall: time not already claimed by higher-priority rules
+- subtract_covered: time not already claimed by higher-priority rules (shared with OB)
 """
 
 import datetime
@@ -16,8 +16,8 @@ from app.core.oncall import (
     _get_rule_intervals_for_shift,
     _parse_time,
     _select_oncall_rules_for_date,
-    _subtract_covered_oncall,
 )
+from app.core.time_utils import subtract_covered
 
 
 def _dt(day, hour, minute=0):
@@ -93,28 +93,28 @@ class TestGetRuleIntervalsForShift:
         assert _get_rule_intervals_for_shift(rule, _dt(5, 0), _dt(6, 0)) == []
 
 
-class TestSubtractCoveredOncall:
+class TestSubtractCovered:
     def test_no_coverage_returns_whole_interval(self):
-        assert _subtract_covered_oncall(_dt(1, 0), _dt(1, 10), []) == [(_dt(1, 0), _dt(1, 10))]
+        assert subtract_covered(_dt(1, 0), _dt(1, 10), []) == [(_dt(1, 0), _dt(1, 10))]
 
     def test_middle_coverage_splits_into_two_gaps(self):
         covered = [(_dt(1, 2), _dt(1, 4))]
-        result = _subtract_covered_oncall(_dt(1, 0), _dt(1, 10), covered)
+        result = subtract_covered(_dt(1, 0), _dt(1, 10), covered)
         assert result == [(_dt(1, 0), _dt(1, 2)), (_dt(1, 4), _dt(1, 10))]
 
     def test_full_coverage_returns_empty(self):
-        assert _subtract_covered_oncall(_dt(1, 0), _dt(1, 10), [(_dt(1, 0), _dt(1, 10))]) == []
+        assert subtract_covered(_dt(1, 0), _dt(1, 10), [(_dt(1, 0), _dt(1, 10))]) == []
 
     def test_leading_coverage_leaves_tail(self):
         covered = [(_dt(1, 0), _dt(1, 6))]
-        assert _subtract_covered_oncall(_dt(1, 0), _dt(1, 10), covered) == [(_dt(1, 6), _dt(1, 10))]
+        assert subtract_covered(_dt(1, 0), _dt(1, 10), covered) == [(_dt(1, 6), _dt(1, 10))]
 
     def test_unsorted_and_overlapping_coverage_is_merged(self):
         # Out-of-order, overlapping covers should still leave only the true gaps.
         covered = [(_dt(1, 6), _dt(1, 8)), (_dt(1, 1), _dt(1, 3)), (_dt(1, 2), _dt(1, 4))]
-        result = _subtract_covered_oncall(_dt(1, 0), _dt(1, 10), covered)
+        result = subtract_covered(_dt(1, 0), _dt(1, 10), covered)
         assert result == [(_dt(1, 0), _dt(1, 1)), (_dt(1, 4), _dt(1, 6)), (_dt(1, 8), _dt(1, 10))]
 
     def test_coverage_outside_interval_is_ignored(self):
         covered = [(_dt(2, 0), _dt(2, 5))]  # entirely after the interval
-        assert _subtract_covered_oncall(_dt(1, 0), _dt(1, 10), covered) == [(_dt(1, 0), _dt(1, 10))]
+        assert subtract_covered(_dt(1, 0), _dt(1, 10), covered) == [(_dt(1, 0), _dt(1, 10))]

--- a/tests/test_overtime_upsert.py
+++ b/tests/test_overtime_upsert.py
@@ -10,9 +10,9 @@ from app.routes.overtime import add_overtime_shift
 async def test_add_overtime_creates_shift(test_db, test_user):
     response = await add_overtime_shift(
         user_id=test_user.id,
-        date="2026-01-15",
-        start_time="06:00",
-        end_time="14:00",
+        date=datetime.date(2026, 1, 15),
+        start_time=datetime.time(6, 0),
+        end_time=datetime.time(14, 0),
         hours=8.0,
         is_extension=False,
         session=test_db,
@@ -34,9 +34,9 @@ async def test_add_overtime_creates_shift(test_db, test_user):
 async def test_add_overtime_updates_existing_shift_for_same_user_and_date(test_db, test_user):
     await add_overtime_shift(
         user_id=test_user.id,
-        date="2026-01-15",
-        start_time="06:00",
-        end_time="14:00",
+        date=datetime.date(2026, 1, 15),
+        start_time=datetime.time(6, 0),
+        end_time=datetime.time(14, 0),
         hours=8.0,
         is_extension=False,
         session=test_db,
@@ -48,9 +48,9 @@ async def test_add_overtime_updates_existing_shift_for_same_user_and_date(test_d
 
     await add_overtime_shift(
         user_id=test_user.id,
-        date="2026-01-15",
-        start_time="14:00",
-        end_time="22:00",
+        date=datetime.date(2026, 1, 15),
+        start_time=datetime.time(14, 0),
+        end_time=datetime.time(22, 0),
         hours=7.5,
         is_extension=True,
         session=test_db,
@@ -71,9 +71,9 @@ async def test_add_overtime_updates_existing_shift_for_same_user_and_date(test_d
 async def test_add_overtime_keeps_different_dates_separate(test_db, test_user):
     await add_overtime_shift(
         user_id=test_user.id,
-        date="2026-01-15",
-        start_time="06:00",
-        end_time="14:00",
+        date=datetime.date(2026, 1, 15),
+        start_time=datetime.time(6, 0),
+        end_time=datetime.time(14, 0),
         hours=8.0,
         is_extension=False,
         session=test_db,
@@ -81,9 +81,9 @@ async def test_add_overtime_keeps_different_dates_separate(test_db, test_user):
     )
     await add_overtime_shift(
         user_id=test_user.id,
-        date="2026-01-16",
-        start_time="14:00",
-        end_time="22:00",
+        date=datetime.date(2026, 1, 16),
+        start_time=datetime.time(14, 0),
+        end_time=datetime.time(22, 0),
         hours=8.0,
         is_extension=False,
         session=test_db,
@@ -122,9 +122,9 @@ async def test_add_overtime_cleans_up_legacy_duplicates(test_db, test_user):
 
     await add_overtime_shift(
         user_id=test_user.id,
-        date="2026-01-15",
-        start_time="22:00",
-        end_time="06:00",
+        date=datetime.date(2026, 1, 15),
+        start_time=datetime.time(22, 0),
+        end_time=datetime.time(6, 0),
         hours=8.5,
         is_extension=False,
         session=test_db,

--- a/tests/test_shift_swap_conflicts.py
+++ b/tests/test_shift_swap_conflicts.py
@@ -56,8 +56,8 @@ async def test_propose_swap_rejects_conflicting_pending_slot(test_db, test_user,
     with pytest.raises(HTTPException) as exc:
         await propose_swap(
             target_id=admin_user.id,
-            requester_date=day_a.isoformat(),
-            target_date=day_c.isoformat(),
+            requester_date=day_a,
+            target_date=day_c,
             message=None,
             current_user=test_user,
             db=test_db,


### PR DESCRIPTION
Step 2 of the review cleanup: mechanical deduplication in areas the characterization tests already protect. No behaviour changes except one bug fix (a 500 becoming a 422). 308 lines added against 469 removed.

## period.py

Six `_batch_fetch_*` functions each repeated the same 25-line preamble resolving rotation positions to user ids, plus the same 8-line comment about `extra_user_ids` pasted verbatim. They now delegate to `_batch_fetch_by_date`, with `_resolve_fetch_user_ids` holding the shared prelude. Names, signatures and all 12 call sites are unchanged. `_batch_fetch_ot_shifts` keeps its one-day lookback via `days_before=1`.

The absence-to-shift-code mapping (VACATION renders as SEM, PARENTAL falls back to LEAVE) existed at three sites. It was flagged at two previously and had since grown to three, which is exactly the drift it invites. All four call sites now go through `_absence_shift_code`. The agent sites still resolve SEM through the `vacation_shift` variable rather than a `shift_types` lookup, so the object identity behind `is_vacation_day` is provably unaffected.

2441 lines to 2340.

## Admin routers

`admin.py`, `admin_users.py` and `substitutes.py` serve admin-only routes exclusively (verified: every path in all three sits under `/admin`), so the gate moved onto the routers as `dependencies=[Depends(get_admin_user)]`. Twenty handlers that declared `current_user` purely to trigger the dependency lost the parameter; those that read it kept it. A new route on these routers can no longer forget the gate.

Coverage here was weaker than it looked: `test_api.py` accepted any of 302, 303, 307 or 403, which passes even if the gate disappears and the route merely redirects. `test_admin_router_gate.py` now asserts a hard 403 per router.

## Date parsing (bug fix)

The small mutation routes parsed form dates with `datetime.strptime` and no guard, so a malformed value raised an unhandled `ValueError` and returned **500**. Those parameters are now annotated `datetime.date`/`datetime.time` and FastAPI validates them, giving a 422. `day_pay_override.py` additionally had an unguarded `int(form["user_id"])` with the same failure mode; its stable fields moved to `Form(...)` params while the dynamic `ob_hours_*`/`oc_hours_*` keys still come from the raw form. `test_malformed_date_forms.py` pins the 4xx, and was confirmed to fail with 500 against the old code.

`api_v1.py` was deliberately left alone. Its seven hand-rolled parsers already return a clean 400 with a string `detail`, and native validation would change both the status and the body shape on an API consumed by a Home Assistant integration, with no test asserting either. Routes that parse dates inside a try/except and re-render a form with a specific error message were also left alone, since a raw 422 body would be a UX regression there.

## Shared interval subtraction

`subtract_covered` moved to `app/core/time_utils.py`. OB and on-call both resolve overlapping rules by priority (highest priority claims an interval, lower ones get the remainder) and each had its own copy of that sweep. The two were equivalent apart from an early return for empty coverage, which only diverges when `start >= end`: one call site already guards that explicitly and the other filters on `hours > 0` downstream, so neither could observe the difference. The six existing interval tests now cover the OB path too.

## storage.py

Seven loaders repeated the same 18 lines: build the path, `_load_json`, isinstance check, comprehension into a pydantic model, identical except clause. They now delegate to `_load_list` or `_load_obj` and are one line each. Error message wording is preserved via the `what` label.

## Tests

662 passed (651 baseline plus 11 new). `ruff check` and `ruff format --check` clean.

`test_overtime_upsert.py` and `test_shift_swap_conflicts.py` call handler functions directly rather than over HTTP, so they were updated to pass real `date`/`time` objects, which is the handlers' contract now.

## Note for a follow-up

`app/core/oncall.py`, `app/core/translations.py`, `app/routes/admin_users.py`, `app/routes/oncall.py` and `app/routes/shift_swap.py` are stored with CRLF line endings while the rest of the repo is LF. Scripted edits normalise them silently and turn a small change into thousands of lines of diff churn. A `.gitattributes` would settle it, at the cost of one renormalisation commit.