### PR TITLE
Kill three shadow schedule engines

### DIFF
--- a/app/core/schedule/summary.py
+++ b/app/core/schedule/summary.py
@@ -2,6 +2,7 @@
 
 from typing import NamedTuple
 
+from app.core.logging_config import get_logger
 from app.core.storage import load_persons, load_tax_brackets
 
 from .core import get_settings, weekday_names
@@ -14,6 +15,8 @@ from .wages import (
     get_effective_monthly_wage,
     get_user_wage,
 )
+
+logger = get_logger(__name__)
 
 _tax_brackets = None
 _persons = None
@@ -1280,6 +1283,120 @@ def summarize_year_for_person(
         "months": months,
         "year_summary": year_summary,
     }
+
+
+def apply_year_pay_adjustments(months: list[dict], year_summary: dict, user, year: int, session) -> dict | None:
+    """Fold the vacation supplement and the employment transition into a year's pay.
+
+    Mutates ``months`` and ``year_summary`` in place: adds the per-month
+    semestertillägg (0.8% salary + 0.5% variable per vacation day, computed by
+    calculate_vacation_balance), folds it into gross/net, injects the consultant
+    vacation payout into the transition month and appends a row for the direct
+    employer's share, then recomputes the year totals and averages.
+
+    Both /year/<id> and /statistics/<id> show these figures. They each used to
+    do this arithmetic themselves and disagreed about the same person's gross
+    and net, so it lives here and both call it.
+
+    Returns the vacation balance dict (the year view renders it), or None when
+    it could not be calculated.
+    """
+    from app.core.schedule.transition import calculate_transition_month_summary
+    from app.core.schedule.vacation import calculate_vacation_balance, fold_vacation_supplement_into_pay
+
+    vacation_pay = None
+    try:
+        vacation_pay = calculate_vacation_balance(user, year, session)
+        supp_per_day = vacation_pay.get("pay", {}).get("supplement_per_day", 0)
+        total_sem_days = 0
+        total_supplement = 0.0
+        for m in months:
+            sem_days = sum(1 for d in m.get("days", []) if d.get("shift") and d["shift"].code == "SEM")
+            m["vacation_days"] = sem_days
+            m["vacation_supplement"] = round(supp_per_day * sem_days, 0)
+            total_sem_days += sem_days
+            total_supplement += m["vacation_supplement"]
+
+            # Include supplement in gross/net so table columns add up
+            if m["vacation_supplement"] > 0:
+                m["brutto_pay"], m["netto_pay"] = fold_vacation_supplement_into_pay(
+                    m.get("brutto_pay", 0), m.get("netto_pay", 0), m["vacation_supplement"]
+                )
+
+        # Recalculate year totals with updated brutto/netto
+        month_count = len(months) or 1
+        year_summary["total_brutto"] = sum((m.get("brutto_pay", 0) or 0) for m in months)
+        year_summary["total_netto"] = sum((m.get("netto_pay", 0) or 0) for m in months)
+        year_summary["avg_brutto"] = round(year_summary["total_brutto"] / month_count, 0)
+        year_summary["avg_netto"] = round(year_summary["total_netto"] / month_count, 0)
+        year_summary["total_vacation_days"] = total_sem_days
+        year_summary["total_vacation_supplement"] = total_supplement
+        year_summary["avg_vacation_supplement"] = round(total_supplement / month_count, 0)
+    except Exception:
+        logger.warning("Vacation supplement could not be applied for user %s, year %s", user.id, year, exc_info=True)
+
+    if not user.employment_transition or user.employment_transition.transition_date.year != year:
+        return vacation_pay
+
+    try:
+        transition_data = calculate_transition_month_summary(user.employment_transition, user, session)
+    except Exception:
+        logger.warning("Employment transition could not be applied for user %s, year %s", user.id, year, exc_info=True)
+        return vacation_pay
+
+    vac_payout = float(transition_data["consultant_employer"]["vacation_payout"]["total"])
+    direct_salary = float(transition_data["direct_employer"]["base_salary"])
+    t_year = transition_data["transition_year"]
+    t_month = transition_data["transition_month"]
+
+    for i, m in enumerate(months):
+        if m["payment_date"].year != t_year or m["payment_date"].month != t_month:
+            continue
+
+        brutto = float(m.get("brutto_pay") or 0)
+        netto = float(m.get("netto_pay") or 0)
+        tax_ratio = (netto / brutto) if brutto > 0 else 0.72
+
+        # Add vacation payout to Sem.till. and Gross on the trailing consultant row
+        m["vacation_supplement"] = round((m.get("vacation_supplement") or 0) + vac_payout, 0)
+        m["brutto_pay"] = round(brutto + vac_payout, 0)
+        m["netto_pay"] = round(netto + vac_payout * tax_ratio, 0)
+
+        # Extra row: direct employer innestående base salary. Same payslip month
+        # as the row above, which is how consumers can fold the two together.
+        original_count = len(months)  # before insert
+        months.insert(
+            i + 1,
+            {
+                "payment_date": m["payment_date"],
+                "year": t_year,
+                "month": t_month,
+                "transition_direct": True,
+                "netto_pay": round(direct_salary * tax_ratio, 0),
+                "brutto_pay": direct_salary,
+                "num_shifts": 0,
+                "total_hours": 0,
+                "total_ob": 0,
+                "oncall_pay": 0,
+                "ot_pay": 0,
+                "absence_deduction": 0,
+                "vacation_supplement": 0,
+            },
+        )
+
+        # Update year totals and averages: average uses the original month count
+        year_summary["total_brutto"] = sum(float(m2.get("brutto_pay") or 0) for m2 in months)
+        year_summary["total_netto"] = sum(float(m2.get("netto_pay") or 0) for m2 in months)
+        year_summary["avg_brutto"] = round(year_summary["total_brutto"] / original_count, 0)
+        year_summary["avg_netto"] = round(year_summary["total_netto"] / original_count, 0)
+        if "total_vacation_supplement" in year_summary:
+            year_summary["total_vacation_supplement"] = sum(float(m2.get("vacation_supplement") or 0) for m2 in months)
+            year_summary["avg_vacation_supplement"] = round(
+                year_summary["total_vacation_supplement"] / original_count, 0
+            )
+        break
+
+    return vacation_pay
 
 
 def _report_row_from_summary(summary: dict, is_substitute: bool) -> dict:

