### PR TITLE
Run one day priority chain in period.py

### DIFF
--- a/app/core/schedule/period.py
+++ b/app/core/schedule/period.py
@@ -1524,27 +1524,9 @@ def _build_person_day_basic(
                 "end": None,
             }
 
-    # Kolla semester (veckobaserad). Visa endast SEM på dagar personen är schemalagd
-    # (icke-OFF), så markeringen matchar hur semesterdagar räknas. OFF-dagar lämnas
-    # orörda och renderas som vanligt nedan. Dagsnivå-semester hanteras av absence-blocket ovan.
-    if vacation_dates and vacation_shift and date in vacation_dates.get(person_id, set()):
-        result = determine_shift_for_date(date, person_id)
-        original_shift, rotation_week = result if result else (None, None)
-        if original_shift and original_shift.code != "OFF":
-            return {
-                "person_id": person_id,
-                "person_name": person_name,
-                "shift": vacation_shift,
-                "original_shift": original_shift,  # For coworker matching
-                "rotation_week": rotation_week,
-                "rotation_length": rotation_length,
-                "hours": 0.0,
-                "start": None,
-                "end": None,
-            }
-
-    # Kolla föräldraledighet (veckobaserad). Samma regel: visa LEAVE endast på schemalagda
+    # Kolla föräldraledighet (veckobaserad). Visa LEAVE endast på schemalagda
     # (icke-OFF) dagar. Dagsnivå-föräldraledighet hanteras av absence-blocket ovan.
+    # Checked before vacation, matching the canonical path (_populate_single_person_day).
     if parental_dates and date in parental_dates.get(person_id, set()):
         leave_shift = next((s for s in shift_types if s.code == "LEAVE"), None)
         result = determine_shift_for_date(date, person_id)
@@ -1563,6 +1545,25 @@ def _build_person_day_basic(
                 # Week-based parental leave renders as LEAVE; flag it so summaries can
                 # count it as parental rather than ordinary leave.
                 "parental_leave": True,
+            }
+
+    # Kolla semester (veckobaserad). Visa endast SEM på dagar personen är schemalagd
+    # (icke-OFF), så markeringen matchar hur semesterdagar räknas. OFF-dagar lämnas
+    # orörda och renderas som vanligt nedan. Dagsnivå-semester hanteras av absence-blocket ovan.
+    if vacation_dates and vacation_shift and date in vacation_dates.get(person_id, set()):
+        result = determine_shift_for_date(date, person_id)
+        original_shift, rotation_week = result if result else (None, None)
+        if original_shift and original_shift.code != "OFF":
+            return {
+                "person_id": person_id,
+                "person_name": person_name,
+                "shift": vacation_shift,
+                "original_shift": original_shift,  # For coworker matching
+                "rotation_week": rotation_week,
+                "rotation_length": rotation_length,
+                "hours": 0.0,
+                "start": None,
+                "end": None,
             }
 
     # Check for manual shift override (admin-assigned N1/N2/N3 replacing rotation)
