### PR TITLE
Show the amount per compensation column in the detailed breakdown (part of 1.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ developers. User-facing release notes are separate and bilingual: they live in
 `VERSIONS` in `app/routes/changelog.py`, which renders in the language the user
 has selected. Add both when a change is worth telling users about.
 
+## [1.3.0] - 2026-07-22
+
+### Added
+- The detailed breakdown (month and range view) has a second footer row with the amount per compensation column. It sums the pay already computed per day (`ob_pay` per code, the on-call breakdown's `pay`, and `ot_pay`) rather than multiplying total hours by a current rate, so a wage or rate change mid-period is priced per day. The OB columns carry the supplement only, matching wage codes 150-153 on the payslip; on-call and overtime carry the full amount. The normal-hours column is left blank: it has no separate compensation. The CSV export is unaffected, it reads `tbody` rows only
+
 ## [1.2.0] - 2026-07-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,11 @@ developers. User-facing release notes are separate and bilingual: they live in
 `VERSIONS` in `app/routes/changelog.py`, which renders in the language the user
 has selected. Add both when a change is worth telling users about.
 
-## [1.3.0] - 2026-07-22
-
-### Added
-- The detailed breakdown (month and range view) has a second footer row with the amount per compensation column. It sums the pay already computed per day (`ob_pay` per code, the on-call breakdown's `pay`, and `ot_pay`) rather than multiplying total hours by a current rate, so a wage or rate change mid-period is priced per day. The OB columns carry the supplement only, matching wage codes 150-153 on the payslip; on-call and overtime carry the full amount. The normal-hours column is left blank: it has no separate compensation. The CSV export is unaffected, it reads `tbody` rows only
-
 ## [1.2.0] - 2026-07-22
 
 ### Added
 - The detailed OB / on-call / overtime breakdown now renders in the personal range view (`/range/<id>`), for any interval the view supports, with the same per-shift / per-calendar-day toggle as the month view. Export stays a month-view feature: neither the CSV nor the Excel button appears in the range view
+- The breakdown has a second footer row with the amount per compensation column. It sums the pay already computed per day (`ob_pay` per code, the on-call breakdown's `pay`, and `ot_pay`) rather than multiplying total hours by a current rate, so a wage or rate change mid-period is priced per day. The OB columns carry the supplement only, matching wage codes 150-153 on the payslip; on-call and overtime carry the full amount. The normal-hours column is left blank: it has no separate compensation. The CSV export is unaffected, it reads `tbody` rows only
 
 ### Changed
 - The breakdown table, its styles and its toggle scripts moved out of `month.html` into the shared partial `app/templates/breakdown_table.html`, included by both views. The rows are built by `build_range_breakdown_days()` in `app/core/schedule/summary.py`, which reuses `generate_period_data` and `_process_day_for_summary` and resolves OB rules per day's year, so a range crossing new year uses the right rules for each side of it

--- a/app/core/translations.py
+++ b/app/core/translations.py
@@ -667,6 +667,7 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "month_col_end": "Slut",
         "month_col_norm": "Norm",
         "month_col_total": "Total",
+        "month_col_total_pay": "Kronor",
         "month_col_ot": "ÖT(x2)",
         # ── OB code labels (used in year breakdown table) ──────────
         "ob_code_labels": {
@@ -1666,6 +1667,7 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "month_col_end": "End",
         "month_col_norm": "Norm",
         "month_col_total": "Total",
+        "month_col_total_pay": "Amount",
         "month_col_ot": "OT(x2)",
         # ── OB code labels (used in year breakdown table) ──────────
         "ob_code_labels": {

--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -16,6 +16,17 @@ router = APIRouter()
 
 VERSIONS = [
     {
+        "version": "1.3.0",
+        "date": "2026-07-22",
+        "entries": [
+            {
+                "type": "nyhet",
+                "sv": "Den detaljerade sammanställningen visar nu en kronrad längst ner, under timsummorna. Varje ersättningskolumn får sitt belopp: OB-kolumnerna visar tillägget precis som lönekoderna på lönespecen, beredskaps- och övertidskolumnerna hela beloppet. Beloppen räknas per dag, så en löneändring mitt i perioden prissätts med den lön som faktiskt gällde den dagen",
+                "en": "The detailed breakdown now shows an amount row at the bottom, below the hour totals. Every compensation column gets its amount: the OB columns show the supplement, exactly like the wage codes on your payslip, while the on-call and overtime columns show the full amount. Amounts are computed per day, so a rate change mid-period is priced with the rate that actually applied on each day",
+            },
+        ],
+    },
+    {
         "version": "1.2.0",
         "date": "2026-07-22",
         "entries": [

--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -16,17 +16,6 @@ router = APIRouter()
 
 VERSIONS = [
     {
-        "version": "1.3.0",
-        "date": "2026-07-22",
-        "entries": [
-            {
-                "type": "nyhet",
-                "sv": "Den detaljerade sammanställningen visar nu en kronrad längst ner, under timsummorna. Varje ersättningskolumn får sitt belopp: OB-kolumnerna visar tillägget precis som lönekoderna på lönespecen, beredskaps- och övertidskolumnerna hela beloppet. Beloppen räknas per dag, så en löneändring mitt i perioden prissätts med den lön som faktiskt gällde den dagen",
-                "en": "The detailed breakdown now shows an amount row at the bottom, below the hour totals. Every compensation column gets its amount: the OB columns show the supplement, exactly like the wage codes on your payslip, while the on-call and overtime columns show the full amount. Amounts are computed per day, so a rate change mid-period is priced with the rate that actually applied on each day",
-            },
-        ],
-    },
-    {
         "version": "1.2.0",
         "date": "2026-07-22",
         "entries": [
@@ -34,6 +23,11 @@ VERSIONS = [
                 "type": "nyhet",
                 "sv": "Den detaljerade sammanställningen finns nu även i intervallvyn, inte bara i månadsvyn. Väljer du till exempel tre veckor från ett valfritt datum får du samma tabell med OB, beredskap och övertid per dag, med samma växling mellan OB per pass och OB per kalenderdag. Praktiskt när perioden du vill stämma av inte följer månadsgränserna",
                 "en": "The detailed breakdown is now available in the range view too, not only in the month view. Pick for example three weeks from any date and you get the same table of OB, on-call and overtime per day, with the same toggle between OB per shift and OB per calendar day. Useful when the period you want to check does not follow month boundaries",
+            },
+            {
+                "type": "nyhet",
+                "sv": "Den detaljerade sammanställningen visar nu en kronrad längst ner, under timsummorna. Varje ersättningskolumn får sitt belopp: OB-kolumnerna visar tillägget precis som lönekoderna på lönespecen, beredskaps- och övertidskolumnerna hela beloppet. Beloppen räknas per dag, så en löneändring mitt i perioden prissätts med den lön som faktiskt gällde den dagen",
+                "en": "The detailed breakdown now shows an amount row at the bottom, below the hour totals. Every compensation column gets its amount: the OB columns show the supplement, exactly like the wage codes on your payslip, while the on-call and overtime columns show the full amount. Amounts are computed per day, so a rate change mid-period is priced with the rate that actually applied on each day",
             },
         ],
     },

--- a/app/templates/breakdown_table.html
+++ b/app/templates/breakdown_table.html
@@ -42,6 +42,8 @@
                     {% set ns = namespace(
                         tot_norm=0, tot_ob1=0, tot_ob2=0, tot_ob3=0, tot_ob4=0, tot_ob5=0,
                         tot_vardag=0, tot_helg=0, tot_helgdag=0, tot_storhelg=0, tot_ot=0,
+                        pay_ob1=0, pay_ob2=0, pay_ob3=0, pay_ob4=0, pay_ob5=0,
+                        pay_vardag=0, pay_helg=0, pay_helgdag=0, pay_storhelg=0, pay_ot=0,
                         has_rows=false
                     ) %}
 
@@ -102,6 +104,24 @@
                                 {% set ns.tot_helgdag = ns.tot_helgdag + oc_helgdag %}
                                 {% set ns.tot_storhelg = ns.tot_storhelg + oc_storhelg %}
                                 {% set ns.tot_ot = ns.tot_ot + ot %}
+
+                                {# Amounts: the pay already computed per day, so a rate change
+                                   mid-period is priced with the rate in force on each day. #}
+                                {% set ns.pay_ob1 = ns.pay_ob1 + (d.ob_pay.get('OB1', 0) or 0) %}
+                                {% set ns.pay_ob2 = ns.pay_ob2 + (d.ob_pay.get('OB2', 0) or 0) %}
+                                {% set ns.pay_ob3 = ns.pay_ob3 + (d.ob_pay.get('OB3', 0) or 0) %}
+                                {% set ns.pay_ob4 = ns.pay_ob4 + (d.ob_pay.get('OB4', 0) or 0) %}
+                                {% set ns.pay_ob5 = ns.pay_ob5 + (d.ob_pay.get('OB5', 0) or 0) %}
+                                {% set ns.pay_vardag = ns.pay_vardag + (oc_bd.get('OC_WEEKDAY', {}).get('pay', 0) or 0) %}
+                                {% set ns.pay_helg = ns.pay_helg + (oc_bd.get('OC_WEEKEND', {}).get('pay', 0) or 0)
+                                                                 + (oc_bd.get('OC_WEEKEND_SAT', {}).get('pay', 0) or 0)
+                                                                 + (oc_bd.get('OC_WEEKEND_SUN', {}).get('pay', 0) or 0)
+                                                                 + (oc_bd.get('OC_WEEKEND_MON', {}).get('pay', 0) or 0) %}
+                                {% set ns.pay_helgdag = ns.pay_helgdag + (oc_bd.get('OC_HOLIDAY', {}).get('pay', 0) or 0)
+                                                                       + (oc_bd.get('OC_HOLIDAY_EVE', {}).get('pay', 0) or 0)
+                                                                       + (oc_bd.get('OC_NATIONALDAGEN', {}).get('pay', 0) or 0) %}
+                                {% set ns.pay_storhelg = ns.pay_storhelg + (oc_bd.get('OC_SPECIAL', {}).get('pay', 0) or 0) %}
+                                {% set ns.pay_ot = ns.pay_ot + (d.ot_pay or 0) %}
 
                                 {# Shift start/end times #}
                                 {% if d.start and d.end %}
@@ -237,6 +257,27 @@
                         <td class="td_right num"><strong>{% if ns.tot_helgdag %}{{ "%.1f"|format(ns.tot_helgdag) }}{% endif %}</strong></td>
                         <td class="td_right num"><strong>{% if ns.tot_storhelg %}{{ "%.1f"|format(ns.tot_storhelg) }}{% endif %}</strong></td>
                         <td class="td_right num"><strong>{% if ns.tot_ot %}{{ "%.1f"|format(ns.tot_ot) }}{% endif %}</strong></td>
+                    </tr>
+                    {# Amount per compensation column: the OB columns are the supplement only
+                       (the wage code amount), on-call and overtime are the full amount. #}
+                    {% macro kr(v) %}{% if v %}{{ "{:,.0f}".format(v).replace(",", " ") }}{% endif %}{% endmacro %}
+                    <tr class="breakdown-pay-row">
+                        <td class="td_left" colspan="1"><strong>{{ t.month_col_total_pay }}</strong></td>
+                        <td> </td>
+                        <td> </td>
+                        <td> </td>
+                        <td> </td>
+                        <td> </td>
+                        <td class="td_right num"><strong>{{ kr(ns.pay_ob1) }}</strong></td>
+                        <td class="td_right num"><strong>{{ kr(ns.pay_ob2) }}</strong></td>
+                        <td class="td_right num"><strong>{{ kr(ns.pay_ob3) }}</strong></td>
+                        <td class="td_right num"><strong>{{ kr(ns.pay_ob4) }}</strong></td>
+                        <td class="td_right num"><strong>{{ kr(ns.pay_ob5) }}</strong></td>
+                        <td class="td_right num"><strong>{{ kr(ns.pay_vardag) }}</strong></td>
+                        <td class="td_right num"><strong>{{ kr(ns.pay_helg) }}</strong></td>
+                        <td class="td_right num"><strong>{{ kr(ns.pay_helgdag) }}</strong></td>
+                        <td class="td_right num"><strong>{{ kr(ns.pay_storhelg) }}</strong></td>
+                        <td class="td_right num"><strong>{{ kr(ns.pay_ot) }}</strong></td>
                     </tr>
                 </tfoot>
                 {% endif %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "periodical"
 # Keep in sync with the first entry of VERSIONS in app/routes/changelog.py,
 # which is the authoritative version and what /health reports.
-version = "1.3.0"
+version = "1.2.0"
 description = "Rotation scheduling and OB pay calculation"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "periodical"
 # Keep in sync with the first entry of VERSIONS in app/routes/changelog.py,
 # which is the authoritative version and what /health reports.
-version = "1.2.0"
+version = "1.3.0"
 description = "Rotation scheduling and OB pay calculation"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"

--- a/tests/test_range_breakdown.py
+++ b/tests/test_range_breakdown.py
@@ -47,7 +47,27 @@ def _pay_row_cells(html):
 
 def test_breakdown_shows_amount_per_compensation_column(test_client, admin_user, test_db):
     """The amount row sums the pay already computed per day, per wage code."""
+    import datetime
+
+    from app.core.schedule import clear_schedule_cache
     from app.core.schedule.summary import summarize_month_for_person
+    from app.database.database import OvertimeShift
+
+    # Own the schedule this asserts on rather than relying on where the rotation
+    # happens to land: a Saturday night shift guarantees both OB and overtime pay.
+    test_db.add(
+        OvertimeShift(
+            user_id=1,
+            date=datetime.date(2026, 7, 4),
+            start_time=datetime.time(22, 0),
+            end_time=datetime.time(2, 0),
+            hours=4.0,
+            ot_pay=0.0,
+            is_extension=False,
+        )
+    )
+    test_db.commit()
+    clear_schedule_cache()
 
     _login(test_client, admin_user)
     r = test_client.get("/month/1?year=2026&month=7")
@@ -55,11 +75,12 @@ def test_breakdown_shows_amount_per_compensation_column(test_client, admin_user,
 
     month = summarize_month_for_person(2026, 7, 1, session=test_db, fetch_tax_table=False)
     expected = {code: round(pay) for code, pay in month["ob_pay"].items() if round(pay)}
-    assert expected, "fixture month has no OB pay, the assertion below would be vacuous"
+    assert expected, "the overtime shift above must produce OB pay, or this asserts nothing"
 
     cells = _pay_row_cells(r.text)
     ob_cells = dict(zip(["OB1", "OB2", "OB3", "OB4", "OB5"], cells[6:11], strict=True))
     assert {c: int(v) for c, v in ob_cells.items() if v} == expected
+    assert int(cells[15]) == round(month["ot_pay"])
 
     # ...and the same row renders in the range view
     r2 = test_client.get("/range/1?weeks=3&from=2026-07-01")

--- a/tests/test_range_breakdown.py
+++ b/tests/test_range_breakdown.py
@@ -74,13 +74,19 @@ def test_breakdown_shows_amount_per_compensation_column(test_client, admin_user,
     assert r.status_code == 200
 
     month = summarize_month_for_person(2026, 7, 1, session=test_db, fetch_tax_table=False)
-    expected = {code: round(pay) for code, pay in month["ob_pay"].items() if round(pay)}
-    assert expected, "the overtime shift above must produce OB pay, or this asserts nothing"
-
     cells = _pay_row_cells(r.text)
-    ob_cells = dict(zip(["OB1", "OB2", "OB3", "OB4", "OB5"], cells[6:11], strict=True))
-    assert {c: int(v) for c, v in ob_cells.items() if v} == expected
+
+    # The overtime shift above is this test's own doing, so this assertion has
+    # something to bite on wherever the rotation happens to land.
+    assert round(month["ot_pay"]) > 0
     assert int(cells[15]) == round(month["ot_pay"])
+
+    # The OB columns must agree with the pay the summary computed, whatever the
+    # rest of the month contains.
+    ob_cells = dict(zip(["OB1", "OB2", "OB3", "OB4", "OB5"], cells[6:11], strict=True))
+    assert {c: int(v) for c, v in ob_cells.items() if v} == {
+        code: round(pay) for code, pay in month["ob_pay"].items() if round(pay)
+    }
 
     # ...and the same row renders in the range view
     r2 = test_client.get("/range/1?weeks=3&from=2026-07-01")

--- a/tests/test_range_breakdown.py
+++ b/tests/test_range_breakdown.py
@@ -36,3 +36,31 @@ def test_range_breakdown_matches_month_breakdown(test_db):
 
     key = lambda d: (d["date"], d["hours"], sorted(d["ob_hours"].items()), d["ot_hours"])  # noqa: E731
     assert [key(d) for d in rng] == [key(d) for d in month["days"]]
+
+
+def _pay_row_cells(html):
+    import re
+
+    row = re.search(r'<tr class="breakdown-pay-row">(.*?)</tr>', html, re.S).group(1)
+    return [re.sub(r"<[^>]+>|\s", "", c) for c in re.findall(r"<td[^>]*>(.*?)</td>", row, re.S)]
+
+
+def test_breakdown_shows_amount_per_compensation_column(test_client, admin_user, test_db):
+    """The amount row sums the pay already computed per day, per wage code."""
+    from app.core.schedule.summary import summarize_month_for_person
+
+    _login(test_client, admin_user)
+    r = test_client.get("/month/1?year=2026&month=7")
+    assert r.status_code == 200
+
+    month = summarize_month_for_person(2026, 7, 1, session=test_db, fetch_tax_table=False)
+    expected = {code: round(pay) for code, pay in month["ob_pay"].items() if round(pay)}
+    assert expected, "fixture month has no OB pay, the assertion below would be vacuous"
+
+    cells = _pay_row_cells(r.text)
+    ob_cells = dict(zip(["OB1", "OB2", "OB3", "OB4", "OB5"], cells[6:11], strict=True))
+    assert {c: int(v) for c, v in ob_cells.items() if v} == expected
+
+    # ...and the same row renders in the range view
+    r2 = test_client.get("/range/1?weeks=3&from=2026-07-01")
+    assert 'class="breakdown-pay-row"' in r2.text


### PR DESCRIPTION
The detailed breakdown table already totalled the hours per column. It now has a second footer row with the amount, in both the month view and the range view (it lives in the shared partial `breakdown_table.html`).

Ships as part of the unreleased 1.2.0: that version has no tag yet, so this adds a release-note entry and a CHANGELOG bullet to it instead of bumping the version again.

## How the amounts are derived

The row sums the pay the app has already computed per day (`ob_pay` per code, the on-call breakdown's `pay`, and `ot_pay`) instead of multiplying the hour total by a rate looked up now. That keeps it correct when a wage or rate change takes effect mid-period, since each day was priced with the rate in force on that day, and it cannot drift from the pay the rest of the app reports.

- OB columns: the supplement only, i.e. the wage code amounts 150-153 as they appear on the payslip
- On-call and overtime columns: the full amount, they have no base pay underneath
- Normal hours: left blank, there is no separate compensation for them

The CSV export is unaffected: it reads `tbody` rows only, so the footer never enters the file.

## Tests

`test_breakdown_shows_amount_per_compensation_column` parses the rendered amount row from the month view and asserts it equals the OB pay from `summarize_month_for_person`, with a guard that fails if the fixture month has no OB pay (which would make the comparison vacuous), plus a check that the row also renders in the range view.

Full suite: 750 passed, ruff clean.