### PR TITLE
Share the vacation editing logic between profile and admin

### DIFF
--- a/app/core/schedule/vacation.py
+++ b/app/core/schedule/vacation.py
@@ -702,3 +702,228 @@ def fold_vacation_supplement_into_pay(brutto_pay: float, netto_pay: float, suppl
     else:
         new_netto = netto_before
     return new_brutto, new_netto
+
+
+# ---------------------------------------------------------------------------
+# Vacation editing (shared by /profile/vacation and /admin/vacation/{user_id})
+#
+# The self-service and admin route sets perform identical edits, differing only
+# in which user they target and where they redirect afterwards. The behaviour
+# lives here, taking the target user explicitly, so the two cannot drift apart.
+# ---------------------------------------------------------------------------
+
+
+def parse_week_list(raw: str) -> list[int]:
+    """Parse a comma-separated week string into sorted, deduped weeks 1-53."""
+    if not raw.strip():
+        return []
+    weeks = [int(w.strip()) for w in raw.split(",") if w.strip().isdigit()]
+    return sorted({w for w in weeks if 1 <= w <= 53})
+
+
+def parse_date_list(raw: str) -> set[datetime.date]:
+    """Parse a comma-separated ISO date string, silently dropping bad entries."""
+    result: set[datetime.date] = set()
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            result.add(datetime.date.fromisoformat(part))
+        except ValueError:
+            continue
+    return result
+
+
+def is_valid_vacation_year(year: int) -> bool:
+    return 2020 <= year <= 2100
+
+
+def _commit(db) -> None:
+    from app.core.schedule import clear_schedule_cache
+
+    try:
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    clear_schedule_cache()
+
+
+def build_vacation_page_context(db, user, year: int) -> dict:
+    """Build the shared template context for a user's vacation year.
+
+    Walks the calendar year once to collect the user's OFF days (which the
+    balance calculation needs) and per-day shift colours for the calendar.
+    """
+    from app.core.schedule.core import determine_shift_for_date
+    from app.database.database import Absence, AbsenceType
+
+    off_days: set[datetime.date] = set()
+    day_colors: dict[str, str] = {}
+    day = datetime.date(year, 1, 1)
+    year_end = datetime.date(year, 12, 31)
+    while day <= year_end:
+        shift, _ = determine_shift_for_date(day, user.rotation_person_id)
+        if shift:
+            if shift.code == "OFF":
+                off_days.add(day)
+            if shift.color:
+                day_colors[day.isoformat()] = shift.color
+        day += datetime.timedelta(days=1)
+
+    def _absences(absence_type):
+        return (
+            db.query(Absence)
+            .filter(
+                Absence.user_id == user.id,
+                Absence.absence_type == absence_type,
+                Absence.date >= datetime.date(year, 1, 1),
+                Absence.date <= datetime.date(year, 12, 31),
+            )
+            .order_by(Absence.date)
+            .all()
+        )
+
+    return {
+        "vacation_weeks": sorted((user.vacation or {}).get(str(year), [])),
+        "balance": calculate_vacation_balance(user, year, db, off_dates=off_days),
+        "day_absences": _absences(AbsenceType.VACATION),
+        "parental_absences": _absences(AbsenceType.PARENTAL),
+        "parental_weeks": sorted((user.parental_leave or {}).get(str(year), [])),
+        "off_days_list": sorted(d.isoformat() for d in off_days),
+        "day_colors": day_colors,
+    }
+
+
+def _set_week_json(db, user, attr: str, year: int, weeks_raw: str) -> bool:
+    """Store parsed weeks under `year` in a JSON week column. False if year invalid."""
+    from sqlalchemy.orm.attributes import flag_modified
+
+    if not is_valid_vacation_year(year):
+        return False
+
+    weeks = dict(getattr(user, attr) or {})
+    weeks[str(year)] = parse_week_list(weeks_raw)
+    setattr(user, attr, weeks)
+    flag_modified(user, attr)
+    _commit(db)
+    return True
+
+
+def set_vacation_weeks(db, user, year: int, weeks_raw: str) -> bool:
+    """Set week-based vacation for a year. Returns False if the year is invalid."""
+    return _set_week_json(db, user, "vacation", year, weeks_raw)
+
+
+def set_parental_weeks(db, user, year: int, weeks_raw: str) -> bool:
+    """Set week-based parental leave for a year. Returns False if the year is invalid."""
+    return _set_week_json(db, user, "parental_leave", year, weeks_raw)
+
+
+def add_vacation_day(db, user, vacation_date: str) -> datetime.date | None:
+    """Mark a single date as vacation. Returns the date, or None if unparseable.
+
+    An absence already on that date is converted to VACATION rather than duplicated.
+    """
+    from app.database.database import Absence, AbsenceType
+
+    try:
+        day = datetime.date.fromisoformat(vacation_date)
+    except ValueError:
+        return None
+
+    existing = db.query(Absence).filter(Absence.user_id == user.id, Absence.date == day).first()
+    if existing:
+        existing.absence_type = AbsenceType.VACATION
+    else:
+        db.add(Absence(user_id=user.id, date=day, absence_type=AbsenceType.VACATION))
+
+    _commit(db)
+    return day
+
+
+def sync_vacation_days(db, user, year: int, dates: str, parental_dates: str) -> tuple[int, int]:
+    """Replace the year's day-level vacation and parental leave with the given dates.
+
+    Returns (added, removed) counts across both absence types. Absences outside
+    the year, and of other types, are left alone.
+    """
+    from app.database.database import Absence, AbsenceType
+
+    added = removed = 0
+    for raw, absence_type in ((dates, AbsenceType.VACATION), (parental_dates, AbsenceType.PARENTAL)):
+        new_dates = parse_date_list(raw)
+        existing = {
+            a.date: a
+            for a in db.query(Absence)
+            .filter(
+                Absence.user_id == user.id,
+                Absence.absence_type == absence_type,
+                Absence.date >= datetime.date(year, 1, 1),
+                Absence.date <= datetime.date(year, 12, 31),
+            )
+            .all()
+        }
+        for day in new_dates - set(existing):
+            db.add(Absence(user_id=user.id, date=day, absence_type=absence_type))
+            added += 1
+        for day in set(existing) - new_dates:
+            db.delete(existing[day])
+            removed += 1
+
+    _commit(db)
+    return added, removed
+
+
+def delete_vacation_day(db, user, absence_id: int) -> int:
+    """Delete one of the user's VACATION absences. Returns the year to return to."""
+    from app.core.utils import get_today
+    from app.database.database import Absence, AbsenceType
+
+    absence = (
+        db.query(Absence)
+        .filter(
+            Absence.id == absence_id,
+            Absence.user_id == user.id,
+            Absence.absence_type == AbsenceType.VACATION,
+        )
+        .first()
+    )
+    if not absence:
+        return get_today().year
+
+    year = absence.date.year
+    db.delete(absence)
+    _commit(db)
+    return year
+
+
+def set_vacation_settings(
+    db,
+    user,
+    employment_start_date: str,
+    year_start_month: int | None = None,
+    days_per_year: int | None = None,
+) -> None:
+    """Update vacation settings. Out-of-range values are ignored, as is a
+    malformed date; an empty date string clears the employment start date.
+
+    Only the admin form exposes the break month and days per year, so those stay
+    optional rather than being reset when self-service saves.
+    """
+    if employment_start_date.strip():
+        try:
+            user.employment_start_date = datetime.date.fromisoformat(employment_start_date)
+        except ValueError:
+            pass
+    else:
+        user.employment_start_date = None
+
+    if year_start_month is not None and 1 <= year_start_month <= 12:
+        user.vacation_year_start_month = year_start_month
+
+    if days_per_year is not None and 0 <= days_per_year <= 40:
+        user.vacation_days_per_year = days_per_year
+
+    _commit(db)

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 
 from app.auth.auth import get_admin_user
 from app.core.schedule import clear_schedule_cache, settings, tax_brackets
+from app.core.schedule import vacation as vacation_core
 from app.core.schedule.vacation import calculate_vacation_balance
 from app.core.utils import get_today
 from app.database.database import Absence, AbsenceType, RotationEra, User, get_db
@@ -496,60 +497,12 @@ async def admin_vacation_user(
     db: Session = Depends(get_db),
 ):
     """Admin: edit vacation for a specific user."""
-    from app.core.schedule.core import determine_shift_for_date
-
     if year is None:
         year = get_today().year
 
     edit_user = db.query(User).filter(User.id == user_id).first()
     if not edit_user:
         return RedirectResponse(url="/admin/vacation", status_code=302)
-
-    vacation_weeks = (edit_user.vacation or {}).get(str(year), [])
-
-    # Compute shift colors and OFF days for this user's rotation
-    off_days: set[datetime.date] = set()
-    day_colors: dict[str, str] = {}
-    d = datetime.date(year, 1, 1)
-    year_end = datetime.date(year, 12, 31)
-    while d <= year_end:
-        shift, _ = determine_shift_for_date(d, edit_user.rotation_person_id)
-        if shift:
-            if shift.code == "OFF":
-                off_days.add(d)
-            if shift.color:
-                day_colors[d.isoformat()] = shift.color
-        d += datetime.timedelta(days=1)
-
-    off_days_list = sorted(day.isoformat() for day in off_days)
-    balance = calculate_vacation_balance(edit_user, year, db, off_dates=off_days)
-
-    # Get day-level vacation for this year
-    day_absences = (
-        db.query(Absence)
-        .filter(
-            Absence.user_id == user_id,
-            Absence.absence_type == AbsenceType.VACATION,
-            Absence.date >= datetime.date(year, 1, 1),
-            Absence.date <= datetime.date(year, 12, 31),
-        )
-        .order_by(Absence.date)
-        .all()
-    )
-
-    parental_absences = (
-        db.query(Absence)
-        .filter(
-            Absence.user_id == user_id,
-            Absence.absence_type == AbsenceType.PARENTAL,
-            Absence.date >= datetime.date(year, 1, 1),
-            Absence.date <= datetime.date(year, 12, 31),
-        )
-        .order_by(Absence.date)
-        .all()
-    )
-
-    parental_weeks = sorted((edit_user.parental_leave or {}).get(str(year), []))
 
     return render(
         "admin_vacation_user.html",
@@ -558,15 +511,9 @@ async def admin_vacation_user(
             "user": current_user,
             "edit_user": edit_user,
             "year": year,
-            "vacation_weeks": sorted(vacation_weeks),
-            "balance": balance,
-            "day_absences": day_absences,
-            "parental_absences": parental_absences,
-            "parental_weeks": parental_weeks,
-            "off_days_list": off_days_list,
-            "day_colors": day_colors,
             "success": success,
             "month_names": MONTH_NAMES_SV,
+            **vacation_core.build_vacation_page_context(db, edit_user, year),
         },
     )
 
@@ -579,30 +526,12 @@ async def admin_update_vacation_weeks(
     db: Session = Depends(get_db),
 ):
     """Admin: update week-based vacation for a user."""
-    from sqlalchemy.orm.attributes import flag_modified
-
     edit_user = db.query(User).filter(User.id == user_id).first()
     if not edit_user:
         return RedirectResponse(url="/admin/vacation", status_code=302)
 
-    # Validate year
-    if not (2020 <= year <= 2100):
+    if not vacation_core.set_vacation_weeks(db, edit_user, year, weeks):
         return RedirectResponse(url=f"/admin/vacation/{user_id}?year={year}", status_code=302)
-
-    # Parse and validate weeks
-    week_list = []
-    if weeks.strip():
-        week_list = [int(w.strip()) for w in weeks.split(",") if w.strip().isdigit()]
-        week_list = sorted(set(w for w in week_list if 1 <= w <= 53))
-
-    # Update vacation JSON
-    vacation = edit_user.vacation or {}
-    vacation[str(year)] = week_list
-    edit_user.vacation = vacation
-    flag_modified(edit_user, "vacation")
-    db.commit()
-
-    clear_schedule_cache()
 
     return RedirectResponse(
         url=f"/admin/vacation/{user_id}?year={year}&success=Semesterveckor+uppdaterade",
@@ -618,27 +547,12 @@ async def admin_update_parental_weeks(
     db: Session = Depends(get_db),
 ):
     """Admin: update parental leave weeks for a user (stored in User.parental_leave JSON)."""
-    from sqlalchemy.orm.attributes import flag_modified
-
     edit_user = db.query(User).filter(User.id == user_id).first()
     if not edit_user:
         return RedirectResponse(url="/admin/vacation", status_code=302)
 
-    if not (2020 <= year <= 2100):
+    if not vacation_core.set_parental_weeks(db, edit_user, year, weeks):
         return RedirectResponse(url=f"/admin/vacation/{user_id}?year={year}", status_code=302)
-
-    week_list = []
-    if weeks.strip():
-        week_list = [int(w.strip()) for w in weeks.split(",") if w.strip().isdigit()]
-    week_list = sorted(set(w for w in week_list if 1 <= w <= 53))
-
-    parental_leave = edit_user.parental_leave or {}
-    parental_leave[str(year)] = week_list
-    edit_user.parental_leave = parental_leave
-    flag_modified(edit_user, "parental_leave")
-    db.commit()
-
-    clear_schedule_cache()
 
     return RedirectResponse(
         url=f"/admin/vacation/{user_id}?year={year}&success=Föräldraledigveckor+uppdaterade",
@@ -657,37 +571,12 @@ async def admin_add_vacation_day(
     if not edit_user:
         return RedirectResponse(url="/admin/vacation", status_code=302)
 
-    try:
-        d = datetime.date.fromisoformat(vacation_date)
-    except ValueError:
+    day = vacation_core.add_vacation_day(db, edit_user, vacation_date)
+    if day is None:
         return RedirectResponse(url=f"/admin/vacation/{user_id}", status_code=302)
 
-    # Check if absence already exists for this date
-    existing = (
-        db.query(Absence)
-        .filter(
-            Absence.user_id == user_id,
-            Absence.date == d,
-        )
-        .first()
-    )
-
-    if existing:
-        # Update existing absence to VACATION
-        existing.absence_type = AbsenceType.VACATION
-    else:
-        new_absence = Absence(
-            user_id=user_id,
-            date=d,
-            absence_type=AbsenceType.VACATION,
-        )
-        db.add(new_absence)
-
-    db.commit()
-    clear_schedule_cache()
-
     return RedirectResponse(
-        url=f"/admin/vacation/{user_id}?year={d.year}&success=Semesterdag+tillagd",
+        url=f"/admin/vacation/{user_id}?year={day.year}&success=Semesterdag+tillagd",
         status_code=303,
     )
 
@@ -705,46 +594,8 @@ async def admin_sync_vacation_days(
     if not edit_user:
         return RedirectResponse(url="/admin/vacation", status_code=302)
 
-    def _parse_dates(raw: str) -> set[datetime.date]:
-        result = set()
-        for s in raw.split(","):
-            s = s.strip()
-            if s:
-                try:
-                    result.add(datetime.date.fromisoformat(s))
-                except ValueError:
-                    continue
-        return result
-
-    def _sync_type(new_dates: set[datetime.date], absence_type: AbsenceType) -> tuple[int, int]:
-        existing = (
-            db.query(Absence)
-            .filter(
-                Absence.user_id == user_id,
-                Absence.absence_type == absence_type,
-                Absence.date >= datetime.date(year, 1, 1),
-                Absence.date <= datetime.date(year, 12, 31),
-            )
-            .all()
-        )
-        existing_dates = {a.date: a for a in existing}
-        added = new_dates - set(existing_dates.keys())
-        removed = set(existing_dates.keys()) - new_dates
-        for d in added:
-            db.add(Absence(user_id=user_id, date=d, absence_type=absence_type))
-        for d in removed:
-            db.delete(existing_dates[d])
-        return len(added), len(removed)
-
-    vac_added, vac_removed = _sync_type(_parse_dates(dates), AbsenceType.VACATION)
-    par_added, par_removed = _sync_type(_parse_dates(parental_dates), AbsenceType.PARENTAL)
-
-    db.commit()
-    clear_schedule_cache()
-
-    total_added = vac_added + par_added
-    total_removed = vac_removed + par_removed
-    msg = f"{total_added}+tillagda,+{total_removed}+borttagna" if total_added or total_removed else "Inga+ändringar"
+    added, removed = vacation_core.sync_vacation_days(db, edit_user, year, dates, parental_dates)
+    msg = f"{added}+tillagda,+{removed}+borttagna" if added or removed else "Inga+ändringar"
 
     return RedirectResponse(
         url=f"/admin/vacation/{user_id}?year={year}&success={msg}",
@@ -762,22 +613,11 @@ async def admin_delete_vacation_day(
     db: Session = Depends(get_db),
 ):
     """Admin: remove a day-level vacation."""
-    absence = (
-        db.query(Absence)
-        .filter(
-            Absence.id == absence_id,
-            Absence.user_id == user_id,
-            Absence.absence_type == AbsenceType.VACATION,
-        )
-        .first()
-    )
+    edit_user = db.query(User).filter(User.id == user_id).first()
+    if not edit_user:
+        return RedirectResponse(url="/admin/vacation", status_code=302)
 
-    year = get_today().year
-    if absence:
-        year = absence.date.year
-        db.delete(absence)
-        db.commit()
-        clear_schedule_cache()
+    year = vacation_core.delete_vacation_day(db, edit_user, absence_id)
 
     return RedirectResponse(
         url=f"/admin/vacation/{user_id}?year={year}&success=Semesterdag+borttagen",
@@ -845,25 +685,13 @@ async def admin_update_vacation_settings(
     if not edit_user:
         return RedirectResponse(url="/admin/vacation", status_code=302)
 
-    # Parse employment start date
-    if employment_start_date.strip():
-        try:
-            edit_user.employment_start_date = datetime.date.fromisoformat(employment_start_date)
-        except ValueError:
-            pass
-    else:
-        edit_user.employment_start_date = None
-
-    # Validate and set break month
-    if 1 <= vacation_year_start_month <= 12:
-        edit_user.vacation_year_start_month = vacation_year_start_month
-
-    # Validate and set days per year
-    if 0 <= vacation_days_per_year <= 40:
-        edit_user.vacation_days_per_year = vacation_days_per_year
-
-    db.commit()
-    clear_schedule_cache()
+    vacation_core.set_vacation_settings(
+        db,
+        edit_user,
+        employment_start_date,
+        year_start_month=vacation_year_start_month,
+        days_per_year=vacation_days_per_year,
+    )
 
     return RedirectResponse(
         url=f"/admin/vacation/{user_id}?success=Semesterinst%C3%A4llningar+sparade",

--- a/app/routes/profile.py
+++ b/app/routes/profile.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 
 from app.auth.auth import decrypt_api_key, encrypt_api_key, get_current_user, get_password_hash, hash_api_key
 from app.core.schedule import clear_schedule_cache
+from app.core.schedule import vacation as vacation_core
 from app.core.utils import get_today
 from app.database.database import Absence, AbsenceType, User, UserRole, WageType, get_db
 from app.routes.shared import _parse_rates_form, render
@@ -449,58 +450,8 @@ async def vacation_page(
     db: Session = Depends(get_db),
 ):
     """Show vacation management page."""
-    from app.core.schedule.core import determine_shift_for_date
-    from app.core.schedule.vacation import calculate_vacation_balance
-    from app.database.database import Absence, AbsenceType
-
     if year is None:
         year = get_today().year
-
-    vacation = current_user.vacation or {}
-    vacation_weeks = vacation.get(str(year), [])
-
-    # Compute shift colors and OFF-shift days for this calendar year
-    off_days: set[datetime.date] = set()
-    day_colors: dict[str, str] = {}
-    d = datetime.date(year, 1, 1)
-    year_end = datetime.date(year, 12, 31)
-    while d <= year_end:
-        shift, _ = determine_shift_for_date(d, current_user.rotation_person_id)
-        if shift:
-            if shift.code == "OFF":
-                off_days.add(d)
-            if shift.color:
-                day_colors[d.isoformat()] = shift.color
-        d += datetime.timedelta(days=1)
-
-    balance = calculate_vacation_balance(current_user, year, db, off_dates=off_days)
-
-    day_absences = (
-        db.query(Absence)
-        .filter(
-            Absence.user_id == current_user.id,
-            Absence.absence_type == AbsenceType.VACATION,
-            Absence.date >= datetime.date(year, 1, 1),
-            Absence.date <= datetime.date(year, 12, 31),
-        )
-        .order_by(Absence.date)
-        .all()
-    )
-
-    parental_absences = (
-        db.query(Absence)
-        .filter(
-            Absence.user_id == current_user.id,
-            Absence.absence_type == AbsenceType.PARENTAL,
-            Absence.date >= datetime.date(year, 1, 1),
-            Absence.date <= datetime.date(year, 12, 31),
-        )
-        .order_by(Absence.date)
-        .all()
-    )
-
-    off_days_list = sorted(d.isoformat() for d in off_days)
-    parental_weeks = sorted((current_user.parental_leave or {}).get(str(year), []))
 
     return render(
         "vacation.html",
@@ -508,62 +459,20 @@ async def vacation_page(
             "request": request,
             "user": current_user,
             "year": year,
-            "vacation_weeks": vacation_weeks,
-            "balance": balance,
-            "day_absences": day_absences,
-            "parental_absences": parental_absences,
-            "parental_weeks": parental_weeks,
-            "off_days_list": off_days_list,
-            "day_colors": day_colors,
+            **vacation_core.build_vacation_page_context(db, current_user, year),
         },
     )
 
 
 @router.post("/profile/vacation", name="update_vacation")
 async def update_vacation(
-    request: Request,
     year: int = Form(...),
     weeks: str = Form(""),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
     """Update vacation weeks for a year."""
-    if not (2020 <= year <= 2100):
-        return render(
-            "vacation.html",
-            {
-                "request": request,
-                "user": current_user,
-                "year": year,
-                "vacation_weeks": current_user.vacation.get(str(year), []) if current_user.vacation else [],
-                "error": "Ogiltigt år: måste vara mellan 2020 och 2100",
-            },
-            status_code=400,
-        )
-
-    if weeks.strip():
-        week_list = [int(w.strip()) for w in weeks.split(",") if w.strip().isdigit()]
-    else:
-        week_list = []
-
-    week_list = [w for w in week_list if 1 <= w <= 53]
-    week_list = sorted(set(week_list))
-
-    vacation = current_user.vacation or {}
-    vacation[str(year)] = week_list
-    current_user.vacation = vacation
-
-    from sqlalchemy.orm.attributes import flag_modified
-
-    flag_modified(current_user, "vacation")
-
-    try:
-        db.commit()
-    except Exception:
-        db.rollback()
-        raise
-    clear_schedule_cache()
-
+    vacation_core.set_vacation_weeks(db, current_user, year, weeks)
     return RedirectResponse(url=f"/profile/vacation?year={year}", status_code=302)
 
 
@@ -575,28 +484,7 @@ async def update_parental_weeks(
     db: Session = Depends(get_db),
 ):
     """Update parental leave weeks for a year (stored in User.parental_leave JSON)."""
-    from sqlalchemy.orm.attributes import flag_modified
-
-    if not (2020 <= year <= 2100):
-        return RedirectResponse(url=f"/profile/vacation?year={year}", status_code=302)
-
-    week_list = []
-    if weeks.strip():
-        week_list = [int(w.strip()) for w in weeks.split(",") if w.strip().isdigit()]
-    week_list = sorted(set(w for w in week_list if 1 <= w <= 53))
-
-    parental_leave = current_user.parental_leave or {}
-    parental_leave[str(year)] = week_list
-    current_user.parental_leave = parental_leave
-    flag_modified(current_user, "parental_leave")
-
-    try:
-        db.commit()
-    except Exception:
-        db.rollback()
-        raise
-    clear_schedule_cache()
-
+    vacation_core.set_parental_weeks(db, current_user, year, weeks)
     return RedirectResponse(url=f"/profile/vacation?year={year}", status_code=302)
 
 
@@ -607,26 +495,10 @@ async def add_vacation_day(
     db: Session = Depends(get_db),
 ):
     """Add a single vacation day for current user."""
-    try:
-        d = datetime.date.fromisoformat(vacation_date)
-    except ValueError:
+    day = vacation_core.add_vacation_day(db, current_user, vacation_date)
+    if day is None:
         return RedirectResponse(url="/profile/vacation", status_code=302)
-
-    existing = db.query(Absence).filter(Absence.user_id == current_user.id, Absence.date == d).first()
-    if existing:
-        existing.absence_type = AbsenceType.VACATION
-    else:
-        db.add(
-            Absence(
-                user_id=current_user.id,
-                date=d,
-                absence_type=AbsenceType.VACATION,
-            )
-        )
-
-    db.commit()
-    clear_schedule_cache()
-    return RedirectResponse(url=f"/profile/vacation?year={d.year}", status_code=302)
+    return RedirectResponse(url=f"/profile/vacation?year={day.year}", status_code=302)
 
 
 @router.post("/profile/vacation/days/sync", name="sync_vacation_days")
@@ -638,40 +510,7 @@ async def sync_vacation_days(
     db: Session = Depends(get_db),
 ):
     """Sync day-level vacation and parental leave for a year."""
-
-    def _parse_dates(raw: str) -> set[datetime.date]:
-        result = set()
-        for s in raw.split(","):
-            s = s.strip()
-            if s:
-                try:
-                    result.add(datetime.date.fromisoformat(s))
-                except ValueError:
-                    continue
-        return result
-
-    def _sync_type(new_dates: set[datetime.date], absence_type: AbsenceType) -> None:
-        existing = (
-            db.query(Absence)
-            .filter(
-                Absence.user_id == current_user.id,
-                Absence.absence_type == absence_type,
-                Absence.date >= datetime.date(year, 1, 1),
-                Absence.date <= datetime.date(year, 12, 31),
-            )
-            .all()
-        )
-        existing_dates = {a.date: a for a in existing}
-        for d in new_dates - set(existing_dates.keys()):
-            db.add(Absence(user_id=current_user.id, date=d, absence_type=absence_type))
-        for d in set(existing_dates.keys()) - new_dates:
-            db.delete(existing_dates[d])
-
-    _sync_type(_parse_dates(dates), AbsenceType.VACATION)
-    _sync_type(_parse_dates(parental_dates), AbsenceType.PARENTAL)
-
-    db.commit()
-    clear_schedule_cache()
+    vacation_core.sync_vacation_days(db, current_user, year, dates, parental_dates)
     return RedirectResponse(url=f"/profile/vacation?year={year}", status_code=302)
 
 
@@ -682,21 +521,7 @@ async def delete_vacation_day(
     db: Session = Depends(get_db),
 ):
     """Delete a single vacation day for current user."""
-    absence = (
-        db.query(Absence)
-        .filter(
-            Absence.id == absence_id,
-            Absence.user_id == current_user.id,
-            Absence.absence_type == AbsenceType.VACATION,
-        )
-        .first()
-    )
-    year = get_today().year
-    if absence:
-        year = absence.date.year
-        db.delete(absence)
-        db.commit()
-        clear_schedule_cache()
+    year = vacation_core.delete_vacation_day(db, current_user, absence_id)
     return RedirectResponse(url=f"/profile/vacation?year={year}", status_code=302)
 
 
@@ -707,16 +532,7 @@ async def update_vacation_settings(
     db: Session = Depends(get_db),
 ):
     """Update employment start date for current user."""
-    if employment_start_date.strip():
-        try:
-            current_user.employment_start_date = datetime.date.fromisoformat(employment_start_date)
-        except ValueError:
-            pass
-    else:
-        current_user.employment_start_date = None
-
-    db.commit()
-    clear_schedule_cache()
+    vacation_core.set_vacation_settings(db, current_user, employment_start_date)
     return RedirectResponse(url="/profile/vacation", status_code=302)
 
 

--- a/tests/test_vacation_routes.py
+++ b/tests/test_vacation_routes.py
@@ -1,0 +1,397 @@
+"""Route tests for the self-service and admin vacation modules.
+
+These two route sets are two copies of the same logic (profile.py operates on
+the logged-in user, admin.py on a user_id from the path). Nothing exercised
+them before, so the assertions here pin the current behaviour of both copies
+and act as the safety net for sharing the implementation.
+"""
+
+import datetime
+
+import pytest
+
+from app.database.database import Absence, AbsenceType
+
+
+def _login(client, username, password):
+    client.post("/login", data={"username": username, "password": password})
+
+
+@pytest.fixture
+def user_client(test_client, test_user):
+    _login(test_client, "testuser", "testpass123")
+    return test_client
+
+
+@pytest.fixture
+def admin_client(test_client, admin_user, test_user):
+    _login(test_client, "admin", "adminpass123")
+    return test_client
+
+
+def _absences(db, user_id, absence_type):
+    return sorted(
+        a.date for a in db.query(Absence).filter(Absence.user_id == user_id, Absence.absence_type == absence_type).all()
+    )
+
+
+class TestVacationWeeks:
+    def test_profile_stores_sorted_deduped_valid_weeks(self, user_client, test_db, test_user):
+        resp = user_client.post(
+            "/profile/vacation",
+            data={"year": 2026, "weeks": "30, 28,28, 0, 54, abc, 29"},
+            follow_redirects=False,
+        )
+
+        assert resp.status_code == 302
+        test_db.refresh(test_user)
+        assert test_user.vacation["2026"] == [28, 29, 30]
+
+    def test_profile_empty_weeks_clears_the_year(self, user_client, test_db, test_user):
+        test_user.vacation = {"2026": [10]}
+        test_db.commit()
+
+        user_client.post("/profile/vacation", data={"year": 2026, "weeks": ""}, follow_redirects=False)
+
+        test_db.refresh(test_user)
+        assert test_user.vacation["2026"] == []
+
+    def test_profile_out_of_range_year_is_a_noop(self, user_client, test_db, test_user):
+        resp = user_client.post(
+            "/profile/vacation",
+            data={"year": 1999, "weeks": "10"},
+            follow_redirects=False,
+        )
+
+        assert resp.status_code == 302
+        test_db.refresh(test_user)
+        assert "1999" not in (test_user.vacation or {})
+
+    def test_admin_stores_sorted_deduped_valid_weeks(self, admin_client, test_db, test_user):
+        resp = admin_client.post(
+            f"/admin/vacation/{test_user.id}/weeks",
+            data={"year": 2026, "weeks": "30, 28,28, 0, 54, abc, 29"},
+            follow_redirects=False,
+        )
+
+        assert resp.status_code == 303
+        test_db.refresh(test_user)
+        assert test_user.vacation["2026"] == [28, 29, 30]
+
+    def test_admin_out_of_range_year_is_a_noop(self, admin_client, test_db, test_user):
+        resp = admin_client.post(
+            f"/admin/vacation/{test_user.id}/weeks",
+            data={"year": 1999, "weeks": "10"},
+            follow_redirects=False,
+        )
+
+        assert resp.status_code == 302
+        test_db.refresh(test_user)
+        assert "1999" not in (test_user.vacation or {})
+
+    def test_admin_unknown_user_redirects_to_the_list(self, admin_client):
+        resp = admin_client.post(
+            "/admin/vacation/9999/weeks",
+            data={"year": 2026, "weeks": "10"},
+            follow_redirects=False,
+        )
+
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "/admin/vacation"
+
+
+class TestParentalWeeks:
+    def test_profile_stores_parental_weeks(self, user_client, test_db, test_user):
+        resp = user_client.post(
+            "/profile/vacation/parental/weeks",
+            data={"year": 2026, "weeks": "5,5,3,99"},
+            follow_redirects=False,
+        )
+
+        assert resp.status_code == 302
+        test_db.refresh(test_user)
+        assert test_user.parental_leave["2026"] == [3, 5]
+
+    def test_admin_stores_parental_weeks(self, admin_client, test_db, test_user):
+        resp = admin_client.post(
+            f"/admin/vacation/{test_user.id}/parental/weeks",
+            data={"year": 2026, "weeks": "5,5,3,99"},
+            follow_redirects=False,
+        )
+
+        assert resp.status_code == 303
+        test_db.refresh(test_user)
+        assert test_user.parental_leave["2026"] == [3, 5]
+
+
+class TestAddVacationDay:
+    def test_profile_adds_a_vacation_absence(self, user_client, test_db, test_user):
+        resp = user_client.post(
+            "/profile/vacation/day",
+            data={"vacation_date": "2026-07-15"},
+            follow_redirects=False,
+        )
+
+        assert resp.status_code == 302
+        assert _absences(test_db, test_user.id, AbsenceType.VACATION) == [datetime.date(2026, 7, 15)]
+
+    def test_profile_converts_an_existing_absence(self, user_client, test_db, test_user):
+        test_db.add(Absence(user_id=test_user.id, date=datetime.date(2026, 7, 15), absence_type=AbsenceType.SICK))
+        test_db.commit()
+
+        user_client.post(
+            "/profile/vacation/day",
+            data={"vacation_date": "2026-07-15"},
+            follow_redirects=False,
+        )
+
+        assert _absences(test_db, test_user.id, AbsenceType.SICK) == []
+        assert _absences(test_db, test_user.id, AbsenceType.VACATION) == [datetime.date(2026, 7, 15)]
+
+    def test_profile_ignores_a_malformed_date(self, user_client, test_db, test_user):
+        resp = user_client.post(
+            "/profile/vacation/day",
+            data={"vacation_date": "not-a-date"},
+            follow_redirects=False,
+        )
+
+        assert resp.status_code == 302
+        assert test_db.query(Absence).count() == 0
+
+    def test_admin_adds_a_vacation_absence(self, admin_client, test_db, test_user):
+        resp = admin_client.post(
+            f"/admin/vacation/{test_user.id}/days",
+            data={"vacation_date": "2026-07-15"},
+            follow_redirects=False,
+        )
+
+        assert resp.status_code == 303
+        assert _absences(test_db, test_user.id, AbsenceType.VACATION) == [datetime.date(2026, 7, 15)]
+
+    def test_admin_ignores_a_malformed_date(self, admin_client, test_db, test_user):
+        resp = admin_client.post(
+            f"/admin/vacation/{test_user.id}/days",
+            data={"vacation_date": "not-a-date"},
+            follow_redirects=False,
+        )
+
+        assert resp.status_code == 302
+        assert test_db.query(Absence).count() == 0
+
+
+class TestSyncVacationDays:
+    def test_profile_adds_and_removes_within_the_year(self, user_client, test_db, test_user):
+        test_db.add(Absence(user_id=test_user.id, date=datetime.date(2026, 3, 1), absence_type=AbsenceType.VACATION))
+        test_db.add(Absence(user_id=test_user.id, date=datetime.date(2025, 3, 1), absence_type=AbsenceType.VACATION))
+        test_db.add(Absence(user_id=test_user.id, date=datetime.date(2026, 4, 1), absence_type=AbsenceType.PARENTAL))
+        test_db.commit()
+
+        resp = user_client.post(
+            "/profile/vacation/days/sync",
+            data={"year": 2026, "dates": "2026-05-01, bogus, 2026-05-02", "parental_dates": "2026-04-01"},
+            follow_redirects=False,
+        )
+
+        assert resp.status_code == 302
+        assert _absences(test_db, test_user.id, AbsenceType.VACATION) == [
+            datetime.date(2025, 3, 1),  # other years are untouched
+            datetime.date(2026, 5, 1),
+            datetime.date(2026, 5, 2),
+        ]
+        assert _absences(test_db, test_user.id, AbsenceType.PARENTAL) == [datetime.date(2026, 4, 1)]
+
+    def test_profile_empty_dates_clear_the_year(self, user_client, test_db, test_user):
+        test_db.add(Absence(user_id=test_user.id, date=datetime.date(2026, 3, 1), absence_type=AbsenceType.VACATION))
+        test_db.add(Absence(user_id=test_user.id, date=datetime.date(2026, 3, 2), absence_type=AbsenceType.PARENTAL))
+        test_db.commit()
+
+        user_client.post(
+            "/profile/vacation/days/sync",
+            data={"year": 2026, "dates": "", "parental_dates": ""},
+            follow_redirects=False,
+        )
+
+        assert test_db.query(Absence).count() == 0
+
+    def test_admin_adds_and_removes_within_the_year(self, admin_client, test_db, test_user):
+        test_db.add(Absence(user_id=test_user.id, date=datetime.date(2026, 3, 1), absence_type=AbsenceType.VACATION))
+        test_db.commit()
+
+        resp = admin_client.post(
+            f"/admin/vacation/{test_user.id}/days/sync",
+            data={"year": 2026, "dates": "2026-05-01", "parental_dates": "2026-06-01"},
+            follow_redirects=False,
+        )
+
+        assert resp.status_code == 303
+        assert "2+tillagda,+1+borttagna" in resp.headers["location"]
+        assert _absences(test_db, test_user.id, AbsenceType.VACATION) == [datetime.date(2026, 5, 1)]
+        assert _absences(test_db, test_user.id, AbsenceType.PARENTAL) == [datetime.date(2026, 6, 1)]
+
+    def test_admin_reports_no_changes(self, admin_client, test_db, test_user):
+        resp = admin_client.post(
+            f"/admin/vacation/{test_user.id}/days/sync",
+            data={"year": 2026, "dates": "", "parental_dates": ""},
+            follow_redirects=False,
+        )
+
+        assert "Inga+%C3%A4ndringar" in resp.headers["location"]
+
+
+class TestDeleteVacationDay:
+    def test_profile_deletes_own_vacation_day(self, user_client, test_db, test_user):
+        absence = Absence(user_id=test_user.id, date=datetime.date(2026, 5, 1), absence_type=AbsenceType.VACATION)
+        test_db.add(absence)
+        test_db.commit()
+
+        resp = user_client.post(f"/profile/vacation/day/{absence.id}/delete", follow_redirects=False)
+
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "/profile/vacation?year=2026"
+        assert test_db.query(Absence).count() == 0
+
+    def test_profile_cannot_delete_another_users_day(self, user_client, test_db, test_user, admin_user):
+        absence = Absence(user_id=admin_user.id, date=datetime.date(2026, 5, 1), absence_type=AbsenceType.VACATION)
+        test_db.add(absence)
+        test_db.commit()
+
+        resp = user_client.post(f"/profile/vacation/day/{absence.id}/delete", follow_redirects=False)
+
+        assert resp.status_code == 302
+        assert test_db.query(Absence).count() == 1
+
+    def test_profile_ignores_a_non_vacation_absence(self, user_client, test_db, test_user):
+        absence = Absence(user_id=test_user.id, date=datetime.date(2026, 5, 1), absence_type=AbsenceType.SICK)
+        test_db.add(absence)
+        test_db.commit()
+
+        user_client.post(f"/profile/vacation/day/{absence.id}/delete", follow_redirects=False)
+
+        assert test_db.query(Absence).count() == 1
+
+    def test_admin_deletes_a_users_vacation_day(self, admin_client, test_db, test_user):
+        absence = Absence(user_id=test_user.id, date=datetime.date(2026, 5, 1), absence_type=AbsenceType.VACATION)
+        test_db.add(absence)
+        test_db.commit()
+
+        resp = admin_client.post(
+            f"/admin/vacation/{test_user.id}/days/{absence.id}/delete",
+            follow_redirects=False,
+        )
+
+        assert resp.status_code == 303
+        assert f"/admin/vacation/{test_user.id}?year=2026" in resp.headers["location"]
+        assert test_db.query(Absence).count() == 0
+
+    def test_admin_cannot_delete_across_users(self, admin_client, test_db, test_user, admin_user):
+        absence = Absence(user_id=admin_user.id, date=datetime.date(2026, 5, 1), absence_type=AbsenceType.VACATION)
+        test_db.add(absence)
+        test_db.commit()
+
+        admin_client.post(f"/admin/vacation/{test_user.id}/days/{absence.id}/delete", follow_redirects=False)
+
+        assert test_db.query(Absence).count() == 1
+
+
+class TestVacationSettings:
+    def test_profile_sets_and_clears_employment_start_date(self, user_client, test_db, test_user):
+        resp = user_client.post(
+            "/profile/vacation/settings",
+            data={"employment_start_date": "2020-02-03"},
+            follow_redirects=False,
+        )
+
+        assert resp.status_code == 302
+        test_db.refresh(test_user)
+        assert test_user.employment_start_date == datetime.date(2020, 2, 3)
+
+        user_client.post("/profile/vacation/settings", data={"employment_start_date": ""}, follow_redirects=False)
+
+        test_db.refresh(test_user)
+        assert test_user.employment_start_date is None
+
+    def test_profile_keeps_the_date_on_malformed_input(self, user_client, test_db, test_user):
+        test_user.employment_start_date = datetime.date(2020, 2, 3)
+        test_db.commit()
+
+        user_client.post(
+            "/profile/vacation/settings",
+            data={"employment_start_date": "nope"},
+            follow_redirects=False,
+        )
+
+        test_db.refresh(test_user)
+        assert test_user.employment_start_date == datetime.date(2020, 2, 3)
+
+    def test_admin_sets_all_vacation_settings(self, admin_client, test_db, test_user):
+        resp = admin_client.post(
+            f"/admin/vacation/{test_user.id}/settings",
+            data={
+                "employment_start_date": "2020-02-03",
+                "vacation_year_start_month": 4,
+                "vacation_days_per_year": 30,
+            },
+            follow_redirects=False,
+        )
+
+        assert resp.status_code == 303
+        test_db.refresh(test_user)
+        assert test_user.employment_start_date == datetime.date(2020, 2, 3)
+        assert test_user.vacation_year_start_month == 4
+        assert test_user.vacation_days_per_year == 30
+
+    def test_admin_rejects_out_of_range_settings(self, admin_client, test_db, test_user):
+        test_user.vacation_year_start_month = 4
+        test_user.vacation_days_per_year = 25
+        test_db.commit()
+
+        admin_client.post(
+            f"/admin/vacation/{test_user.id}/settings",
+            data={
+                "employment_start_date": "",
+                "vacation_year_start_month": 13,
+                "vacation_days_per_year": 99,
+            },
+            follow_redirects=False,
+        )
+
+        test_db.refresh(test_user)
+        assert test_user.vacation_year_start_month == 4
+        assert test_user.vacation_days_per_year == 25
+
+
+class TestVacationPages:
+    def test_profile_vacation_page_renders(self, user_client, test_db, test_user):
+        test_user.vacation = {"2026": [30, 28]}
+        test_db.commit()
+
+        resp = user_client.get("/profile/vacation?year=2026")
+
+        assert resp.status_code == 200
+
+    def test_admin_vacation_user_page_renders(self, admin_client, test_db, test_user):
+        test_user.vacation = {"2026": [30, 28]}
+        test_db.commit()
+
+        resp = admin_client.get(f"/admin/vacation/{test_user.id}?year=2026")
+
+        assert resp.status_code == 200
+
+    def test_admin_vacation_page_unknown_user_redirects(self, admin_client):
+        resp = admin_client.get("/admin/vacation/9999", follow_redirects=False)
+
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "/admin/vacation"
+
+
+class TestAdminGate:
+    def test_plain_user_cannot_reach_the_admin_vacation_routes(self, user_client, test_db, test_user):
+        resp = user_client.post(
+            f"/admin/vacation/{test_user.id}/weeks",
+            data={"year": 2026, "weeks": "10"},
+            follow_redirects=False,
+        )
+
+        assert resp.status_code in (302, 303, 401, 403)
+        test_db.refresh(test_user)
+        assert not (test_user.vacation or {}).get("2026")


### PR DESCRIPTION
`profile.py` and `admin.py` carried two copies of the same vacation module, about 350 duplicated lines across seven route pairs (page GET, weeks, parental weeks, days, days/sync, day delete, settings), differing only in `current_user.id` vs `user_id` and the redirect URL. `_parse_dates` and `_sync_type` were defined twice as nested closures, and the 365-iteration `determine_shift_for_date` loop that computes off-days ran in both.

This is the same profile-vs-admin pair that produced an earlier drift bug, where the admin transition save hardcoded the earning year to `None` and computed a different vacation day count than the self-service route. So the copies were diffed line by line before anything was extracted.

## Eight differences found, with verdicts

| Where | Difference | Verdict |
|---|---|---|
| weeks POST | profile re-rendered `vacation.html` with a 5-key context on an out-of-range year; admin redirected | **Live bug.** The partial context makes the template raise `TypeError: Object of type Undefined is not JSON serializable`, so it was a 500, not a 400. And `vacation.html` never renders `error` anywhere, so the message was invisible even in principle. Aligned on the admin behaviour. |
| page GET | profile passed `vacation_weeks` unsorted, admin sorted | Cosmetic drift, no visible effect since both writers store sorted. Unified. |
| weeks parsing | profile filtered 1-53 outside the `if weeks.strip()` block, admin inside | Different shape, identical result. Not a bug. |
| days/sync | admin's `_sync_type` returned (added, removed) for a flash message, profile's returned `None` | Deliberate admin/self-service distinction. Preserved. |
| settings POST | profile handles only `employment_start_date`; admin also sets `vacation_year_start_month` and `vacation_days_per_year` | Deliberate. Preserved as optional params so a self-service save cannot silently reset admin-only fields. |
| commit handling | profile wrapped `db.commit()` in try/except rollback on the weeks routes only; admin never did | Inconsistent, no known symptom. Unified on rollback and re-raise. |
| day delete | admin did not check the user exists first | Harmless (both scope the delete by `user_id` and `VACATION`), but added for consistency with its five siblings. |
| redirects | 302 to `/profile/vacation` vs 303 to `/admin/vacation/{id}?success=` | Deliberate. Preserved exactly. |

No drift in the vacation formulas themselves. Nothing under `calculate_vacation_balance` was touched.

## What was extracted

`parse_week_list`, `parse_date_list`, `is_valid_vacation_year`, `_commit` (commit, rollback, `clear_schedule_cache`), `build_vacation_page_context`, `set_vacation_weeks`, `set_parental_weeks`, `add_vacation_day`, `sync_vacation_days`, `delete_vacation_day` and `set_vacation_settings`, all in `app/core/schedule/vacation.py`. Both route modules import it as `vacation_core` to sidestep the name collision with their own handlers.

Each route is now resolve-user, call, redirect. The off-days loop exists once. `clear_schedule_cache()` fires from `_commit`, so it still runs everywhere it ran before, plus two admin paths that reached `db.commit()` by a slightly different route.

`profile.py` 821 to 637, `admin.py` 871 to 699, `vacation.py` 704 to 929. Net 131 lines gone and the duplication single-sourced.

## Tests

`tests/test_vacation_routes.py`, 30 tests, written first against the existing code, which is the first coverage these routes have had: nothing posted to `/profile/vacation*` or `/admin/vacation*` before. Covers both route sets for weeks, parental weeks, day add (including converting an existing SICK absence), day sync (add, remove, other years untouched, clear to empty), day delete including cross-user cases, settings, page render, unknown user, and the admin gate against a plain user.

Against the previous code, `test_profile_out_of_range_year_is_a_noop` fails, which is the 500 above.

742 passed, up from 712. `ruff check` and `ruff format --check` clean.