@@ -1922,7 +1923,9 @@ def _resolve_effective_shift(
         rot = determine_shift_for_date(current_day, person_id)
         rot_shift = rot[0] if rot else None
         if rot_shift and rot_shift.code != "OFF":
-            return _ShiftResolution(vacation_shift, None, 0.0, None, None, {})
+            # The rotation week is a property of the date, not of the shift shown, so it
+            # survives the vacation marking (the week path has always reported it).
+            return _ShiftResolution(vacation_shift, rot[1], 0.0, None, None, {})
 
     # Manual shift override
     if shift_override_map is not None and shift_override_map.get((person_id, current_day)):

--- a/app/core/schedule/period.py
+++ b/app/core/schedule/period.py
@@ -1414,6 +1414,68 @@ def _batch_fetch_swap_map(
     return swap_map
 
 
+def _lookup_for_day(batch_map, session, model, person_id: int, date: datetime.date):
+    """Row for (person, date), from the pre-fetched batch map or, without one, a query."""
+    if batch_map is not None:
+        return batch_map.get((person_id, date))
+    if session:
+        return session.query(model).filter(model.user_id == person_id, model.date == date).first()
+    return None
+
+
+def _lookup_ot_shifts(person_id: int, date: datetime.date, ot_shift_map, session):
+    """Returns (ot_shift on the date, ot_shift that affects on-call).
+
+    The second may come from the previous day when that overtime crosses midnight; it
+    affects the on-call calculation but is never displayed as the day's shift.
+    """
+    ot_shift = _lookup_ot_shift(person_id, date, ot_shift_map, session)
+    if ot_shift:
+        return ot_shift, ot_shift
+
+    prev_day = date - datetime.timedelta(days=1)
+    prev_ot = _lookup_ot_shift(person_id, prev_day, ot_shift_map, session)
+    if prev_ot:
+        try:
+            _, ot_end_dt = parse_ot_times(prev_ot, prev_day)
+            if ot_end_dt.date() > prev_day:
+                return None, prev_ot
+        except ValueError:
+            pass
+    return None, None
+
+
+def _lookup_ot_shift(person_id: int, date: datetime.date, ot_shift_map, session):
+    if ot_shift_map is not None:
+        return ot_shift_map.get((person_id, date))
+    if session:
+        return get_overtime_shift_for_date(session, person_id, date)
+    return None
+
+
+def _apply_ot_display_shift(ot_shift, date: datetime.date, shift, hours, start, end, shift_types):
+    """Replace the day's shift with OT for display, unless the overtime only extends it."""
+    if ot_shift.is_extension:
+        return shift, hours, start, end
+    ot_shift_type = next((s for s in shift_types if s.code == "OT"), None)
+    if not ot_shift_type:
+        return shift, hours, start, end
+    try:
+        ot_start, ot_end = parse_ot_times(ot_shift, date)
+    except ValueError:
+        ot_start, ot_end = None, None
+    return ot_shift_type, ot_shift.hours, ot_start, ot_end
+
+
+# Pay keys the canonical path fills in and the week path does not report.
+_PAY_KEYS = ("ob", "oncall_pay", "oncall_details", "ot_pay", "ot_hours", "ot_details")
+
+
+def _basic_day_result(day: dict, rotation_length: int) -> dict:
+    """The week path's day dict: the shared helpers' output plus rotation_length, minus pay."""
+    return {"rotation_length": rotation_length, **{k: v for k, v in day.items() if k not in _PAY_KEYS}}
+
+
 def _build_person_day_basic(
     date: datetime.date,
     person_id: int,
@@ -1421,21 +1483,22 @@ def _build_person_day_basic(
     session=None,
     employment_start: datetime.date | None = None,
 ) -> dict:
-    """Builds basic day data for a person."""
-    persons = ctx.persons
+    """Builds basic day data for a person.
+
+    Runs the same priority chain as _populate_single_person_day through the same helpers;
+    this builder only adds rotation_length, skips the pay computation (no OB rules are
+    passed in, and the pay keys are dropped) and exposes ot_shift_for_oncall.
+    """
+    from app.database.database import Absence, OnCallOverride
+
     shift_types = get_shift_types()
-    vacation_dates = ctx.vacation_dates
-    parental_dates = ctx.parental_dates
-    absence_map = ctx.absence_map
-    ot_shift_map = ctx.ot_shift_map
-    oncall_override_map = ctx.oncall_override_map
-    swap_map = ctx.swap_map
-    shift_override_map = ctx.shift_override_map
     vacation_shift = get_vacation_shift()
     rotation_length = get_rotation_length_for_date(date)
 
     # Get person name via PersonHistory and whether the date precedes employment.
-    person_name, show_off_before_employment = _resolve_day_person(session, person_id, date, persons, employment_start)
+    person_name, show_off_before_employment = _resolve_day_person(
+        session, person_id, date, ctx.persons, employment_start
+    )
 
     # If date is before current person's employment, show OFF - unless a linked
     # substitute has activity on the date (issue #290): same injection layer as
@@ -1460,235 +1523,43 @@ def _build_person_day_basic(
             "before_employment": True,  # Flag to indicate this is before employment
         }
 
+    day: dict = {}
+
     # Kolla frånvaro först (högsta prioritet) - använd batch-hämtad data
-    absence = None
-    if absence_map is not None:
-        absence = absence_map.get((person_id, date))
-    elif session:
-        from app.database.database import Absence
+    absence = _lookup_for_day(ctx.absence_map, session, Absence, person_id, date)
+    if absence and _populate_absence_day(day, absence, date, person_id, person_name, [], vacation_shift, shift_types):
+        return _basic_day_result(day, rotation_length)
 
-        absence = session.query(Absence).filter(Absence.user_id == person_id, Absence.date == date).first()
+    # Kolla föräldraledighet (veckobaserad)
+    if _populate_parental_day(day, date, person_id, person_name, ctx.parental_dates, shift_types):
+        return _basic_day_result(day, rotation_length)
 
-    if absence:
-        from app.database.database import AbsenceType
+    # Kolla semester / override / byte / normalt skift (i prioritetsordning)
+    shift, rotation_week, hours, start, end, _ob = _resolve_effective_shift(
+        date,
+        person_id,
+        vacation_shift,
+        ctx.vacation_dates or {},
+        ctx.shift_override_map,
+        ctx.swap_map,
+        shift_types,
+        [],
+    )
 
-        # Partial absence: show original shift with truncated start/end
-        if (
-            absence.left_at is not None or absence.arrived_at is not None
-        ) and absence.absence_type != AbsenceType.VACATION:
-            result = determine_shift_for_date(date, person_id)
-            if result and result[0]:
-                original_shift, rotation_week = result
-                hours, start, end = calculate_shift_hours(date, original_shift.code)
-                if start is not None:
-                    if absence.left_at:
-                        left_time = datetime.datetime.strptime(absence.left_at, "%H:%M").time()
-                        end = datetime.datetime.combine(date, left_time)
-                        if end <= start:
-                            end = start
-                    if absence.arrived_at:
-                        arrived_time = datetime.datetime.strptime(absence.arrived_at, "%H:%M").time()
-                        start = datetime.datetime.combine(date, arrived_time)
-                        if start >= end:
-                            start = end
-                    hours = (end - start).total_seconds() / 3600.0
-                return {
-                    "person_id": person_id,
-                    "person_name": person_name,
-                    "shift": original_shift,
-                    "original_shift": original_shift,
-                    "rotation_week": rotation_week,
-                    "rotation_length": rotation_length,
-                    "hours": hours,
-                    "start": start,
-                    "end": end,
-                    "partial_absence": absence,
-                }
+    # Week-based vacation outranks the overtime overlay below (issue #285). Captured
+    # here, before the on-call override can rebind `shift`.
+    is_vacation_day = vacation_shift is not None and shift is vacation_shift
 
-        # VACATION renders as the SEM shift (same object as week-based vacation), the rest
-        # resolve by code (see _absence_shift_code).
-        code = _absence_shift_code(absence.absence_type)
-        absence_shift = vacation_shift if code == "SEM" else next((s for s in shift_types if s.code == code), None)
-        if absence_shift:
-            result = determine_shift_for_date(date, person_id)
-            original_shift, rotation_week = result if result else (None, None)
-            return {
-                "person_id": person_id,
-                "person_name": person_name,
-                "shift": absence_shift,
-                "original_shift": original_shift,  # For coworker matching
-                "rotation_week": rotation_week,
-                "rotation_length": rotation_length,
-                "hours": 0.0,
-                "start": None,
-                "end": None,
-            }
+    # Rotationsskiftet (för coworker-matchning och "visa rotation"-toggle i alla-vyer)
+    _rot = determine_shift_for_date(date, person_id)
+    original_shift = _rot[0] if _rot else shift
 
-    # Kolla föräldraledighet (veckobaserad). Visa LEAVE endast på schemalagda
-    # (icke-OFF) dagar. Dagsnivå-föräldraledighet hanteras av absence-blocket ovan.
-    # Checked before vacation, matching the canonical path (_populate_single_person_day).
-    if parental_dates and date in parental_dates.get(person_id, set()):
-        leave_shift = next((s for s in shift_types if s.code == "LEAVE"), None)
-        result = determine_shift_for_date(date, person_id)
-        original_shift, rotation_week = result if result else (None, None)
-        if leave_shift and original_shift and original_shift.code != "OFF":
-            return {
-                "person_id": person_id,
-                "person_name": person_name,
-                "shift": leave_shift,
-                "original_shift": original_shift,
-                "rotation_week": rotation_week,
-                "rotation_length": rotation_length,
-                "hours": 0.0,
-                "start": None,
-                "end": None,
-                # Week-based parental leave renders as LEAVE; flag it so summaries can
-                # count it as parental rather than ordinary leave.
-                "parental_leave": True,
-            }
+    oncall_override = _lookup_for_day(ctx.oncall_override_map, session, OnCallOverride, person_id, date)
+    shift, hours, start, end, _ob = _apply_oncall_override(oncall_override, shift, hours, start, end, _ob, shift_types)
 
-    # Kolla semester (veckobaserad). Visa endast SEM på dagar personen är schemalagd
-    # (icke-OFF), så markeringen matchar hur semesterdagar räknas. OFF-dagar lämnas
-    # orörda och renderas som vanligt nedan. Dagsnivå-semester hanteras av absence-blocket ovan.
-    if vacation_dates and vacation_shift and date in vacation_dates.get(person_id, set()):
-        result = determine_shift_for_date(date, person_id)
-        original_shift, rotation_week = result if result else (None, None)
-        if original_shift and original_shift.code != "OFF":
-            return {
-                "person_id": person_id,
-                "person_name": person_name,
-                "shift": vacation_shift,
-                "original_shift": original_shift,  # For coworker matching
-                "rotation_week": rotation_week,
-                "rotation_length": rotation_length,
-                "hours": 0.0,
-                "start": None,
-                "end": None,
-            }
-
-    # Check for manual shift override (admin-assigned N1/N2/N3 replacing rotation)
-    if shift_override_map is not None:
-        _shift_override_obj = shift_override_map.get((person_id, date))
-        override_code = _shift_override_obj.shift_code if _shift_override_obj else None
-        if override_code:
-            result = determine_shift_for_date(date, person_id)
-            original_shift, rotation_week = result if result else (None, None)
-            override_shift = next((s for s in shift_types if s.code == override_code), None)
-            if override_shift:
-                hours, start, end = calculate_shift_hours(date, override_shift.code)
-                return {
-                    "person_id": person_id,
-                    "person_name": person_name,
-                    "shift": override_shift,
-                    "original_shift": original_shift,
-                    "rotation_week": rotation_week,
-                    "rotation_length": rotation_length,
-                    "hours": hours,
-                    "start": start,
-                    "end": end,
-                }
-
-    # Kolla skiftbyte
-    if swap_map is not None:
-        new_code = swap_map.get((person_id, date))
-        if new_code:
-            result = determine_shift_for_date(date, person_id)
-            original_shift, rotation_week = result if result else (None, None)
-            swapped_shift = next((s for s in shift_types if s.code == new_code), None)
-            if swapped_shift:
-                hours, start, end = calculate_shift_hours(date, swapped_shift.code)
-                return {
-                    "person_id": person_id,
-                    "person_name": person_name,
-                    "shift": swapped_shift,
-                    "original_shift": original_shift,
-                    "rotation_week": rotation_week,
-                    "rotation_length": rotation_length,
-                    "hours": hours,
-                    "start": start,
-                    "end": end,
-                }
-
-    # Normalt skift
-    result = determine_shift_for_date(date, person_id)
-    if result is None or result[0] is None:
-        shift, rotation_week = None, None
-        hours, start, end = 0.0, None, None
-    else:
-        shift, rotation_week = result
-        hours, start, end = calculate_shift_hours(date, shift.code)
-
-    # Spara det ursprungliga skiftet för coworker-matchning
-    original_shift = shift
-
-    # Kolla oncall override - hämta från batch eller databas
-    oncall_override = None
-    if oncall_override_map is not None:
-        oncall_override = oncall_override_map.get((person_id, date))
-    elif session:
-        from app.database.database import OnCallOverride
-
-        oncall_override = (
-            session.query(OnCallOverride)
-            .filter(OnCallOverride.user_id == person_id, OnCallOverride.date == date)
-            .first()
-        )
-
-    if oncall_override:
-        from app.database.database import OnCallOverrideType
-
-        if oncall_override.override_type == OnCallOverrideType.ADD:
-            # Add on-call shift, replacing the regular shift
-            oc_shift = next((s for s in shift_types if s.code == "OC"), None)
-            if oc_shift:
-                shift = oc_shift
-                hours, start, end = 0.0, None, None  # OC har inga specifika tider
-        elif oncall_override.override_type == OnCallOverrideType.REMOVE:
-            # Ta bort OC-pass - om skiftet är OC, ersätt med OFF
-            if shift and shift.code == "OC":
-                off_shift = next((s for s in shift_types if s.code == "OFF"), None)
-                if off_shift:
-                    shift = off_shift
-                    hours, start, end = 0.0, None, None
-
-    # Kolla övertid på aktuell dag (för att visa som skift)
-    ot_shift_for_display = None
-    if ot_shift_map is not None:
-        ot_shift_for_display = ot_shift_map.get((person_id, date))
-    elif session:
-        ot_shift_for_display = get_overtime_shift_for_date(session, person_id, date)
-
-    # Kolla också föregående dag för OT som påverkar beredskap (men visas inte som skift)
-    ot_shift_for_oncall = ot_shift_for_display
-    if not ot_shift_for_oncall:
-        prev_day = date - datetime.timedelta(days=1)
-        if ot_shift_map is not None:
-            prev_ot = ot_shift_map.get((person_id, prev_day))
-        elif session:
-            prev_ot = get_overtime_shift_for_date(session, person_id, prev_day)
-        else:
-            prev_ot = None
-
-        if prev_ot:
-            try:
-                _, ot_end_dt = parse_ot_times(prev_ot, prev_day)
-                if ot_end_dt.date() > prev_day:
-                    # OT går över midnatt in i aktuell dag - används för beredskapsberäkning
-                    ot_shift_for_oncall = prev_ot
-            except ValueError:
-                pass
-
-    # Visa OT som skift bara om det är registrerat på aktuell dag
-    # is_extension=True innebär att skiftet förlängs – visa originalskiftet kvar
-    if ot_shift_for_display and not ot_shift_for_display.is_extension:
-        ot_shift_type = next((s for s in shift_types if s.code == "OT"), None)
-        if ot_shift_type:
-            shift = ot_shift_type
-            hours = ot_shift_for_display.hours
-            try:
-                start, end = parse_ot_times(ot_shift_for_display, date)
-            except ValueError:
-                start, end = None, None
+    ot_shift, ot_shift_for_oncall = _lookup_ot_shifts(person_id, date, ctx.ot_shift_map, session)
+    if ot_shift and not is_vacation_day:
+        shift, hours, start, end = _apply_ot_display_shift(ot_shift, date, shift, hours, start, end, shift_types)
 
     return {
         "person_id": person_id,
@@ -2024,6 +1895,8 @@ def _populate_single_person_day(
     employment_start: datetime.date | None = None,
 ) -> None:
     """Populates detailed day info for a person."""
+    from app.database.database import Absence, OnCallOverride
+
     vacation_dates = ctx.vacation_dates
     combined_ob_rules = ctx.combined_ob_rules
     user_wages = ctx.user_wages
@@ -2086,13 +1959,7 @@ def _populate_single_person_day(
         return
 
     # Kolla frånvaro först (högsta prioritet) - använd batch-hämtad data
-    absence = None
-    if absence_map is not None:
-        absence = absence_map.get((person_id, current_day))
-    elif session:
-        from app.database.database import Absence
-
-        absence = session.query(Absence).filter(Absence.user_id == person_id, Absence.date == current_day).first()
+    absence = _lookup_for_day(absence_map, session, Absence, person_id, current_day)
 
     if absence and _populate_absence_day(
         day_info, absence, current_day, person_id, person_name, combined_ob_rules, vacation_shift, shift_types
@@ -2127,17 +1994,7 @@ def _populate_single_person_day(
     original_shift = _rot[0] if _rot else shift
 
     # Kolla oncall override - hämta från batch eller databas
-    oncall_override = None
-    if oncall_override_map is not None:
-        oncall_override = oncall_override_map.get((person_id, current_day))
-    elif session:
-        from app.database.database import OnCallOverride
-
-        oncall_override = (
-            session.query(OnCallOverride)
-            .filter(OnCallOverride.user_id == person_id, OnCallOverride.date == current_day)
-            .first()
-        )
+    oncall_override = _lookup_for_day(oncall_override_map, session, OnCallOverride, person_id, current_day)
 
     shift, hours, start, end, ob = _apply_oncall_override(oncall_override, shift, hours, start, end, ob, shift_types)
 
@@ -2148,31 +2005,7 @@ def _populate_single_person_day(
     )
 
     # Kolla övertid - både på aktuell dag (för visning) och föregående dag (för beredskap)
-    ot_shift = None
-    if ot_shift_map is not None:
-        ot_shift = ot_shift_map.get((person_id, current_day))
-    elif session:
-        ot_shift = get_overtime_shift_for_date(session, person_id, current_day)
-
-    # Check previous day for OT that crosses midnight (affects on-call but not displayed as OT)
-    ot_shift_for_oncall = ot_shift
-    if not ot_shift_for_oncall:
-        prev_day = current_day - datetime.timedelta(days=1)
-        if ot_shift_map is not None:
-            prev_ot = ot_shift_map.get((person_id, prev_day))
-        elif session:
-            prev_ot = get_overtime_shift_for_date(session, person_id, prev_day)
-        else:
-            prev_ot = None
-
-        if prev_ot:
-            try:
-                _, ot_end_dt = parse_ot_times(prev_ot, prev_day)
-                if ot_end_dt.date() > prev_day:
-                    # OT crosses midnight into current day - used for on-call calc
-                    ot_shift_for_oncall = prev_ot
-            except ValueError:
-                pass
+    ot_shift, ot_shift_for_oncall = _lookup_ot_shifts(person_id, current_day, ot_shift_map, session)
 
     # Om beredskap + övertid (samma dag ELLER föregående dag över midnatt), räkna om beredskap
     if shift and shift.code == "OC" and ot_shift_for_oncall:
@@ -2195,15 +2028,7 @@ def _populate_single_person_day(
         )
 
         # Ersätt skift med OT för visning – men inte om det är en förlängning
-        if not ot_shift.is_extension:
-            ot_shift_type = next((s for s in shift_types if s.code == "OT"), None)
-            if ot_shift_type:
-                shift = ot_shift_type
-                hours = ot_shift.hours
-                try:
-                    start, end = parse_ot_times(ot_shift, current_day)
-                except ValueError:
-                    start, end = None, None
+        shift, hours, start, end = _apply_ot_display_shift(ot_shift, current_day, shift, hours, start, end, shift_types)
 
     # Apply manual hour overrides if one exists for this person and date
     day_pay_override_map = ctx.day_pay_override_map or {}

--- a/tests/test_day_builder_agreement.py
+++ b/tests/test_day_builder_agreement.py
@@ -261,12 +261,11 @@ def test_builders_agree_when_vacation_and_parental_overlap(agree_session):
 
 
 def test_oncall_add_on_a_vacation_day(agree_session):
-    """A manual on-call ADD on a scheduled day inside a vacation week.
+    """A manual on-call ADD on a scheduled day inside a vacation week renders OC in both.
 
-    Third known disagreement: the canonical path lets the override replace SEM with OC
-    (and pays on-call for the day), while the week path renders SEM because vacation
-    returns before the override is applied. Pinned here with figures; the unification
-    resolves it toward the canonical answer, so display matches the money.
+    The canonical path lets the override replace SEM with OC and pays on-call for the day;
+    the week path used to render SEM because vacation returned before the override was
+    applied. Both now answer OC, so the display matches the money.
     """
     user = agree_session.query(User).filter(User.id == 1).first()
     user.vacation = {"2026": [11]}
@@ -279,7 +278,7 @@ def test_oncall_add_on_a_vacation_day(agree_session):
 
     assert canonical["shift"].code == "OC"
     assert canonical["oncall_pay"] > 0
-    assert basic["shift"].code == "SEM"
+    assert basic["shift"].code == "OC"
 
 
 def test_fixtures_actually_exercise_the_chain(agree_session):

--- a/tests/test_day_builder_agreement.py
+++ b/tests/test_day_builder_agreement.py
@@ -260,6 +260,28 @@ def test_builders_agree_when_vacation_and_parental_overlap(agree_session):
     assert [_shape(canonical[d])["shift"] for d in week] == [_shape(basic[d])["shift"] for d in week]
 
 
+def test_oncall_add_on_a_vacation_day(agree_session):
+    """A manual on-call ADD on a scheduled day inside a vacation week.
+
+    Third known disagreement: the canonical path lets the override replace SEM with OC
+    (and pays on-call for the day), while the week path renders SEM because vacation
+    returns before the override is applied. Pinned here with figures; the unification
+    resolves it toward the canonical answer, so display matches the money.
+    """
+    user = agree_session.query(User).filter(User.id == 1).first()
+    user.vacation = {"2026": [11]}
+    agree_session.add(OnCallOverride(user_id=1, date=D(2026, 3, 13), override_type=OnCallOverrideType.ADD))
+    agree_session.commit()
+    clear_schedule_cache()
+
+    canonical = _canonical_days(agree_session)[D(2026, 3, 13)]
+    basic = _basic_days(agree_session)[D(2026, 3, 13)]
+
+    assert canonical["shift"].code == "OC"
+    assert canonical["oncall_pay"] > 0
+    assert basic["shift"].code == "SEM"
+
+
 def test_fixtures_actually_exercise_the_chain(agree_session):
     """Guards the net itself: if the fixtures stop hitting the branches, agreement is vacuous."""
     _seed_chain_fixtures(agree_session)

--- a/tests/test_day_builder_agreement.py
+++ b/tests/test_day_builder_agreement.py
@@ -1,0 +1,303 @@
+"""Agreement net for the two day builders in period.py.
+
+period.py resolves the day priority chain twice: `_build_person_day_basic` (used by
+build_week_data, the week/range views) and `_populate_single_person_day` (used by
+generate_period_data, the canonical month/year path). This module pins that both
+builders answer the schedule question identically for a month whose fixtures exercise
+every branch of the chain: absence (full and partial, left_at and arrived_at),
+week-based vacation and parental leave, shift override, swap, on-call override
+(ADD and REMOVE), overtime, overtime crossing midnight, an overtime day inside a
+vacation week (issue #285), and an employment boundary.
+
+Only the fields both paths genuinely produce are compared; the pay fields (ob,
+oncall_pay, ot_pay, ot_hours) exist on the canonical path only.
+"""
+
+import datetime
+import sys
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+# ruff: noqa: E402
+import app.database.database as db_module
+from app.core.schedule import clear_schedule_cache
+from app.core.schedule.period import build_week_data, generate_period_data
+from app.database.database import (
+    Absence,
+    AbsenceType,
+    Base,
+    OnCallOverride,
+    OnCallOverrideType,
+    OvertimeShift,
+    PersonHistory,
+    RotationEra,
+    ShiftOverride,
+    ShiftSwap,
+    SwapStatus,
+    User,
+    UserRole,
+    WageType,
+)
+
+TEST_DB_URL = "sqlite:///file:test_day_builder_agreement_memdb?mode=memory&cache=shared&uri=true"
+test_engine = create_engine(TEST_DB_URL, connect_args={"check_same_thread": False, "uri": True})
+TestSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=test_engine)
+
+ERA_PATTERN = {
+    "1": ["OFF", "OFF", "OFF", "N3", "N3", "N3", "N3"],
+    "2": ["OFF", "OC", "N3", "N3", "N3", "N3", "OFF"],
+    "3": ["OFF", "OFF", "N1", "N1", "N1", "N1", "OC"],
+    "4": ["OC", "OFF", "N2", "N2", "N2", "OFF", "N1"],
+    "5": ["N1", "N1", "N1", "N1", "OC", "OFF", "OFF"],
+    "6": ["N3", "N3", "N3", "OFF", "OFF", "OC", "N3"],
+    "7": ["N3", "N3", "OFF", "OC", "N2", "N2", "N2"],
+    "8": ["N2", "N2", "OFF", "OFF", "N1", "N1", "N1"],
+    "9": ["N1", "N1", "OC", "OFF", "OFF", "N2", "N2"],
+    "10": ["N2", "N2", "N2", "N2", "OFF", "OFF", "OFF"],
+}
+
+D = datetime.date
+START = D(2026, 3, 1)
+END = D(2026, 3, 31)
+
+
+def _mk_user(uid: int, name: str, person_id: int | None) -> User:
+    return User(
+        id=uid,
+        username=f"user{uid}",
+        password_hash="x",
+        name=name,
+        role=UserRole.USER,
+        wage=30000,
+        wage_type=WageType.MONTHLY,
+        person_id=person_id,
+        tax_table="33",
+        vacation={},
+        must_change_password=0,
+    )
+
+
+@pytest.fixture
+def agree_session(monkeypatch):
+    Base.metadata.create_all(bind=test_engine)
+    monkeypatch.setattr(db_module, "SessionLocal", TestSessionLocal)
+    clear_schedule_cache()
+
+    session = TestSessionLocal()
+    session.query(RotationEra).delete()
+    session.add(
+        RotationEra(
+            start_date=D(2026, 1, 2),
+            end_date=None,
+            rotation_length=10,
+            weeks_pattern=ERA_PATTERN,
+        )
+    )
+    session.add(_mk_user(1, "Person One", 1))
+    session.add(_mk_user(2, "Person Two", 2))
+    session.commit()
+
+    yield session
+
+    session.close()
+    clear_schedule_cache()
+    Base.metadata.drop_all(bind=test_engine)
+
+
+def _seed_chain_fixtures(session, *, with_boundary: bool = True) -> None:
+    """Seed one fixture per branch of the day priority chain, all in March 2026."""
+    user = session.query(User).filter(User.id == 1).first()
+    user.vacation = {"2026": [11]}  # ISO week 11 = 9-15 March
+    user.parental_leave = {"2026": [13]}  # ISO week 13 = 23-29 March
+
+    # Full-day absence and both partial-absence shapes.
+    session.add(Absence(user_id=1, date=D(2026, 3, 1), absence_type=AbsenceType.SICK))
+    session.add(Absence(user_id=1, date=D(2026, 3, 2), absence_type=AbsenceType.SICK, left_at="20:00"))
+    session.add(Absence(user_id=1, date=D(2026, 3, 3), absence_type=AbsenceType.SICK, arrived_at="20:00"))
+
+    # Overtime: a plain OT day, an OT day inside the vacation week (issue #285),
+    # and one crossing midnight into the next day.
+    session.add(
+        OvertimeShift(
+            user_id=1,
+            date=D(2026, 3, 5),
+            start_time=datetime.time(8, 0),
+            end_time=datetime.time(12, 0),
+            hours=4.0,
+            ot_pay=0.0,
+            is_extension=False,
+        )
+    )
+    session.add(
+        OvertimeShift(
+            user_id=1,
+            date=D(2026, 3, 12),
+            start_time=datetime.time(8, 0),
+            end_time=datetime.time(12, 0),
+            hours=4.0,
+            ot_pay=0.0,
+            is_extension=False,
+        )
+    )
+    session.add(
+        OvertimeShift(
+            user_id=1,
+            date=D(2026, 3, 7),
+            start_time=datetime.time(21, 0),
+            end_time=datetime.time(5, 0),
+            hours=8.0,
+            ot_pay=0.0,
+            is_extension=False,
+        )
+    )
+
+    # On-call overrides: ADD on an OFF day, REMOVE on a rotation OC day.
+    session.add(OnCallOverride(user_id=1, date=D(2026, 3, 6), override_type=OnCallOverrideType.ADD))
+    session.add(OnCallOverride(user_id=1, date=D(2026, 3, 17), override_type=OnCallOverrideType.REMOVE))
+
+    # Manual shift override.
+    session.add(ShiftOverride(user_id=1, date=D(2026, 3, 20), shift_code="N1", created_by=1))
+
+    # Accepted swap between the two positions.
+    session.add(
+        ShiftSwap(
+            requester_id=1,
+            target_id=2,
+            requester_date=D(2026, 3, 19),
+            target_date=D(2026, 3, 18),
+            requester_shift_code="N2",
+            target_shift_code="N1",
+            status=SwapStatus.ACCEPTED,
+        )
+    )
+
+    if with_boundary:
+        # Employment boundary: position 1 ends 30 March, so 31 March is before/after employment.
+        session.add(
+            PersonHistory(
+                user_id=1,
+                person_id=1,
+                name="Person One",
+                username="user1",
+                is_active=0,
+                effective_from=D(2026, 1, 2),
+                effective_to=D(2026, 3, 30),
+                created_by=1,
+            )
+        )
+
+    session.commit()
+    clear_schedule_cache()
+
+
+# Fields both builders genuinely produce. Pay fields are canonical-only.
+_COMPARED = ("hours", "start", "end", "rotation_week")
+_FLAGS = ("before_employment", "parental_leave")
+
+
+def _shape(day: dict) -> dict:
+    out = {
+        "shift": day["shift"].code if day.get("shift") else None,
+        "original_shift": day["original_shift"].code if day.get("original_shift") else None,
+    }
+    out.update({k: day.get(k) for k in _COMPARED})
+    out.update({k: bool(day.get(k)) for k in _FLAGS})
+    out["partial_absence"] = day.get("partial_absence") is not None
+    return out
+
+
+def _basic_days(session) -> dict[datetime.date, dict]:
+    """Day dicts from build_week_data (the _build_person_day_basic path), keyed by date."""
+    days = {}
+    week = START - datetime.timedelta(days=START.weekday())
+    while week <= END:
+        iso = week.isocalendar()
+        for day in build_week_data(iso.year, iso.week, person_id=1, session=session):
+            days[day["date"]] = day
+        week += datetime.timedelta(days=7)
+    return days
+
+
+def _canonical_days(session) -> dict[datetime.date, dict]:
+    """Day dicts from generate_period_data (the _populate_single_person_day path)."""
+    return {d["date"]: d for d in generate_period_data(START, END, person_id=1, session=session)}
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="known disagreement: on week-vacation days the canonical path reports rotation_week "
+    "None while the week path reports the real rotation week (see _resolve_effective_shift)",
+)
+def test_builders_agree_across_the_priority_chain(agree_session):
+    _seed_chain_fixtures(agree_session)
+
+    canonical = _canonical_days(agree_session)
+    basic = _basic_days(agree_session)
+
+    mismatches = {}
+    for date, canon_day in canonical.items():
+        basic_day = basic[date]
+        want, got = _shape(canon_day), _shape(basic_day)
+        if want != got:
+            mismatches[date] = {k: (want[k], got[k]) for k in want if want[k] != got[k]}
+
+    assert mismatches == {}, f"canonical vs basic (canonical, basic): {mismatches}"
+
+
+def test_known_disagreement_rotation_week_on_vacation_days(agree_session):
+    """Pins the figures of the rotation_week disagreement until it is resolved."""
+    _seed_chain_fixtures(agree_session)
+
+    canonical = _canonical_days(agree_session)
+    basic = _basic_days(agree_session)
+
+    for date in (D(2026, 3, 12), D(2026, 3, 13), D(2026, 3, 14), D(2026, 3, 15)):
+        assert canonical[date]["shift"].code == "SEM"
+        assert canonical[date]["rotation_week"] is None
+        assert basic[date]["rotation_week"] == 1
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="known disagreement: on a week that is both vacation and parental leave the canonical "
+    "path renders LEAVE (parental checked first) and the week path renders SEM",
+)
+def test_builders_agree_when_vacation_and_parental_overlap(agree_session):
+    """A week flagged as both vacation and parental leave must resolve the same way in both."""
+    user = agree_session.query(User).filter(User.id == 1).first()
+    user.vacation = {"2026": [11]}
+    user.parental_leave = {"2026": [11]}
+    agree_session.commit()
+    clear_schedule_cache()
+
+    canonical = _canonical_days(agree_session)
+    basic = _basic_days(agree_session)
+
+    week = [D(2026, 3, d) for d in range(9, 16)]
+    assert [_shape(canonical[d])["shift"] for d in week] == [_shape(basic[d])["shift"] for d in week]
+
+
+def test_fixtures_actually_exercise_the_chain(agree_session):
+    """Guards the net itself: if the fixtures stop hitting the branches, agreement is vacuous."""
+    _seed_chain_fixtures(agree_session)
+    days = _canonical_days(agree_session)
+
+    assert days[D(2026, 3, 1)]["shift"].code == "SICK"
+    assert days[D(2026, 3, 2)].get("partial_absence") is not None
+    assert days[D(2026, 3, 3)].get("partial_absence") is not None
+    assert days[D(2026, 3, 5)]["shift"].code == "OT"
+    assert days[D(2026, 3, 6)]["shift"].code == "OC"
+    assert days[D(2026, 3, 12)]["shift"].code == "SEM"  # OT must not override vacation (issue #285)
+    assert days[D(2026, 3, 17)]["shift"].code == "OFF"
+    assert days[D(2026, 3, 20)]["shift"].code == "N1"
+    leave_week = [d for dt, d in days.items() if D(2026, 3, 23) <= dt <= D(2026, 3, 29)]
+    assert any(d["shift"] and d["shift"].code == "LEAVE" for d in leave_week)
+    assert days[D(2026, 3, 31)].get("before_employment") is True
+    swapped = days[D(2026, 3, 19)]
+    assert swapped["shift"].code != (swapped["original_shift"].code if swapped["original_shift"] else None)

--- a/tests/test_day_builder_agreement.py
+++ b/tests/test_day_builder_agreement.py
@@ -229,11 +229,6 @@ def _canonical_days(session) -> dict[datetime.date, dict]:
     return {d["date"]: d for d in generate_period_data(START, END, person_id=1, session=session)}
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="known disagreement: on week-vacation days the canonical path reports rotation_week "
-    "None while the week path reports the real rotation week (see _resolve_effective_shift)",
-)
 def test_builders_agree_across_the_priority_chain(agree_session):
     _seed_chain_fixtures(agree_session)
 
@@ -250,24 +245,6 @@ def test_builders_agree_across_the_priority_chain(agree_session):
     assert mismatches == {}, f"canonical vs basic (canonical, basic): {mismatches}"
 
 
-def test_known_disagreement_rotation_week_on_vacation_days(agree_session):
-    """Pins the figures of the rotation_week disagreement until it is resolved."""
-    _seed_chain_fixtures(agree_session)
-
-    canonical = _canonical_days(agree_session)
-    basic = _basic_days(agree_session)
-
-    for date in (D(2026, 3, 12), D(2026, 3, 13), D(2026, 3, 14), D(2026, 3, 15)):
-        assert canonical[date]["shift"].code == "SEM"
-        assert canonical[date]["rotation_week"] is None
-        assert basic[date]["rotation_week"] == 1
-
-
-@pytest.mark.xfail(
-    strict=True,
-    reason="known disagreement: on a week that is both vacation and parental leave the canonical "
-    "path renders LEAVE (parental checked first) and the week path renders SEM",
-)
 def test_builders_agree_when_vacation_and_parental_overlap(agree_session):
     """A week flagged as both vacation and parental leave must resolve the same way in both."""
     user = agree_session.query(User).filter(User.id == 1).first()


### PR DESCRIPTION
The fourth and last shadow engine, and structurally the deepest. `period.py` had two implementations of the same ten-branch day priority chain:

- `_build_person_day_basic` (~293 lines), used by `build_week_data`
- `_populate_single_person_day` plus its named helpers, used by `generate_period_data`

Both express before-employment and linked-substitute injection, partial absence with `left_at`/`arrived_at` clipping, absence-to-shift, week vacation, week parental, shift override, swap, rotation, on-call override ADD/REMOVE, OT lookback across midnight, and OT display replacement.

The standing project rule "new override layers go in `_populate_single_person_day`" exists precisely because the second path kept being forgotten. The `is_vacation_day` guard for issue #285 lived only in the canonical path; the week builder was correct only because it happened to return early on vacation. That is coincidence, not design.

## Three real disagreements, found before touching anything

A characterization test comparing the two builders across one March 2026 fixture set (swap, shift override, on-call ADD and REMOVE, full and partial absence, week vacation, week parental, OT, OT inside a vacation week, OT crossing midnight, employment boundary) found that they already disagreed in three places. Each was landed as its own explained commit before the refactor:

1. **`rotation_week` blank on vacation days.** `_resolve_effective_shift` hardcoded `None`, so the month, year and day views blanked the rotation-week column on every vacation day while the week view showed the number. The rotation week is a property of the date, not of the shift rendered. Fixed on the canonical side.
2. **Vacation and parental flagged for the same ISO week** rendered `LEAVE` on one path and `SEM` on the other, on all four scheduled days. The week path now checks parental first, matching canonical.
3. **On-call ADD on a scheduled day inside a vacation week.** Canonical produced shift `OC` with `oncall_pay > 0`; the week path produced `SEM` with no on-call marking, because vacation returned before the override was applied. The money was already being paid through the canonical path, so the week views were showing a day as vacation that was in fact paid on-call. Resolved toward canonical.

## The unification

`_build_person_day_basic` now delegates to `_populate_absence_day`, `_populate_parental_day`, `_resolve_effective_shift` and `_apply_oncall_override`, keeping only its own concerns: it adds `rotation_length`, passes no OB rules so no pay is computed, and strips the pay keys. Three verbatim-duplicated lookup blocks became shared helpers used by both builders: `_lookup_for_day`, `_lookup_ot_shifts` and `_apply_ot_display_shift`.

`is_vacation_day` (#285) is now carried explicitly in both paths rather than depending on an early return.

`period.py`: 2343 to 2168 lines. The builder body: 287 to 100 including the new shared helpers.

## Contract

Returned keys are unchanged for every branch. The only shape delta is additive: days resolved through the vacation, override and swap branches now also carry `ot_shift_for_oncall`, which previously only the plain-rotation branch had. Nothing outside `period.py` reads that key. No route signatures changed and no routes were edited.

## What resisted, deliberately

- The **before-employment branch** is still written out in both builders. The two versions differ only by pay keys and extracting a helper would have added more code than it removed. Partial delegation by choice.
- **Invalid-data fallthrough changed shape.** On a `ShiftOverride` or swap whose `shift_code` is not in `get_shift_types()`, the old week builder fell through to the rotation shift; `_resolve_effective_shift` returns no shift instead. Both paths now behave identically, which is the canonical answer, but it is a genuine behaviour difference on corrupt data. No test covers it and nothing writes an unknown code today.

## Tests

716 passed, up from 712. The four added are the agreement net, which fails on the previous code with exactly the three disagreements above.