--- a/app/routes/api_v1.py
+++ b/app/routes/api_v1.py
@@ -6,16 +6,13 @@ from fastapi import APIRouter, Depends, FastAPI, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from app.auth.auth import get_admin_api_user, get_api_user
-from app.core.schedule.core import calculate_shift_hours, determine_shift_for_date, get_shift_types
-from app.core.schedule.ob import calculate_ob_pay, get_combined_rules_for_year
+from app.core.schedule.core import determine_shift_for_date, get_shift_types
+from app.core.schedule.ob import compute_day_ob_pay, get_combined_rules_for_year
+from app.core.schedule.period import generate_period_data
 from app.core.utils import APP_TIMEZONE, get_today
 from app.database.database import (
     Absence,
-    OnCallOverride,
-    OnCallOverrideType,
     OvertimeShift,
-    ShiftSwap,
-    SwapStatus,
     User,
     UserRole,
     get_db,
@@ -99,13 +96,23 @@ def _build_coworkers(
     date: datetime.date,
     all_users: list[User],
     absent_ids: set[int],
-    overtime_map: dict[int, datetime.time] | None = None,
+    overtime_map: dict[int, datetime.time],
 ) -> list[dict]:
+    """Who else is working that day.
+
+    NOTE: this is the one place left in the module that reads the rotation directly
+    instead of the canonical path, so a co-worker's swap or shift override is not
+    reflected in their shift_code (their absences are, via absent_ids). The canonical
+    source would be generate_period_data(person_id=None), but that resolves
+    PersonHistory per person and day: measured at ~52 queries per calendar day
+    against ~5 for the single-person call, which turns /schedule/year from ~2.5k
+    into ~21k queries. Switch this over once period.py batches those lookups.
+    """
     result = []
     for u in all_users:
         if u.id == user_id or u.id in absent_ids or u.role == UserRole.ADMIN:
             continue
-        if overtime_map is not None and u.id in overtime_map:
+        if u.id in overtime_map:
             code, label = _find_shift_for_overtime(overtime_map[u.id])
             result.append({"id": u.id, "name": u.name, "shift_code": code, "shift_label": label})
             continue
@@ -115,101 +122,92 @@ def _build_coworkers(
     return result
 
 
-def _build_day_status(
-    user: User,
+def _day_status_and_shift(canonical: dict, absence, overtime) -> tuple[str, object]:
+    """Map a canonical day to the API's (status, shift) pair.
+
+    The API's `shift` field has always meant "the shift this person was assigned",
+    with absence/vacation reported separately in `status`; the canonical day instead
+    replaces `shift` with the absence, vacation or overtime shift. So the assigned
+    shift is taken from `original_shift` on those days, and from the fully resolved
+    `shift` (rotation + swap + override + on-call override) on every other day.
+    """
+    shift = canonical.get("shift")
+    assigned = canonical.get("original_shift") or shift
+
+    def _status(s) -> str:
+        if s is None:
+            return "unknown"
+        return "off" if s.code == "OFF" else "working"
+
+    if absence is not None:
+        return absence.absence_type.value.lower(), assigned
+    if canonical.get("parental_leave"):
+        return "parental", assigned
+    if shift is not None and shift.code == "SEM":
+        return "vacation", assigned
+    if overtime is not None and not overtime.is_extension:
+        # Canonical swaps in the OT shift type; the API reports overtime in its own
+        # block and keeps the underlying shift here.
+        return _status(assigned), assigned
+    return _status(shift), shift
+
+
+def _build_day(
+    canonical: dict,
     date: datetime.date,
+    user: User,
     db: Session,
-    include_salary: bool = False,
-    all_users: list[User] | None = None,
-    absent_ids: set[int] | None = None,
-    overtime_map: dict[int, datetime.time] | None = None,
+    absence,
+    overtime,
+    include_salary: bool,
+    coworkers: list[dict] | None,
 ) -> dict:
-    absence = db.query(Absence).filter(Absence.user_id == user.id, Absence.date == date).first()
-    overtime = db.query(OvertimeShift).filter(OvertimeShift.user_id == user.id, OvertimeShift.date == date).first()
-    shift, rotation_week = determine_shift_for_date(date, user.rotation_person_id)
-
-    coworkers = None
-    if all_users is not None:
-        effective_absent = (
-            absent_ids
-            if absent_ids is not None
-            else {row[0] for row in db.query(Absence.user_id).filter(Absence.date == date).all()}
-        )
-        # Include the current user as absent if they have an absence
-        if absence:
-            effective_absent = effective_absent | {user.id}
-        if overtime_map is not None:
-            effective_overtime = overtime_map
-        else:
-            effective_overtime = {
-                row[0]: row[1]
-                for row in db.query(OvertimeShift.user_id, OvertimeShift.end_time)
-                .filter(OvertimeShift.date == date, OvertimeShift.is_extension.is_(False))
-                .all()
-            }
-        coworkers = _build_coworkers(user.id, date, all_users, effective_absent, effective_overtime)
-
-    shift_data = _shift_to_dict(shift) if shift else None
-
-    if absence:
-        result = {
-            "date": date.isoformat(),
-            "status": absence.absence_type.value.lower(),
-            "shift": shift_data,
-            "rotation_week": rotation_week,
-            "overtime": None,
-            "partial_day": absence.left_at,
-            "arrived_late": absence.arrived_at,
-        }
-        if include_salary:
-            result["ob_pay"] = None
-            result["ob_total"] = 0.0
-        if coworkers is not None:
-            result["coworkers"] = coworkers
-        return result
-
-    ob_pay_data = None
-    ob_total = 0.0
-
-    if shift and shift.code not in ("OFF", "OC") and include_salary:
-        is_full_ot = overtime and not overtime.is_extension
-        if not is_full_ot:
-            _, start_dt, end_dt = calculate_shift_hours(date, shift)
-            if start_dt and end_dt:
-                rules = get_combined_rules_for_year(date.year)
-                rate_overrides = (user.custom_rates or {}).get("ob")
-                from app.core.schedule.wages import get_effective_monthly_wage
-
-                monthly_wage = get_effective_monthly_wage(db, user.id, user.wage, effective_date=date)
-                ob_pay_raw = calculate_ob_pay(start_dt, end_dt, rules, monthly_wage, rate_overrides)
-                ob_total = round(sum(ob_pay_raw.values()), 2)
-                ob_pay_data = {k: round(v, 2) for k, v in ob_pay_raw.items() if v > 0}
-
-    overtime_data = None
-    if overtime:
-        overtime_data = {
-            "start_time": overtime.start_time.strftime("%H:%M"),
-            "end_time": overtime.end_time.strftime("%H:%M"),
-            "hours": overtime.hours,
-            "is_extension": overtime.is_extension,
-        }
-
-    status = "off" if (shift and shift.code == "OFF") else ("working" if shift else "unknown")
+    status, shift = _day_status_and_shift(canonical, absence, overtime)
 
     result = {
         "date": date.isoformat(),
         "status": status,
-        "shift": shift_data,
-        "rotation_week": rotation_week,
-        "overtime": overtime_data,
-        "partial_day": None,
+        "shift": _shift_to_dict(shift) if shift else None,
+        "rotation_week": canonical.get("rotation_week"),
+        # An absence outranks overtime in the response, as it always has.
+        "overtime": None
+        if (absence is not None or overtime is None)
+        else {
+            "start_time": overtime.start_time.strftime("%H:%M"),
+            "end_time": overtime.end_time.strftime("%H:%M"),
+            "hours": overtime.hours,
+            "is_extension": overtime.is_extension,
+        },
+        "partial_day": absence.left_at if absence is not None else None,
     }
+    if absence is not None:
+        result["arrived_late"] = absence.arrived_at
     if include_salary:
-        result["ob_pay"] = ob_pay_data
-        result["ob_total"] = ob_total
+        result["ob_pay"], result["ob_total"] = _day_ob_pay(canonical, date, user, db)
     if coworkers is not None:
         result["coworkers"] = coworkers
     return result
+
+
+def _day_ob_pay(canonical: dict, date: datetime.date, user: User, db: Session) -> tuple[dict | None, float]:
+    """OB pay for a canonical day, through the shared gate used by the day view."""
+    c_shift = canonical.get("shift")
+    has_ob = bool(canonical.get("ob_hours_override")) or bool(
+        c_shift and c_shift.code not in ("OFF", "OC", "OT") and canonical.get("start") and canonical.get("end")
+    )
+    if not has_ob:
+        return None, 0.0
+
+    from app.core.schedule.wages import get_effective_monthly_wage
+
+    monthly_wage = get_effective_monthly_wage(db, user.id, user.wage, effective_date=date)
+    _, ob_pay, _ = compute_day_ob_pay(
+        canonical,
+        get_combined_rules_for_year(date.year),
+        monthly_wage,
+        (user.custom_rates or {}).get("ob"),
+    )
+    return {k: round(v, 2) for k, v in ob_pay.items() if v > 0}, round(sum(ob_pay.values()), 2)
 
 
 def _build_period(
@@ -218,29 +216,87 @@ def _build_period(
     end: datetime.date,
     db: Session,
     include_salary: bool,
+    with_coworkers: bool = True,
 ) -> tuple[list[dict], float]:
-    """Build day-status list for a range; returns (days, ob_total_sum)."""
-    all_users = db.query(User).filter(User.is_active == 1).all()
-    absent_by_date = _absent_ids_by_date(start, end, db)
-    overtime_by_date = _overtime_by_date(start, end, db)
+    """Build day-status list for a range; returns (days, ob_total_sum).
+
+    INVARIANT (issue #206, same rule as app/routes/schedule_personal.py): shift
+    resolution comes exclusively from generate_period_data, so shift overrides,
+    swaps, on-call overrides, day pay overrides, linked substitutes and employment
+    masking reach this API automatically. The Absence and OvertimeShift rows read
+    below only decorate the response (status text, partial-day times, the overtime
+    block); do not reintroduce shadow calculations on top of them. A new override
+    layer belongs in period.py, where it reaches every view at once.
+    """
+    canonical_days = {
+        day["date"]: day for day in generate_period_data(start, end, person_id=target.rotation_person_id, session=db)
+    }
+    absences = {
+        a.date: a
+        for a in db.query(Absence).filter(Absence.user_id == target.id, Absence.date.between(start, end)).all()
+    }
+    overtimes = {
+        o.date: o
+        for o in db.query(OvertimeShift)
+        .filter(OvertimeShift.user_id == target.id, OvertimeShift.date.between(start, end))
+        .all()
+    }
+
+    all_users: list[User] = []
+    absent_by_date: dict[datetime.date, set[int]] = {}
+    overtime_by_date: dict[datetime.date, dict[int, datetime.time]] = {}
+    if with_coworkers:
+        all_users = db.query(User).filter(User.is_active == 1).all()
+        absent_by_date = _absent_ids_by_date(start, end, db)
+        overtime_by_date = _overtime_by_date(start, end, db)
+
     days = []
     ob_sum = 0.0
     d = start
     while d <= end:
-        day = _build_day_status(
-            target,
+        absence = absences.get(d)
+        coworkers = None
+        if with_coworkers:
+            # The viewed user counts as absent for co-worker matching too.
+            absent_ids = absent_by_date.get(d, set()) | ({target.id} if absence else set())
+            coworkers = _build_coworkers(target.id, d, all_users, absent_ids, overtime_by_date.get(d, {}))
+        day = _build_day(
+            canonical_days.get(d, {}),
             d,
+            target,
             db,
-            include_salary=include_salary,
-            all_users=all_users,
-            absent_ids=absent_by_date.get(d, set()),
-            overtime_map=overtime_by_date.get(d, {}),
+            absence,
+            overtimes.get(d),
+            include_salary,
+            coworkers,
         )
         if include_salary:
             ob_sum += day.get("ob_total") or 0.0
         days.append(day)
         d += datetime.timedelta(days=1)
     return days, round(ob_sum, 2)
+
+
+def _active_overnight_shift(day: dict, current_time: datetime.time) -> dict | None:
+    """The given day's shift, when it crosses midnight and is still running at current_time."""
+    shift = day["shift"]
+    if day["status"] != "working" or not shift or shift["code"] == "OC" or not shift["overnight"]:
+        return None
+    if current_time >= datetime.time.fromisoformat(shift["end_time"]):
+        return None
+    return {"date": day["date"], "shift": shift, "rotation_week": day["rotation_week"]}
+
+
+def _build_day_status(
+    user: User,
+    date: datetime.date,
+    db: Session,
+    include_salary: bool = False,
+    with_coworkers: bool = False,
+) -> dict:
+    """Single-day status; a one-day slice of the canonical period path."""
+    days, _ = _build_period(user, date, date, db, include_salary, with_coworkers=with_coworkers)
+    return days[0]
 
 
 # ── Own user shortcut ────────────────────────────────────────────────────────
@@ -313,24 +369,13 @@ async def get_user_status(
         now = datetime.datetime.now(APP_TIMEZONE)
         today = now.date()
         current_time = now.time()
-    all_users = db.query(User).filter(User.is_active == 1).all()
-    absent_ids = {row[0] for row in db.query(Absence.user_id).filter(Absence.date == today).all()}
-    result = _build_day_status(
-        target, today, db, include_salary=include_salary, all_users=all_users, absent_ids=absent_ids
-    )
-    # Check for an ongoing overnight shift from the previous day.
     yesterday = today - datetime.timedelta(days=1)
-    yesterday_absence = db.query(Absence).filter(Absence.user_id == target.id, Absence.date == yesterday).first()
-    if not yesterday_absence:
-        prev_shift, prev_rw = determine_shift_for_date(yesterday, target.rotation_person_id)
-        if prev_shift and prev_shift.code not in ("OFF", "OC") and _is_overnight(prev_shift):
-            prev_end = datetime.time.fromisoformat(prev_shift.end_time)
-            if current_time < prev_end:
-                result["currently_active_shift"] = {
-                    "date": yesterday.isoformat(),
-                    "shift": _shift_to_dict(prev_shift),
-                    "rotation_week": prev_rw,
-                }
+    days, _ = _build_period(target, yesterday, today, db, include_salary)
+    previous, result = days
+    # Check for an ongoing overnight shift from the previous day.
+    active = _active_overnight_shift(previous, current_time)
+    if active is not None:
+        result["currently_active_shift"] = active
     return result
 
 
@@ -344,7 +389,6 @@ async def get_user_schedule_today(
     """Schedule for today including co-workers. Pass ?date=YYYY-MM-DD to simulate another day."""
     target = _get_user_or_404(user_id, db)
     include_salary = _can_see_salary(current_user, target)
-    all_users = db.query(User).filter(User.is_active == 1).all()
     if at_date:
         try:
             today = datetime.date.fromisoformat(at_date)
@@ -352,10 +396,7 @@ async def get_user_schedule_today(
             raise HTTPException(status_code=400, detail="Ogiltigt datumformat, använd YYYY-MM-DD") from e
     else:
         today = get_today()
-    absent_ids = {row[0] for row in db.query(Absence.user_id).filter(Absence.date == today).all()}
-    return _build_day_status(
-        target, today, db, include_salary=include_salary, all_users=all_users, absent_ids=absent_ids
-    )
+    return _build_day_status(target, today, db, include_salary=include_salary, with_coworkers=True)
 
 
 @router.get("/users/{user_id}/schedule/month")
@@ -461,11 +502,7 @@ async def get_user_schedule_date(
     except ValueError:
         raise HTTPException(status_code=400, detail="Ogiltigt datumformat, använd YYYY-MM-DD") from None
     include_salary = _can_see_salary(current_user, target)
-    all_users = db.query(User).filter(User.is_active == 1).all()
-    absent_ids = {row[0] for row in db.query(Absence.user_id).filter(Absence.date == target_date).all()}
-    return _build_day_status(
-        target, target_date, db, include_salary=include_salary, all_users=all_users, absent_ids=absent_ids
-    )
+    return _build_day_status(target, target_date, db, include_salary=include_salary, with_coworkers=True)
 
 
 # ── Users list ──────────────────────────────────────────────────────────────
@@ -593,47 +630,6 @@ async def get_user_absences(
 # ── Next shift ───────────────────────────────────────────────────────────────
 
 
-def _resolve_effective_shift(date: datetime.date, user: User, db: Session) -> tuple:
-    """Return (shift, rotation_week) for user on date, applying oncall overrides and accepted swaps."""
-    shift, rotation_week = determine_shift_for_date(date, user.rotation_person_id)
-
-    # Apply manual oncall override (ADD or REMOVE OC via day view)
-    override = db.query(OnCallOverride).filter(OnCallOverride.user_id == user.id, OnCallOverride.date == date).first()
-    if override:
-        shift_types = get_shift_types()
-        if override.override_type == OnCallOverrideType.ADD:
-            oc = next((s for s in shift_types if s.code == "OC"), None)
-            if oc:
-                shift = oc
-        elif override.override_type == OnCallOverrideType.REMOVE and shift and shift.code == "OC":
-            off = next((s for s in shift_types if s.code == "OFF"), None)
-            if off:
-                shift = off
-
-    # Apply accepted shift swap (if any)
-    swap = (
-        db.query(ShiftSwap)
-        .filter(
-            ShiftSwap.status == SwapStatus.ACCEPTED,
-            (ShiftSwap.requester_id == user.id) | (ShiftSwap.target_id == user.id),
-            (ShiftSwap.requester_date == date) | (ShiftSwap.target_date == date),
-        )
-        .first()
-    )
-    if swap is not None:
-        shift_types = get_shift_types()
-        if swap.requester_id == user.id and swap.requester_date == date:
-            shift, _ = determine_shift_for_date(date, swap.target.rotation_person_id)
-        elif swap.target_id == user.id and swap.requester_date == date:
-            shift = next((s for s in shift_types if s.code == swap.requester_shift_code), shift)
-        elif swap.requester_id == user.id and swap.target_date == date:
-            shift = next((s for s in shift_types if s.code == swap.target_shift_code), shift)
-        elif swap.target_id == user.id and swap.target_date == date:
-            shift, _ = determine_shift_for_date(date, swap.requester.rotation_person_id)
-
-    return shift, rotation_week
-
-
 @router.get("/users/{user_id}/next-shift")
 async def get_user_next_shift(
     user_id: int,
@@ -658,38 +654,24 @@ async def get_user_next_shift(
         today = now.date()
         current_time = now.time()
 
-    # Check if there is an ongoing overnight shift from yesterday still running.
-    currently_active: dict | None = None
     yesterday = today - datetime.timedelta(days=1)
-    yesterday_absence = db.query(Absence).filter(Absence.user_id == target.id, Absence.date == yesterday).first()
-    if not yesterday_absence:
-        prev_shift, prev_rw = _resolve_effective_shift(yesterday, target, db)
-        if prev_shift and prev_shift.code not in ("OFF", "OC") and _is_overnight(prev_shift):
-            prev_end = datetime.time.fromisoformat(prev_shift.end_time)
-            if current_time < prev_end:
-                currently_active = {
-                    "date": yesterday.isoformat(),
-                    "shift": _shift_to_dict(prev_shift),
-                    "rotation_week": prev_rw,
-                }
+    days, _ = _build_period(
+        target, yesterday, today + datetime.timedelta(days=59), db, include_salary=False, with_coworkers=False
+    )
+    # Check if there is an ongoing overnight shift from yesterday still running.
+    currently_active = _active_overnight_shift(days[0], current_time)
 
-    for offset in range(60):
-        candidate = today + datetime.timedelta(days=offset)
-        absence = db.query(Absence).filter(Absence.user_id == target.id, Absence.date == candidate).first()
-        if absence:
+    for offset, day in enumerate(days[1:]):
+        # Absence, vacation and parental days never report as "working".
+        if day["status"] != "working" or not day["shift"] or not day["shift"]["start_time"]:
             continue
-        shift, rotation_week = _resolve_effective_shift(candidate, target, db)
-        if not shift or shift.code == "OFF":
+        if offset == 0 and current_time >= datetime.time.fromisoformat(day["shift"]["start_time"]):
             continue
-        if offset == 0:
-            shift_start = datetime.time.fromisoformat(shift.start_time)
-            if current_time >= shift_start:
-                continue
         result = {
-            "date": candidate.isoformat(),
+            "date": day["date"],
             "days_from_today": offset,
-            "shift": _shift_to_dict(shift),
-            "rotation_week": rotation_week,
+            "shift": day["shift"],
+            "rotation_week": day["rotation_week"],
         }
         if currently_active is not None:
             result["currently_active_shift"] = currently_active

--- a/app/routes/dashboard.py
+++ b/app/routes/dashboard.py
@@ -4,7 +4,7 @@ Dashboard route - personalized home page for authenticated users.
 """
 
 import datetime as dt
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
@@ -13,23 +13,17 @@ from sqlalchemy.orm import Session
 from app.auth.auth import get_current_user_optional
 from app.core.helpers import can_see_salary
 from app.core.logging_config import get_logger
-from app.core.oncall import _cached_oncall_rules, calculate_oncall_pay
 from app.core.rates import get_user_rates
 from app.core.schedule import (
     _cached_special_rules,
     build_week_data,
-    calculate_ob_hours,
-    calculate_ob_pay,
-    calculate_overtime_pay,
-    calculate_shift_hours,
-    determine_shift_for_date,
+    generate_period_data,
     get_effective_monthly_wage,
-    get_ot_hourly_rate_from_stored_wage,
     get_overtime_shifts_for_month,
-    get_user_wage,
     ob_rules,
     rotation_start_date,
 )
+from app.core.schedule.ob import compute_day_ob_pay
 from app.core.schedule.wages import (
     KARENS_HOURS,
     calculate_absence_deduction,
@@ -38,7 +32,7 @@ from app.core.schedule.wages import (
     get_shift_times_for_date,
 )
 from app.core.utils import get_safe_today, get_today
-from app.database.database import Absence, OnCallOverride, OnCallOverrideType, ShiftSwap, SwapStatus, User, get_db
+from app.database.database import Absence, ShiftSwap, SwapStatus, User, get_db
 from app.routes.shared import render
 
 router = APIRouter(tags=["dashboard"])
@@ -162,8 +156,21 @@ async def read_root(
     # Get user's rotation position (person_id field, or fallback to user.id)
     person_id = current_user.rotation_person_id
 
-    # Build the viewed week's data for the user (pass session for oncall override support)
-    week_data = build_week_data(view_iso_year_w, view_iso_week, person_id=person_id, session=db)
+    user_wage = get_effective_monthly_wage(db, current_user.id)
+    _user_rates = get_user_rates(current_user, session=db)
+    show_salary = can_see_salary(current_user, current_user.id)
+
+    # Build the viewed week on the canonical period path, the same one the month and
+    # year summaries use: its day dicts already carry on-call, overtime and OB, so the
+    # dashboard sums them below instead of recomputing the rules a fourth time.
+    view_week_sunday = view_week_monday + timedelta(days=6)
+    week_data = generate_period_data(
+        view_week_monday,
+        view_week_sunday,
+        person_id=person_id,
+        session=db,
+        user_rates_map={person_id: _user_rates} if _user_rates else None,
+    )
 
     # Create compact week schedule for dashboard display
     week_schedule = []
@@ -191,29 +198,6 @@ async def read_root(
 
     # Create lookup dictionary for O(1) access (used for upcoming-shift detection)
     ot_shift_map = {shift.date: shift for shift in ot_shifts_current + ot_shifts_next}
-
-    # OT map for the viewed week (may differ from current month)
-    view_week_months: set[tuple[int, int]] = set()
-    for _d in range(7):
-        _day = view_week_monday + dt.timedelta(days=_d)
-        view_week_months.add((_day.year, _day.month))
-    _view_week_ot: list = []
-    for _wy, _wm in view_week_months:
-        _view_week_ot.extend(get_overtime_shifts_for_month(db, current_user.id, _wy, _wm))
-    view_week_ot_map = {s.date: s for s in _view_week_ot}
-
-    # On-call overrides for the viewed week (needed to detect OC+OT same day)
-    view_week_sunday = view_week_monday + timedelta(days=6)
-    week_oncall_overrides = (
-        db.query(OnCallOverride)
-        .filter(
-            OnCallOverride.user_id == current_user.id,
-            OnCallOverride.date >= view_week_monday,
-            OnCallOverride.date <= view_week_sunday,
-        )
-        .all()
-    )
-    week_oncall_override_map = {o.date: o for o in week_oncall_overrides}
 
     # Find next upcoming shift (including overtime shifts)
     next_shift = None
@@ -280,106 +264,40 @@ async def read_root(
                     "days_until": days_until,
                 }
 
-    # Setup OB/oncall rules for the viewed week
-    combined_rules_w = ob_rules + _cached_special_rules(view_iso_year_w)
-    oncall_rules_w = _cached_oncall_rules(view_iso_year_w)
-    user_wage = get_effective_monthly_wage(db, current_user.id)
-    _raw_wage_week = get_user_wage(db, current_user.id)
-    _user_rates = get_user_rates(current_user, session=db)
-    show_salary = can_see_salary(current_user, current_user.id)
-
-    # Calculate week summary
+    # Calculate week summary by summing the canonical day dicts. The only rules applied
+    # here are the summary's own aggregation rules (OB through the shared compute_day_ob_pay
+    # gate, on-call hours excluded from worked hours, OT hours added), mirroring
+    # _process_day_for_summary so the week, month and year figures cannot drift apart.
     week_summary = None
     if week_data:
+        combined_rules_w = ob_rules + _cached_special_rules(view_iso_year_w)
         total_hours = 0.0
         ob_hours = 0.0
         total_pay = 0.0
-        oc_pay = 0.0
-        ot_pay = 0.0
         absence_deduction = 0.0
 
         for day in week_data:
-            # Check for absence first
-            absence, deduction = _query_absence_and_deduction(db, current_user.id, day["date"], user_wage, show_salary)
+            _, deduction = _query_absence_and_deduction(db, current_user.id, day["date"], user_wage, show_salary)
             absence_deduction += deduction
 
-            # Check for overtime shift first (use dictionary lookup)
-            ot_shift = view_week_ot_map.get(day["date"])
+            day_ob_hours, day_ob_pay, _ = compute_day_ob_pay(
+                day, combined_rules_w, user_wage, _user_rates["ob"] if _user_rates else None
+            )
+            ob_hours += sum(day_ob_hours.values())
+            if show_salary:
+                total_pay += sum(day_ob_pay.values())
 
-            if ot_shift and not absence:  # Skip OT if there's an absence
-                # Calculate OT hours and pay
-                ot_start = datetime.combine(day["date"], ot_shift.start_time)
-                ot_end = datetime.combine(day["date"], ot_shift.end_time)
-
-                # Handle shifts that cross midnight
-                if ot_shift.end_time < ot_shift.start_time:
-                    ot_end += dt.timedelta(days=1)
-
-                ot_hours = (ot_end - ot_start).total_seconds() / 3600.0
-                total_hours += ot_hours
-
-                if show_salary:
-                    _custom_ot = _user_rates["ot"]
-                    _ot_rate_w = (
-                        _custom_ot
-                        if _custom_ot is not None
-                        else get_ot_hourly_rate_from_stored_wage(db, current_user.id, _raw_wage_week)
-                    )
-                    ot_ob_pay = calculate_overtime_pay(user_wage, ot_hours, ot_hourly_rate=_ot_rate_w)
-                    ot_pay += ot_ob_pay
-
-            # Determine effective on-call status using rotation shift + override
-            # (day["shift"] may show OT which masks an OC override on the same day)
-            _week_override = week_oncall_override_map.get(day["date"])
-            _rot_result = determine_shift_for_date(day["date"], start_week=person_id)
-            _rot_shift = _rot_result[0] if _rot_result else None
-            _has_rot_oc = _rot_shift and _rot_shift.code == "OC"
-            _is_effective_oc = (
-                _has_rot_oc and not (_week_override and _week_override.override_type == OnCallOverrideType.REMOVE)
-            ) or (_week_override and _week_override.override_type == OnCallOverrideType.ADD)
-
-            if _is_effective_oc and show_salary:
-                _oc_excluded = []
-                _ot_on_oc_day = view_week_ot_map.get(day["date"])
-                if _ot_on_oc_day:
-                    _ot_s = datetime.combine(day["date"], _ot_on_oc_day.start_time)
-                    _ot_e = datetime.combine(day["date"], _ot_on_oc_day.end_time)
-                    if _ot_on_oc_day.end_time < _ot_on_oc_day.start_time:
-                        _ot_e += dt.timedelta(days=1)
-                    _oc_excluded = [(_ot_s, _ot_e)]
-                oc_result = calculate_oncall_pay(
-                    day["date"],
-                    user_wage,
-                    oncall_rules_w,
-                    rate_overrides=_user_rates["oncall"],
-                    excluded_intervals=_oc_excluded or None,
-                )
-                oc_pay += oc_result["total_pay"]
-
-            # Handle regular rotation shifts (only if day is not purely on-call with no OT)
-            if day["shift"] and not (_is_effective_oc and day["shift"].code == "OC"):
-                if day["shift"].code not in ("OC", "OFF") and day["shift"].start_time is not None:
-                    # Calculate regular shift hours
-                    hours, start_dt, end_dt = calculate_shift_hours(day["date"], day["shift"])
-                    total_hours += hours
-
-                    # Calculate OB hours and pay if we have valid datetimes
-                    if start_dt and end_dt:
-                        ob_hours_dict = calculate_ob_hours(start_dt, end_dt, combined_rules_w)
-                        ob_hours += sum(ob_hours_dict.values())
-
-                        if show_salary:
-                            ob_pay_dict = calculate_ob_pay(
-                                start_dt, end_dt, combined_rules_w, user_wage, rate_overrides=_user_rates["ob"]
-                            )
-                            total_pay += sum(ob_pay_dict.values())
+            shift = day.get("shift")
+            if shift and shift.code != "OC":
+                total_hours += day.get("hours", 0.0)
+            total_hours += day.get("ot_hours", 0.0)
 
         week_summary = {
             "total_hours": total_hours,
             "ob_hours": ob_hours,
             "total_pay": total_pay,
-            "oc_pay": oc_pay,
-            "ot_pay": ot_pay,
+            "oc_pay": sum(d.get("oncall_pay", 0.0) for d in week_data) if show_salary else 0.0,
+            "ot_pay": sum(d.get("ot_pay", 0.0) for d in week_data) if show_salary else 0.0,
             "absence_deduction": absence_deduction,
         }
 

--- a/app/routes/schedule_personal.py
+++ b/app/routes/schedule_personal.py
@@ -43,6 +43,7 @@ from app.core.schedule import (
 from app.core.schedule import (
     persons as person_list,
 )
+from app.core.schedule.summary import apply_year_pay_adjustments
 from app.core.schedule.vacation import calculate_vacation_balance, fold_vacation_supplement_into_pay
 from app.core.utils import get_navigation_dates, get_ot_shift_display_code, get_safe_today, get_today
 from app.core.validators import validate_date_params, validate_person_id
@@ -1203,7 +1204,8 @@ async def year_view(
         months = [strip_salary_data(m) for m in months]
         year_summary = strip_salary_data(year_summary)
 
-    # Calculate vacation supplement per month if salary is visible
+    # Fold the vacation supplement and any employment transition into the pay
+    # figures. Shared with /statistics/<id> so both pages show the same money.
     vacation_pay = None
     if show_salary:
         vac_user = (
@@ -1212,106 +1214,7 @@ async def year_view(
             else db.query(User).filter(User.person_id == rotation_position).first()
         )
         if vac_user:
-            try:
-                vacation_pay = calculate_vacation_balance(vac_user, year, db)
-                supp_per_day = vacation_pay.get("pay", {}).get("supplement_per_day", 0)
-                total_sem_days = 0
-                total_supplement = 0.0
-                for m in months:
-                    sem_days = sum(1 for d in m.get("days", []) if d.get("shift") and d["shift"].code == "SEM")
-                    m["vacation_days"] = sem_days
-                    m["vacation_supplement"] = round(supp_per_day * sem_days, 0)
-                    total_sem_days += sem_days
-                    total_supplement += m["vacation_supplement"]
-
-                    # Include supplement in gross/net so table columns add up
-                    if m["vacation_supplement"] > 0:
-                        m["brutto_pay"], m["netto_pay"] = fold_vacation_supplement_into_pay(
-                            m.get("brutto_pay", 0), m.get("netto_pay", 0), m["vacation_supplement"]
-                        )
-
-                # Recalculate year totals with updated brutto/netto
-                month_count = len(months) or 1
-                year_summary["total_brutto"] = sum((m.get("brutto_pay", 0) or 0) for m in months)
-                year_summary["total_netto"] = sum((m.get("netto_pay", 0) or 0) for m in months)
-                year_summary["avg_brutto"] = round(year_summary["total_brutto"] / month_count, 0)
-                year_summary["avg_netto"] = round(year_summary["total_netto"] / month_count, 0)
-                year_summary["total_vacation_days"] = total_sem_days
-                year_summary["total_vacation_supplement"] = total_supplement
-                year_summary["avg_vacation_supplement"] = round(total_supplement / month_count, 0)
-            except Exception:
-                pass
-
-    # Check for employment transition in this year
-    transition_data = None
-    if show_salary:
-        t_user = (
-            target_user
-            if target_user is not None
-            else db.query(User).filter(User.person_id == rotation_position).first()
-        )
-        if t_user and t_user.employment_transition:
-            t = t_user.employment_transition
-            if t.transition_date.year == year:
-                try:
-                    from app.core.schedule.transition import calculate_transition_month_summary
-
-                    transition_data = calculate_transition_month_summary(t, t_user, db)
-                except Exception:
-                    pass
-
-    # Inject employment transition into months list
-    if transition_data and show_salary:
-        vac_payout = float(transition_data["consultant_employer"]["vacation_payout"]["total"])
-        direct_salary = float(transition_data["direct_employer"]["base_salary"])
-        t_year = transition_data["transition_year"]
-        t_month = transition_data["transition_month"]
-
-        for i, m in enumerate(months):
-            if m["payment_date"].year == t_year and m["payment_date"].month == t_month:
-                brutto = float(m.get("brutto_pay") or 0)
-                netto = float(m.get("netto_pay") or 0)
-                tax_ratio = (netto / brutto) if brutto > 0 else 0.72
-
-                # Add vacation payout to Sem.till. and Gross on the trailing consultant row
-                m["vacation_supplement"] = round((m.get("vacation_supplement") or 0) + vac_payout, 0)
-                m["brutto_pay"] = round(brutto + vac_payout, 0)
-                m["netto_pay"] = round(netto + vac_payout * tax_ratio, 0)
-
-                # Extra row: direct employer innestående base salary
-                original_count = len(months)  # before insert
-                months.insert(
-                    i + 1,
-                    {
-                        "payment_date": m["payment_date"],
-                        "year": t_year,
-                        "month": t_month,
-                        "transition_direct": True,
-                        "netto_pay": round(direct_salary * tax_ratio, 0),
-                        "brutto_pay": direct_salary,
-                        "num_shifts": 0,
-                        "total_hours": 0,
-                        "total_ob": 0,
-                        "oncall_pay": 0,
-                        "ot_pay": 0,
-                        "absence_deduction": 0,
-                        "vacation_supplement": 0,
-                    },
-                )
-
-                # Update year totals and averages — average uses original month count
-                year_summary["total_brutto"] = sum(float(m2.get("brutto_pay") or 0) for m2 in months)
-                year_summary["total_netto"] = sum(float(m2.get("netto_pay") or 0) for m2 in months)
-                year_summary["avg_brutto"] = round(year_summary["total_brutto"] / original_count, 0)
-                year_summary["avg_netto"] = round(year_summary["total_netto"] / original_count, 0)
-                if "total_vacation_supplement" in year_summary:
-                    year_summary["total_vacation_supplement"] = sum(
-                        float(m2.get("vacation_supplement") or 0) for m2 in months
-                    )
-                    year_summary["avg_vacation_supplement"] = round(
-                        year_summary["total_vacation_supplement"] / original_count, 0
-                    )
-                break
+            vacation_pay = apply_year_pay_adjustments(months, year_summary, vac_user, year, db)
 
     # Calculate and log load time
     end_time = datetime.now()

--- a/app/routes/statistics.py
+++ b/app/routes/statistics.py
@@ -13,7 +13,7 @@ from app.core.schedule import (
     summarize_year_for_person,
 )
 from app.core.schedule import persons as person_list
-from app.core.schedule.vacation import calculate_vacation_balance
+from app.core.schedule.summary import apply_year_pay_adjustments
 from app.core.utils import get_safe_today
 from app.database.database import User, UserRole, get_db
 from app.routes.shared import _resolve_person_param, render
@@ -85,7 +85,8 @@ async def statistics_view(
         months = [strip_salary_data(m) for m in months]
         year_summary = strip_salary_data(year_summary)
 
-    # Add vacation supplement data
+    # Fold the vacation supplement and any employment transition into the pay
+    # figures. Shared with /year/<id> so both pages show the same money.
     if show_salary:
         vac_user = (
             target_user
@@ -93,51 +94,7 @@ async def statistics_view(
             else db.query(User).filter(User.person_id == rotation_position).first()
         )
         if vac_user:
-            try:
-                vacation_pay = calculate_vacation_balance(vac_user, year, db)
-                supp_per_day = vacation_pay.get("pay", {}).get("supplement_per_day", 0)
-                for m in months:
-                    sem_days = sum(1 for d in m.get("days", []) if d.get("shift") and d["shift"].code == "SEM")
-                    m["vacation_days"] = sem_days
-                    m["vacation_supplement"] = round(supp_per_day * sem_days, 0)
-                    if m["vacation_supplement"] > 0:
-                        supp = m["vacation_supplement"]
-                        brutto_before = m.get("brutto_pay", 0) or 0
-                        netto_before = m.get("netto_pay", 0) or 0
-                        m["brutto_pay"] = brutto_before + supp
-                        if brutto_before > 0:
-                            tax_ratio = netto_before / brutto_before
-                            m["netto_pay"] = round(netto_before + supp * tax_ratio, 0)
-
-                year_summary["total_brutto"] = sum((m.get("brutto_pay", 0) or 0) for m in months)
-                year_summary["total_netto"] = sum((m.get("netto_pay", 0) or 0) for m in months)
-            except Exception:
-                pass
-
-        # Add employment transition payout for the transition month
-        if vac_user and vac_user.employment_transition:
-            t = vac_user.employment_transition
-            if t.transition_date.year == year:
-                try:
-                    from app.core.schedule.transition import calculate_transition_month_summary
-
-                    transition_data = calculate_transition_month_summary(t, vac_user, db)
-                    vac_payout = float(transition_data["consultant_employer"]["vacation_payout"]["total"])
-                    direct_salary = float(transition_data["direct_employer"]["base_salary"])
-                    t_month = transition_data["transition_month"]
-                    for m in months:
-                        if m.get("payment_date") and m["payment_date"].month == t_month:
-                            brutto = float(m.get("brutto_pay") or 0)
-                            netto = float(m.get("netto_pay") or 0)
-                            tax_ratio = (netto / brutto) if brutto > 0 else 0.72
-                            extra = vac_payout + direct_salary
-                            m["brutto_pay"] = round(brutto + extra, 0)
-                            m["netto_pay"] = round(netto + extra * tax_ratio, 0)
-                            break
-                    year_summary["total_brutto"] = sum((m.get("brutto_pay", 0) or 0) for m in months)
-                    year_summary["total_netto"] = sum((m.get("netto_pay", 0) or 0) for m in months)
-                except Exception:
-                    pass
+            apply_year_pay_adjustments(months, year_summary, vac_user, year, db)
 
     # Build chart data for template
     chart_labels = []
@@ -148,6 +105,12 @@ async def statistics_view(
     chart_hours = []
 
     for m in months:
+        # The employment transition splits one payslip month into a consultant and a
+        # direct-employer row; the extra row follows its month, so fold it into that bar.
+        if m.get("transition_direct") and chart_labels:
+            chart_brutto[-1] += round(m.get("brutto_pay", 0) or 0)
+            chart_netto[-1] += round(m.get("netto_pay", 0) or 0)
+            continue
         label = f"{m.get('payment_year', m['year'])}-{m.get('payment_month', m['month']):02d}"
         chart_labels.append(label)
         chart_brutto.append(round(m.get("brutto_pay", 0) or 0))

--- a/tests/test_api_v1_characterization.py
+++ b/tests/test_api_v1_characterization.py
@@ -1,0 +1,479 @@
+"""Characterization tests for the /api/v1 schedule endpoints.
+
+The external Home Assistant integration consumes these endpoints, so the response
+CONTRACT (key names, types, nesting, status codes) is frozen here before api_v1.py
+is rebuilt on the canonical period path. Values may become more correct for users
+with swaps/overrides, so the value assertions below deliberately use plain rotation
+days that no override layer touches.
+
+Same technique as tests/test_day_view_consistency.py: bind the global SessionLocal
+to the test DB and seed a rotation era so schedule internals and HTTP routes share
+one database.
+"""
+
+import datetime
+
+import pytest
+from sqlalchemy.orm import sessionmaker
+
+import app.database.database as db_module
+from app.auth.auth import hash_api_key
+from app.core.schedule import clear_schedule_cache, determine_shift_for_date, generate_period_data
+from app.database.database import (
+    Absence,
+    AbsenceType,
+    OnCallOverride,
+    OnCallOverrideType,
+    OvertimeShift,
+    RotationEra,
+    ShiftOverride,
+    ShiftSwap,
+    SwapStatus,
+    User,
+    UserRole,
+    WageType,
+)
+from tests.conftest import _ROTATION_ERA_PATTERN
+
+API_KEY = "char-user-key"
+ADMIN_KEY = "char-admin-key"
+AUTH = {"Authorization": f"Bearer {API_KEY}"}
+ADMIN_AUTH = {"Authorization": f"Bearer {ADMIN_KEY}"}
+
+# Dates inside the seeded era (era starts 2026-01-02).
+N2_DAY = datetime.date(2026, 3, 2)  # position 1 works N2
+OFF_DAY = datetime.date(2026, 3, 7)  # position 1 is OFF
+OC_DAY = datetime.date(2026, 3, 17)  # position 1 has on-call
+SICK_DAY = datetime.date(2026, 3, 3)  # absence seeded below
+PARTIAL_DAY = datetime.date(2026, 3, 4)  # partial absence seeded below
+OT_DAY = datetime.date(2026, 3, 9)  # overtime seeded below
+
+SHIFT_KEYS = {"code", "label", "start_time", "end_time", "color", "overnight"}
+DAY_KEYS = {"date", "status", "shift", "rotation_week", "overtime", "partial_day"}
+SALARY_KEYS = {"ob_pay", "ob_total"}
+
+
+def _make_user(session, uid, person_id, name, role=UserRole.USER, api_key=None):
+    user = User(
+        id=uid,
+        username=f"u{uid}",
+        password_hash="x",
+        name=name,
+        role=role,
+        wage=30000,
+        wage_type=WageType.MONTHLY,
+        vacation={},
+        must_change_password=0,
+        is_active=1,
+        person_id=person_id,
+        api_key=hash_api_key(api_key) if api_key else None,
+    )
+    session.add(user)
+    session.commit()
+    return user
+
+
+@pytest.fixture()
+def api_env(test_db, test_client, monkeypatch):
+    engine = test_db.get_bind()
+    monkeypatch.setattr(db_module, "SessionLocal", sessionmaker(autocommit=False, autoflush=False, bind=engine))
+    clear_schedule_cache()
+    test_db.add(
+        RotationEra(
+            start_date=datetime.date(2026, 1, 2),
+            end_date=None,
+            rotation_length=10,
+            weeks_pattern=_ROTATION_ERA_PATTERN,
+        )
+    )
+    test_db.commit()
+    _make_user(test_db, 1, 1, "User One", api_key=API_KEY)
+    _make_user(test_db, 2, 2, "User Two")
+    _make_user(test_db, 3, 3, "User Three")
+    _make_user(test_db, 4, 4, "Admin", role=UserRole.ADMIN, api_key=ADMIN_KEY)
+    test_db.add(Absence(user_id=1, date=SICK_DAY, absence_type=AbsenceType.SICK))
+    test_db.add(Absence(user_id=1, date=PARTIAL_DAY, absence_type=AbsenceType.SICK, left_at="18:00"))
+    test_db.add(
+        OvertimeShift(
+            user_id=1,
+            date=OT_DAY,
+            start_time=datetime.time(8, 0),
+            end_time=datetime.time(16, 0),
+            hours=8.0,
+            ot_pay=0.0,
+            is_extension=False,
+        )
+    )
+    test_db.commit()
+    yield test_client, test_db
+    clear_schedule_cache()
+
+
+def _get(client, path, headers=AUTH):
+    resp = client.get(path, headers=headers)
+    assert resp.status_code == 200, f"{path} -> {resp.status_code} {resp.text}"
+    return resp.json()
+
+
+def _assert_shift_shape(shift):
+    assert set(shift) == SHIFT_KEYS
+    assert isinstance(shift["code"], str)
+    assert isinstance(shift["label"], str)
+    assert isinstance(shift["overnight"], bool)
+    for key in ("start_time", "end_time", "color"):
+        assert shift[key] is None or isinstance(shift[key], str)
+
+
+def _assert_day_shape(day, salary=False, coworkers=False, absence=False):
+    expected = set(DAY_KEYS)
+    if absence:
+        expected |= {"arrived_late"}
+    if salary:
+        expected |= SALARY_KEYS
+    if coworkers:
+        expected |= {"coworkers"}
+    assert set(day) == expected, f"unexpected keys: {sorted(set(day) ^ expected)}"
+    assert isinstance(day["date"], str)
+    assert isinstance(day["status"], str)
+    assert day["shift"] is None or _assert_shift_shape(day["shift"]) is None
+    assert day["rotation_week"] is None or isinstance(day["rotation_week"], int)
+    if day["overtime"] is not None:
+        assert set(day["overtime"]) == {"start_time", "end_time", "hours", "is_extension"}
+        assert isinstance(day["overtime"]["hours"], int | float)
+        assert isinstance(day["overtime"]["is_extension"], bool)
+    assert day["partial_day"] is None or isinstance(day["partial_day"], str)
+    if salary:
+        assert day["ob_pay"] is None or isinstance(day["ob_pay"], dict)
+        assert isinstance(day["ob_total"], int | float)
+    if coworkers:
+        assert isinstance(day["coworkers"], list)
+        for cw in day["coworkers"]:
+            assert set(cw) == {"id", "name", "shift_code", "shift_label"}
+            assert isinstance(cw["id"], int)
+            assert isinstance(cw["name"], str)
+            assert isinstance(cw["shift_code"], str)
+            assert isinstance(cw["shift_label"], str)
+
+
+class TestSimpleEndpoints:
+    def test_me(self, api_env):
+        client, _ = api_env
+        body = _get(client, "/api/v1/me")
+        assert set(body) == {"id", "name", "username", "role", "is_active", "rotation_person_id"}
+        assert body == {
+            "id": 1,
+            "name": "User One",
+            "username": "u1",
+            "role": "user",
+            "is_active": True,
+            "rotation_person_id": 1,
+        }
+
+    def test_shifts(self, api_env):
+        client, _ = api_env
+        body = _get(client, "/api/v1/shifts")
+        assert isinstance(body, list) and body
+        for shift in body:
+            _assert_shift_shape(shift)
+        codes = {s["code"] for s in body}
+        assert {"N1", "N2", "N3", "OFF", "OC", "OT-N1", "OT-N2", "OT-N3"} <= codes
+
+    def test_users(self, api_env):
+        client, _ = api_env
+        body = _get(client, "/api/v1/users")
+        assert body == [
+            {"id": 4, "name": "Admin"},
+            {"id": 1, "name": "User One"},
+            {"id": 3, "name": "User Three"},
+            {"id": 2, "name": "User Two"},
+        ]
+
+    def test_absences(self, api_env):
+        client, _ = api_env
+        body = _get(client, "/api/v1/users/1/absences?year=2026")
+        assert [set(a) for a in body] == [{"id", "date", "type", "partial_day", "arrived_late"}] * 2
+        assert body[0]["date"] == SICK_DAY.isoformat()
+        assert body[0]["type"] == "SICK"
+        assert body[1]["partial_day"] == "18:00"
+
+
+class TestDayShape:
+    def test_status_plain_working_day(self, api_env):
+        client, _ = api_env
+        body = _get(client, f"/api/v1/users/1/status?date={N2_DAY}&time=06:00")
+        _assert_day_shape(body, salary=True, coworkers=True)
+        assert body["date"] == N2_DAY.isoformat()
+        assert body["status"] == "working"
+        assert body["shift"]["code"] == "N2"
+        assert body["overtime"] is None
+        assert body["partial_day"] is None
+        assert body["ob_total"] > 0
+
+    def test_status_off_day(self, api_env):
+        client, _ = api_env
+        body = _get(client, f"/api/v1/users/1/status?date={OFF_DAY}&time=06:00")
+        _assert_day_shape(body, salary=True, coworkers=True)
+        assert body["status"] == "off"
+        assert body["shift"]["code"] == "OFF"
+        assert body["ob_pay"] is None
+        assert body["ob_total"] == 0.0
+
+    def test_status_oncall_day(self, api_env):
+        client, _ = api_env
+        body = _get(client, f"/api/v1/users/1/status?date={OC_DAY}&time=06:00")
+        _assert_day_shape(body, salary=True, coworkers=True)
+        assert body["status"] == "working"
+        assert body["shift"]["code"] == "OC"
+        assert body["ob_pay"] is None
+
+    def test_status_absence_day_has_arrived_late_key(self, api_env):
+        client, _ = api_env
+        body = _get(client, f"/api/v1/users/1/status?date={SICK_DAY}&time=06:00")
+        _assert_day_shape(body, salary=True, coworkers=True, absence=True)
+        assert body["status"] == "sick"
+        assert body["partial_day"] is None
+        assert body["arrived_late"] is None
+
+    def test_status_partial_absence_reports_left_at(self, api_env):
+        client, _ = api_env
+        body = _get(client, f"/api/v1/users/1/status?date={PARTIAL_DAY}&time=06:00")
+        _assert_day_shape(body, salary=True, coworkers=True, absence=True)
+        assert body["status"] == "sick"
+        assert body["partial_day"] == "18:00"
+
+    def test_status_overtime_day_carries_overtime_block(self, api_env):
+        client, _ = api_env
+        body = _get(client, f"/api/v1/users/1/status?date={OT_DAY}&time=06:00")
+        _assert_day_shape(body, salary=True, coworkers=True)
+        assert body["overtime"] == {
+            "start_time": "08:00",
+            "end_time": "16:00",
+            "hours": 8.0,
+            "is_extension": False,
+        }
+
+    def test_schedule_today_shape(self, api_env):
+        client, _ = api_env
+        body = _get(client, f"/api/v1/users/1/schedule/today?date={N2_DAY}")
+        _assert_day_shape(body, salary=True, coworkers=True)
+
+    def test_schedule_specific_date_shape(self, api_env):
+        client, _ = api_env
+        body = _get(client, f"/api/v1/users/1/schedule/{N2_DAY}")
+        _assert_day_shape(body, salary=True, coworkers=True)
+        assert body["shift"]["code"] == "N2"
+
+    def test_other_user_day_omits_salary(self, api_env):
+        client, _ = api_env
+        body = _get(client, f"/api/v1/users/2/schedule/{N2_DAY}")
+        _assert_day_shape(body, salary=False, coworkers=True)
+
+    def test_admin_key_sees_salary_for_other_user(self, api_env):
+        client, _ = api_env
+        body = _get(client, f"/api/v1/users/1/schedule/{N2_DAY}", headers=ADMIN_AUTH)
+        _assert_day_shape(body, salary=True, coworkers=True)
+
+
+class TestPeriodEndpoints:
+    def test_week(self, api_env):
+        client, _ = api_env
+        body = _get(client, f"/api/v1/users/1/schedule/week/{N2_DAY}")
+        assert set(body) == {"week", "year", "days"}
+        assert body["week"] == N2_DAY.isocalendar()[1]
+        assert body["year"] == 2026
+        assert len(body["days"]) == 7
+        for day in body["days"]:
+            _assert_day_shape(day, salary=True, coworkers=True, absence="arrived_late" in day)
+        assert [d["date"] for d in body["days"]][0] == "2026-03-02"
+
+    def test_range(self, api_env):
+        client, _ = api_env
+        body = _get(client, "/api/v1/users/1/schedule?from_date=2026-03-02&to_date=2026-03-08")
+        assert set(body) == {"days"}
+        assert len(body["days"]) == 7
+        for day in body["days"]:
+            _assert_day_shape(day, salary=True, coworkers=True, absence="arrived_late" in day)
+
+    def test_month(self, api_env):
+        client, _ = api_env
+        body = _get(client, "/api/v1/users/1/schedule/month")
+        assert set(body) == {"month", "year", "days", "wage", "ob_total"}
+        today = datetime.date.today()
+        assert body["month"] == today.month
+        assert body["year"] == today.year
+        assert body["wage"] == 30000
+        assert isinstance(body["ob_total"], int | float)
+        for day in body["days"]:
+            _assert_day_shape(day, salary=True, coworkers=True, absence="arrived_late" in day)
+
+    def test_year(self, api_env):
+        client, _ = api_env
+        body = _get(client, "/api/v1/users/1/schedule/year?year=2026")
+        assert set(body) == {"year", "days", "wage", "ob_total"}
+        assert body["year"] == 2026
+        assert len(body["days"]) == 365
+        assert body["days"][0]["date"] == "2026-01-01"
+        assert body["days"][-1]["date"] == "2026-12-31"
+        for day in body["days"]:
+            _assert_day_shape(day, salary=True, coworkers=True, absence="arrived_late" in day)
+
+    def test_year_ob_total_is_sum_of_days(self, api_env):
+        client, _ = api_env
+        body = _get(client, "/api/v1/users/1/schedule/year?year=2026")
+        assert body["ob_total"] == pytest.approx(round(sum(d["ob_total"] for d in body["days"]), 2), abs=0.01)
+
+
+class TestNextShift:
+    def test_next_shift_shape(self, api_env):
+        client, _ = api_env
+        body = _get(client, f"/api/v1/users/1/next-shift?date={OFF_DAY}&time=06:00")
+        assert set(body) == {"date", "days_from_today", "shift", "rotation_week"}
+        _assert_shift_shape(body["shift"])
+        assert isinstance(body["days_from_today"], int)
+        assert body["shift"]["code"] != "OFF"
+
+    def test_next_shift_404_outside_horizon(self, api_env):
+        client, _ = api_env
+        resp = client.get("/api/v1/users/1/next-shift?date=2025-01-01&time=06:00", headers=AUTH)
+        assert resp.status_code == 404
+
+
+class TestErrorContract:
+    @pytest.mark.parametrize(
+        "path,expected",
+        [
+            ("/api/v1/users/999/status", 404),
+            ("/api/v1/users/1/status?date=not-a-date", 400),
+            ("/api/v1/users/1/status?date=2026-03-02&time=99", 400),
+            ("/api/v1/users/1/schedule/today?date=nope", 400),
+            ("/api/v1/users/1/schedule/week/nope", 400),
+            ("/api/v1/users/1/schedule/nope", 400),
+            ("/api/v1/users/1/schedule?from_date=2026-03-02&to_date=2026-03-01", 400),
+            ("/api/v1/users/1/schedule?from_date=2026-01-01&to_date=2026-12-31", 400),
+            ("/api/v1/users/2/pay/month", 403),
+            ("/api/v1/users/2/vacation/balance", 403),
+            ("/api/v1/users/2/absences", 403),
+        ],
+    )
+    def test_status_codes(self, api_env, path, expected):
+        client, _ = api_env
+        assert client.get(path, headers=AUTH).status_code == expected
+
+
+class TestCanonicalConsistency:
+    """The API must resolve a day the same way the canonical period path does.
+
+    api_v1 used to resolve days with determine_shift_for_date directly, so swaps,
+    shift overrides and week-based vacation were invisible to Home Assistant while
+    the browser showed them (issue: shadow schedule engine in api_v1.py).
+    """
+
+    def test_accepted_swap_is_reflected_in_day_endpoints(self, api_env):
+        client, session = api_env
+        swap_day = N2_DAY
+        other_day = datetime.date(2026, 3, 23)
+        session.add(
+            ShiftSwap(
+                requester_id=1,
+                target_id=2,
+                requester_date=swap_day,
+                target_date=other_day,
+                requester_shift_code="N2",
+                target_shift_code=determine_shift_for_date(other_day, 2)[0].code,
+                status=SwapStatus.ACCEPTED,
+            )
+        )
+        session.commit()
+        clear_schedule_cache()
+
+        canonical = generate_period_data(swap_day, swap_day, person_id=1, session=session)[0]
+        rotation_code = determine_shift_for_date(swap_day, 1)[0].code
+        assert canonical["shift"].code != rotation_code, "fixture must produce a visible swap"
+
+        for path in (
+            f"/api/v1/users/1/status?date={swap_day}&time=06:00",
+            f"/api/v1/users/1/schedule/today?date={swap_day}",
+            f"/api/v1/users/1/schedule/{swap_day}",
+        ):
+            body = _get(client, path)
+            assert body["shift"]["code"] == canonical["shift"].code, path
+
+        week = _get(client, f"/api/v1/users/1/schedule/week/{swap_day}")
+        day = next(d for d in week["days"] if d["date"] == swap_day.isoformat())
+        assert day["shift"]["code"] == canonical["shift"].code
+
+        year = _get(client, "/api/v1/users/1/schedule/year?year=2026")
+        day = next(d for d in year["days"] if d["date"] == swap_day.isoformat())
+        assert day["shift"]["code"] == canonical["shift"].code
+
+    def test_shift_override_is_reflected(self, api_env):
+        client, session = api_env
+        override_day = OFF_DAY
+        session.add(ShiftOverride(user_id=1, date=override_day, shift_code="N1"))
+        session.commit()
+        clear_schedule_cache()
+
+        body = _get(client, f"/api/v1/users/1/schedule/{override_day}")
+        assert body["shift"]["code"] == "N1"
+        assert body["status"] == "working"
+
+    def test_week_based_vacation_is_reflected(self, api_env):
+        client, session = api_env
+        user = session.query(User).filter(User.id == 1).first()
+        user.vacation = {"2026": [10]}  # ISO week 10 contains N2_DAY
+        session.commit()
+        clear_schedule_cache()
+
+        canonical = generate_period_data(N2_DAY, N2_DAY, person_id=1, session=session)[0]
+        assert canonical["shift"].code == "SEM"
+
+        # The API reports absence and vacation through `status`, keeping `shift` as the
+        # shift the person was assigned (same split as a day-level VACATION absence).
+        body = _get(client, f"/api/v1/users/1/schedule/{N2_DAY}")
+        assert body["status"] == "vacation"
+        assert body["shift"]["code"] == "N2"
+        assert body["ob_pay"] is None
+        assert body["ob_total"] == 0.0
+
+    def test_oncall_override_is_reflected(self, api_env):
+        client, session = api_env
+        session.add(OnCallOverride(user_id=1, date=OFF_DAY, override_type=OnCallOverrideType.ADD))
+        session.commit()
+        clear_schedule_cache()
+
+        body = _get(client, f"/api/v1/users/1/schedule/{OFF_DAY}")
+        assert body["shift"]["code"] == "OC"
+
+
+class TestAdminEndpoints:
+    def test_team_today(self, api_env):
+        client, _ = api_env
+        body = _get(client, "/api/v1/admin/team/today", headers=ADMIN_AUTH)
+        assert set(body) == {"date", "team"}
+        assert isinstance(body["date"], str)
+        for entry in body["team"]:
+            assert {"id", "name"} <= set(entry)
+            day = {k: v for k, v in entry.items() if k not in ("id", "name")}
+            _assert_day_shape(day, absence="arrived_late" in day)
+
+    def test_team_schedule_range(self, api_env):
+        client, _ = api_env
+        body = _get(
+            client,
+            "/api/v1/admin/team/schedule?from_date=2026-03-02&to_date=2026-03-08",
+            headers=ADMIN_AUTH,
+        )
+        assert set(body) == {"from_date", "to_date", "team"}
+        for entry in body["team"]:
+            assert set(entry) == {"id", "name", "days"}
+            assert len(entry["days"]) == 7
+            for day in entry["days"]:
+                _assert_day_shape(day, coworkers=True, absence="arrived_late" in day)
+
+    def test_team_schedule_rejects_long_range(self, api_env):
+        client, _ = api_env
+        resp = client.get(
+            "/api/v1/admin/team/schedule?from_date=2026-03-02&to_date=2026-04-02",
+            headers=ADMIN_AUTH,
+        )
+        assert resp.status_code == 400

--- a/tests/test_dashboard_week_summary.py
+++ b/tests/test_dashboard_week_summary.py
@@ -1,0 +1,233 @@
+"""Characterization tests for the dashboard week summary.
+
+The dashboard handler used to recompute OT, on-call and OB itself instead of
+summing the day dicts build_week_data already returns, which made it a fourth
+place the pay rules had to be kept in sync. These tests pin what the dashboard
+reports for a fixture week, and assert that the figures agree with the
+canonical week data.
+
+Same technique as tests/test_api_v1_characterization.py: bind the global
+SessionLocal to the test DB and seed a rotation era so schedule internals and
+the HTTP route share one database. The template context is captured by
+monkeypatching the route's render(), so the numbers are asserted directly
+rather than scraped out of HTML.
+"""
+
+import datetime
+
+import pytest
+from fastapi.responses import HTMLResponse
+from sqlalchemy.orm import sessionmaker
+
+import app.database.database as db_module
+import app.routes.dashboard as dashboard_module
+from app.auth.auth import create_access_token
+from app.core.schedule import _cached_special_rules, clear_schedule_cache, generate_period_data, ob_rules
+from app.core.schedule.ob import compute_day_ob_pay
+from app.database.database import (
+    Absence,
+    AbsenceType,
+    OnCallOverride,
+    OnCallOverrideType,
+    OvertimeShift,
+    RotationEra,
+    User,
+    UserRole,
+    WageType,
+)
+from tests.conftest import _ROTATION_ERA_PATTERN
+
+# ISO week 12 of 2026 for rotation position 1: OFF, OC, N3, N3, N3, N3, OFF.
+WEEK_YEAR = 2026
+WEEK_NO = 12
+MONDAY = datetime.date(2026, 3, 16)
+OC_DAY = datetime.date(2026, 3, 17)
+N3_DAY = datetime.date(2026, 3, 18)
+OT_DAY = MONDAY  # OT placed on the OFF Monday
+WAGE = 30000
+
+SUMMARY_KEYS = ("total_hours", "ob_hours", "total_pay", "oc_pay", "ot_pay", "absence_deduction")
+
+
+@pytest.fixture()
+def dash_env(test_db, test_client, monkeypatch):
+    engine = test_db.get_bind()
+    monkeypatch.setattr(db_module, "SessionLocal", sessionmaker(autocommit=False, autoflush=False, bind=engine))
+    clear_schedule_cache()
+
+    test_db.add(
+        RotationEra(
+            start_date=datetime.date(2026, 1, 2),
+            end_date=None,
+            rotation_length=10,
+            weeks_pattern=_ROTATION_ERA_PATTERN,
+        )
+    )
+    test_db.add(
+        User(
+            id=1,
+            username="dashuser",
+            password_hash="x",
+            name="Dash User",
+            role=UserRole.USER,
+            wage=WAGE,
+            wage_type=WageType.MONTHLY,
+            person_id=1,
+            tax_table="33",
+            vacation={},
+            must_change_password=0,
+            is_active=1,
+        )
+    )
+    test_db.add(
+        OvertimeShift(
+            user_id=1,
+            date=OT_DAY,
+            start_time=datetime.time(8, 0),
+            end_time=datetime.time(16, 0),
+            hours=8.0,
+            ot_pay=0.0,
+            is_extension=False,
+        )
+    )
+    test_db.commit()
+
+    test_client.cookies.set("access_token", f"Bearer {create_access_token(data={'sub': '1'})}")
+
+    captured = {}
+
+    def _capture(template_name, context, status_code=200, headers=None):
+        captured["template"] = template_name
+        captured["context"] = context
+        return HTMLResponse("", status_code=status_code)
+
+    monkeypatch.setattr(dashboard_module, "render", _capture)
+
+    yield test_client, test_db, captured
+    clear_schedule_cache()
+
+
+def _week_summary(client, captured) -> dict:
+    resp = client.get(f"/?week={WEEK_NO}&wyear={WEEK_YEAR}")
+    assert resp.status_code == 200, resp.text
+    assert captured["template"] == "dashboard.html"
+    return captured["context"]["week_summary"]
+
+
+def _rounded(summary: dict) -> dict:
+    return {k: round(summary[k], 2) for k in SUMMARY_KEYS}
+
+
+def _canonical_week_summary(session) -> dict:
+    """What the canonical period path says about the same week.
+
+    Applies the same aggregation the month/year summary applies
+    (_process_day_for_summary): OB through compute_day_ob_pay, on-call hours
+    excluded from worked hours, overtime hours added.
+    """
+    days = generate_period_data(MONDAY, MONDAY + datetime.timedelta(days=6), person_id=1, session=session)
+    combined_rules = ob_rules + _cached_special_rules(WEEK_YEAR)
+    total_hours = 0.0
+    ob_hours = 0.0
+    ob_pay = 0.0
+    for day in days:
+        hours, pay, _ = compute_day_ob_pay(day, combined_rules, WAGE)
+        ob_hours += sum(hours.values())
+        ob_pay += sum(pay.values())
+        shift = day.get("shift")
+        if shift and shift.code != "OC":
+            total_hours += day.get("hours", 0.0)
+        total_hours += day.get("ot_hours", 0.0)
+    return {
+        "total_hours": round(total_hours, 2),
+        "ob_hours": round(ob_hours, 2),
+        "total_pay": round(ob_pay, 2),
+        "oc_pay": round(sum(d.get("oncall_pay", 0.0) for d in days), 2),
+        "ot_pay": round(sum(d.get("ot_pay", 0.0) for d in days), 2),
+    }
+
+
+def test_week_summary_context_keys(dash_env):
+    client, _, captured = dash_env
+    summary = _week_summary(client, captured)
+    assert set(summary) == set(SUMMARY_KEYS)
+
+
+def test_week_summary_figures(dash_env):
+    """Pinned figures for the fixture week: 4 x N3 plus an 8h OT day, one on-call day.
+
+    Before the dashboard was moved onto the canonical day dicts it reported
+    total_hours 50.5, ob_hours 38.5 and total_pay 2837.50 for this same week: it
+    priced OB on the overtime day (which carries no OB anywhere else) and counted
+    the OT day's hours from the OT shift type's nominal length.
+    """
+    client, _, captured = dash_env
+    assert _rounded(_week_summary(client, captured)) == {
+        "total_hours": 50.0,
+        "ob_hours": 34.0,
+        "total_pay": 2612.5,
+        "oc_pay": 1800.0,
+        "ot_pay": 3333.33,
+        "absence_deduction": 0.0,
+    }
+
+
+def test_week_summary_matches_canonical_week_data(dash_env):
+    """The dashboard must not disagree with the week view it summarizes."""
+    client, session, captured = dash_env
+    summary = _rounded(_week_summary(client, captured))
+    canonical = _canonical_week_summary(session)
+    for key, value in canonical.items():
+        assert summary[key] == pytest.approx(value, abs=0.01), key
+
+
+def test_week_summary_matches_canonical_with_oncall_override(dash_env):
+    """An added on-call day and a removed one must move the dashboard's on-call pay."""
+    client, session, captured = dash_env
+    session.add(OnCallOverride(user_id=1, date=MONDAY, override_type=OnCallOverrideType.ADD))
+    session.add(OnCallOverride(user_id=1, date=OC_DAY, override_type=OnCallOverrideType.REMOVE))
+    session.commit()
+    clear_schedule_cache()
+
+    summary = _rounded(_week_summary(client, captured))
+    canonical = _canonical_week_summary(session)
+    for key, value in canonical.items():
+        assert summary[key] == pytest.approx(value, abs=0.01), key
+
+
+def test_week_summary_overtime_on_oncall_day(dash_env):
+    """Overtime worked during an on-call day reduces that day's on-call pay."""
+    client, session, captured = dash_env
+    session.add(
+        OvertimeShift(
+            user_id=1,
+            date=OC_DAY,
+            start_time=datetime.time(22, 0),
+            end_time=datetime.time(6, 0),  # crosses midnight
+            hours=8.0,
+            ot_pay=0.0,
+            is_extension=False,
+        )
+    )
+    session.commit()
+    clear_schedule_cache()
+
+    summary = _rounded(_week_summary(client, captured))
+    canonical = _canonical_week_summary(session)
+    assert summary["oc_pay"] < 1800.0
+    for key, value in canonical.items():
+        assert summary[key] == pytest.approx(value, abs=0.01), key
+
+
+def test_week_summary_absence_day(dash_env):
+    """A full sick day drops the shift's hours/OB and reports a wage deduction."""
+    client, session, captured = dash_env
+    session.add(Absence(user_id=1, date=N3_DAY, absence_type=AbsenceType.SICK))
+    session.commit()
+    clear_schedule_cache()
+
+    summary = _rounded(_week_summary(client, captured))
+    canonical = _canonical_week_summary(session)
+    assert summary["absence_deduction"] > 0
+    for key, value in canonical.items():
+        assert summary[key] == pytest.approx(value, abs=0.01), key

--- a/tests/test_year_statistics_consistency.py
+++ b/tests/test_year_statistics_consistency.py
@@ -1,0 +1,174 @@
+"""The /year/<id> and /statistics/<id> pages must show the same money.
+
+Both routes summarise the same year for the same person, fold the vacation
+supplement into gross/net, and inject the employment transition payout. They
+used to do that with two separate copies of the arithmetic, so the headline
+gross/net figures drifted apart. These tests pin them together.
+
+Schedule internals read the rotation era through the global SessionLocal, so
+the fixture binds it to the same in-memory engine the routes use.
+"""
+
+import datetime
+
+import pytest
+from sqlalchemy.orm import sessionmaker
+
+import app.database.database as db_module
+import app.routes.schedule_personal as schedule_personal
+import app.routes.statistics as statistics
+from app.auth.auth import create_access_token
+from app.core.schedule import clear_schedule_cache
+from app.core.schedule.person_history import start_employment
+from app.database.database import (
+    ConsultantSalaryType,
+    EmploymentTransition,
+    RotationEra,
+    User,
+    UserRole,
+    WageType,
+)
+from tests.conftest import _ROTATION_ERA_PATTERN
+
+YEAR = 2026
+USER_ID = 11
+
+
+@pytest.fixture()
+def env(test_db, test_client, monkeypatch):
+    engine = test_db.get_bind()
+    monkeypatch.setattr(db_module, "SessionLocal", sessionmaker(autocommit=False, autoflush=False, bind=engine))
+    clear_schedule_cache()
+
+    test_db.add(
+        RotationEra(
+            start_date=datetime.date(2026, 1, 2),
+            end_date=None,
+            rotation_length=10,
+            weeks_pattern=_ROTATION_ERA_PATTERN,
+        )
+    )
+    user = User(
+        id=USER_ID,
+        username="peter1",
+        password_hash="x",
+        name="Peter",
+        role=UserRole.USER,
+        wage=30000,
+        wage_type=WageType.MONTHLY,
+        person_id=1,
+        # Weeks 28 and 29 are vacation, so several months carry SEM days.
+        vacation={str(YEAR): [28, 29, 30]},
+        employment_start_date=datetime.date(2024, 1, 1),
+        vacation_days_per_year=25,
+        vacation_year_start_month=4,
+        must_change_password=0,
+    )
+    test_db.add(user)
+    test_db.commit()
+    start_employment(test_db, USER_ID, 1, "Peter", "peter1", datetime.date(2026, 1, 2), created_by=1)
+
+    token = create_access_token(data={"sub": str(USER_ID)})
+    test_client.cookies.set("access_token", f"Bearer {token}")
+
+    yield test_client, test_db
+
+    clear_schedule_cache()
+
+
+def _add_transition(session):
+    session.add(
+        EmploymentTransition(
+            user_id=USER_ID,
+            transition_date=datetime.date(YEAR, 6, 1),
+            consultant_salary_type=ConsultantSalaryType.TRAILING,
+            consultant_vacation_days=13.0,
+            consultant_supplement_pct=0.0043,
+        )
+    )
+    session.commit()
+
+
+def _capture(monkeypatch, module):
+    """Record the template context a route renders, without skipping the render."""
+    captured: dict = {}
+    real = module.render
+
+    def spy(template_name, context, *args, **kwargs):
+        captured.update(context)
+        return real(template_name, context, *args, **kwargs)
+
+    monkeypatch.setattr(module, "render", spy)
+    return captured
+
+
+def _both_pages(env, monkeypatch):
+    client, _session = env
+    year_ctx = _capture(monkeypatch, schedule_personal)
+    assert client.get(f"/year/{USER_ID}?year={YEAR}").status_code == 200
+    year_ctx = dict(year_ctx)
+
+    stats_ctx = _capture(monkeypatch, statistics)
+    assert client.get(f"/statistics/{USER_ID}?year={YEAR}").status_code == 200
+    return year_ctx, dict(stats_ctx)
+
+
+def test_year_totals_match_without_transition(env, monkeypatch):
+    year_ctx, stats_ctx = _both_pages(env, monkeypatch)
+
+    assert year_ctx["year_summary"]["total_brutto"] > 0
+    assert stats_ctx["year_summary"]["total_brutto"] == year_ctx["year_summary"]["total_brutto"]
+    assert stats_ctx["year_summary"]["total_netto"] == year_ctx["year_summary"]["total_netto"]
+
+
+def test_vacation_supplement_folded_identically(env, monkeypatch):
+    year_ctx, stats_ctx = _both_pages(env, monkeypatch)
+
+    year_months = {m["payment_month"]: m for m in year_ctx["months"] if m.get("payment_month")}
+    stats_months = {m["payment_month"]: m for m in stats_ctx["months"] if m.get("payment_month")}
+    assert any(m.get("vacation_supplement") for m in year_months.values()), "fixture must produce SEM days"
+
+    for pm, ym in year_months.items():
+        sm = stats_months[pm]
+        assert sm["vacation_supplement"] == ym["vacation_supplement"], f"payment month {pm}"
+        assert sm["brutto_pay"] == ym["brutto_pay"], f"payment month {pm}"
+        assert sm["netto_pay"] == ym["netto_pay"], f"payment month {pm}"
+
+
+@pytest.mark.parametrize("wage", [29100, 30000])
+def test_year_totals_match_with_employment_transition(env, monkeypatch, wage):
+    """The transition payout must not shift the year totals between the two pages.
+
+    29100 is a wage where the two routes' rounding used to disagree: the year view
+    rounds the consultant and the direct-employer rows separately, so a route that
+    rounds their sum instead lands one krona off.
+    """
+    _client, session = env
+    session.get(User, USER_ID).wage = wage
+    session.commit()
+    _add_transition(session)
+
+    year_ctx, stats_ctx = _both_pages(env, monkeypatch)
+
+    assert any(m.get("transition_direct") for m in year_ctx["months"]), "transition payout must be injected"
+    assert stats_ctx["year_summary"]["total_brutto"] == year_ctx["year_summary"]["total_brutto"]
+    assert stats_ctx["year_summary"]["total_netto"] == year_ctx["year_summary"]["total_netto"]
+
+    # Row by row too: the transition month is the row the two pages used to disagree on.
+    def _rows(ctx):
+        return [(m["payment_date"], m.get("brutto_pay"), m.get("netto_pay")) for m in ctx["months"]]
+
+    assert _rows(stats_ctx) == _rows(year_ctx)
+
+
+def test_statistics_charts_cover_every_payment_month(env, monkeypatch):
+    """The chart series must stay one point per payment month, transition included."""
+    _client, session = env
+    _add_transition(session)
+
+    _year_ctx, stats_ctx = _both_pages(env, monkeypatch)
+
+    labels = stats_ctx["chart_labels"]
+    assert len(labels) == len(set(labels)), f"duplicate month labels: {labels}"
+    assert len(stats_ctx["chart_brutto"]) == len(labels)
+    assert sum(stats_ctx["chart_brutto"]) == pytest.approx(stats_ctx["year_summary"]["total_brutto"], abs=len(labels))


### PR DESCRIPTION
Step 3 of the review cleanup. Three surfaces computed schedule and pay figures with their own private logic instead of the canonical path, and all three had drifted into user-visible wrong numbers. Each fix ships with a characterization test that fails on the previous code.

## 1. /statistics disagreed with /year about money

Both routes called `summarize_year_for_person` identically, then each ran its own copy of the post-processing. The copies had drifted on the employment transition path:

- **/year** rounds each employer's row and sums the rounded rows, so the year total is the sum of what the two payslips actually pay. **/statistics** rounded the combined figure, producing a total matching no payslip. The drift is one krona at some wage levels and zero at others, which is how it survived: it only appears for roughly half of wage and payout combinations.
- **/year** splits the transition payout into its own direct-employer row. **/statistics** merged it into the preceding payslip row, so the same June showed 211370 on one page and 181370 plus a separate 30000 row on the other.

The year view is the reference on both counts. `apply_year_pay_adjustments` in `summary.py` now holds the logic once. /statistics keeps the one thing it was right about: both employers pay in the same month, so its chart folds the two rows back into a single bar.

Contrary to the original review note, the vacation supplement fold itself was **not** diverging. The inline copy was arithmetically identical to `fold_vacation_supplement_into_pay`. What it skipped were derived summary fields that `statistics.html` happens not to render.

Two `except Exception` swallows now log a warning instead of silently dropping the supplement or payout.

## 2. The v1 API ignored swaps, overrides and vacation

`api_v1.py` resolved days with `determine_shift_for_date` plus a local OB call, so it was a second schedule engine that ignored `ShiftOverride`, `ShiftSwap`, `OnCallOverride`, `DayPayOverride`, week-based vacation and parental leave, linked substitutes and PersonHistory employment masking. **A user who swapped a shift saw one schedule in the browser and a different one in Home Assistant.** The day view carries an explicit invariant against exactly this pattern, which this module predated.

`_build_period` now calls `generate_period_data` once per range; `_build_day_status` is a one-day slice of it. OB goes through `compute_day_ob_pay`, the shared gate. `_resolve_effective_shift`, the module's second mini-engine, is gone.

**The JSON contract is unchanged**: same keys, types, nesting, status codes. Only values become correct. The 35 shape tests in the new characterization file pass against the *previous* code, which is what proves the contract is pinned to real prior behaviour rather than to the rewrite. Two mapping decisions worth review:

- On absence, vacation and full-OT days the response keeps reporting the assigned shift with the reason in `status`, which is what this API has always meant, rather than canonical's SICK/SEM/LEAVE/OT substitution.
- Week-based vacation previously reported `working` plus the rotation shift. It now reports `status: vacation` (and `parental`), values already in the vocabulary.

Coworkers deliberately stay on the rotation lookup: routing them through the all-persons canonical path costs about 52 queries per calendar day against 5 for the single-person call, taking `/schedule/year` to roughly 21400 queries. The tradeoff and the precondition for changing it (batch the PersonHistory lookups in period.py) are documented at the call site.

Cost of the fix, measured: `/status` goes from 14 to 50 queries, `/schedule/year` from 1688 to 2448. On a local SQLite file for a ten-person team this is milliseconds, and correctness wins it.

## 3. The dashboard invented 225 kr of OB

On an overtime day the handler saw `shift.code == "OT"`, which is neither `OC` nor `OFF`, so it ran `calculate_shift_hours` on the OT shift type's **nominal** times and priced OB from them. Everywhere else an OT day carries no OB and the day's hours come from the real OT shift. An 8h OT shift therefore produced 4.5 OB hours and 225 kr on the dashboard that no payslip, month view or year view ever showed. It also ignored `ob_hours_override` and `day_pay_override`, and excluded only same-day OT from on-call, missing OT crossing midnight.

The viewed week now comes from `generate_period_data` and the summary is a sum over its day dicts, verified to reproduce `summarize_month_for_person` exactly for March 2026. 488 lines to 406, template context keys unchanged.

**A premise in the review was wrong here and is worth recording**: `build_week_data` day dicts do not carry `ob`, `oncall_pay`, `ot_pay` or `ot_hours`. Its single-person path is `_build_person_day_basic`, not `_populate_single_person_day`. Summing those keys off `build_week_data`, as suggested, would have silently rendered zeros.

## Tests

712 passed, up from 662 at the branch point. 50 new tests, including the first coverage `/statistics/{id}` and the api_v1 response bodies have ever had. `ruff check` and `ruff format --check` clean.

## Found but deliberately not fixed here

The canonical path double-counts an OT day's hours: `_populate_single_person_day` sets `hours = ot_shift.hours` for a non-extension OT day and `_process_day_for_summary` then adds both `hours` and `ot_hours`, so an 8h OT shift contributes 16h. The dashboard now reproduces this rather than disagreeing with the month view. It affects month and year hour totals and deserves its own change with its own test.