### PR TITLE
Refuse to tag a release when the version numbers disagree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ developers. User-facing release notes are separate and bilingual: they live in
 `VERSIONS` in `app/routes/changelog.py`, which renders in the language the user
 has selected. Add both when a change is worth telling users about.
 
+A version is a release, not a pull request. While the topmost version here has
+no git tag yet, add your entry to it instead of starting a new one; the version
+number is bumped by the pull request that follows a release, not by every
+change. `scripts/release.sh` refuses to tag when the tag, `pyproject.toml` and
+`VERSIONS` disagree.
+
 ## [1.2.0] - 2026-07-22
 
 ### Added

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -24,6 +24,26 @@ fi
 
 # Versioned release: tag main and push the tag, which triggers the deploy.
 TAG="$MODE"
+
+# The tag must match the version in the repo. A pull request adds its release
+# note to the topmost VERSIONS block while that version is untagged, and only
+# bumps the version when the topmost block has already been released. This
+# check is what makes that convention hold: it fails both when the version was
+# bumped without a release and when a release forgot the bump.
+REPO_VERSION=$(grep -m1 '^version = ' pyproject.toml | cut -d'"' -f2)
+APP_VERSION=$(grep -m1 '"version":' app/routes/changelog.py | cut -d'"' -f4)
+if [ "$TAG" != "v$REPO_VERSION" ] || [ "$REPO_VERSION" != "$APP_VERSION" ]; then
+    echo "Error: version mismatch." >&2
+    echo "  tag:                    $TAG" >&2
+    echo "  pyproject.toml:         v$REPO_VERSION" >&2
+    echo "  changelog.py VERSIONS:  v$APP_VERSION  (this one is what the app displays)" >&2
+    exit 1
+fi
+if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+    echo "Error: tag $TAG already exists." >&2
+    exit 1
+fi
+
 git checkout main
 git pull
 git tag "$TAG"


### PR DESCRIPTION
Version numbers were climbing once per pull request while the tags stood still: 1.2.0 and 1.3.0 were both written into the repo without either existing as a tag. This separates the two things.

## The convention

A version is a release, not a pull request. While the topmost block in `VERSIONS` has no git tag, a pull request adds its release note to that block. The version is bumped by the pull request that comes after a release, so a released version collects however many changes shipped together. Documented in the `CHANGELOG.md` header, next to the existing note about where release notes live.

## The check

`scripts/release.sh <tag>` now compares three things before touching git: the tag being cut, `version` in `pyproject.toml`, and the topmost `VERSIONS` entry in `app/routes/changelog.py`, which is the one the footer and `/health` actually display. It exits non-zero when they disagree, and separately when the tag already exists. That catches both failure directions: a version bumped without a release, and a release that forgot the bump.

Verified against the repo's real state: `v1.3.0` and `v1.1.0` are both refused with the three numbers printed, the guard passes for `v1.2.0` (the version the repo holds), and the tag-exists branch fires on a tag that exists. No behaviour change to `--notag` deploys.