### PR TITLE
Stop counting standalone overtime hours twice

### DIFF
--- a/app/core/schedule/summary.py
+++ b/app/core/schedule/summary.py
@@ -745,6 +745,23 @@ def build_calendar_grid_for_month(
     }
 
 
+def day_worked_hours(day: dict) -> float:
+    """Hours actually worked on one day, each hour counted exactly once.
+
+    On-call standby (OC) is availability, not worked time, so it contributes nothing.
+    A standalone overtime shift replaces the day's shift with OT and copies the OT
+    hours into "hours" (_apply_ot_display_shift), so for an OT day the hours must be
+    taken from ot_hours alone; an overtime extension keeps the underlying shift and
+    its ot_hours are added on top.
+
+    The week summary in routes/dashboard.py uses this too, so week, month and year
+    figures cannot drift apart.
+    """
+    code = getattr(day.get("shift"), "code", None)
+    shift_hours = 0.0 if code in (None, "OC", "OT") else day.get("hours", 0.0) or 0.0
+    return shift_hours + (day.get("ot_hours", 0.0) or 0.0)
+
+
 def _process_day_for_summary(
     day: dict,
     combined_rules: list,
@@ -799,9 +816,8 @@ def _process_day_for_summary(
         date_next_day = end.date()
         weekday_name_next_day = weekday_names[date_next_day.weekday()]
 
-    # Update totals (exclude OC from shifts and hours)
-    if shift and shift.code != "OC":
-        totals["total_hours"] += hours
+    # Update totals (worked hours, each hour counted once)
+    totals["total_hours"] += day_worked_hours(day)
 
     # "Antal pass" counts actual worked shifts only: day/evening/night and overtime.
     # On-call standby (OC) and all leave/absence days (OFF, SEM, SICK, VAB, LEAVE) are excluded.
@@ -854,7 +870,6 @@ def _process_day_for_summary(
     totals["oncall_hours"] += oncall_hours
     totals["ot_pay"] += ot_pay
     totals["ot_hours"] = totals.get("ot_hours", 0.0) + ot_hours
-    totals["total_hours"] += ot_hours
 
     return {
         "date": day["date"],
@@ -1452,14 +1467,7 @@ def _report_row_from_summary(summary: dict, is_substitute: bool) -> dict:
     def _ob_sum(*codes: str) -> float:
         return round(sum(float(ob_hours_map.get(c, 0.0) or 0.0) for c in codes), 1)
 
-    # Hours = worked shift hours (day/evening/night) plus overtime, each counted once.
-    # summary["total_hours"] cannot be used directly: it double-counts non-extension OT.
     ot_hours = float(summary.get("ot_hours", 0.0) or 0.0)
-    worked_pass_hours = sum(
-        float(d.get("hours", 0.0) or 0.0)
-        for d in (summary.get("days") or [])
-        if d.get("shift") is not None and getattr(d["shift"], "code", None) in ("N1", "N2", "N3")
-    )
 
     return {
         "person_name": summary.get("person_name", ""),
@@ -1467,7 +1475,8 @@ def _report_row_from_summary(summary: dict, is_substitute: bool) -> dict:
         "substitute_id": summary.get("substitute_id"),
         "is_substitute": is_substitute,
         "num_shifts": summary.get("num_shifts", 0) or 0,
-        "total_hours": round(worked_pass_hours + ot_hours, 1),
+        # Worked shift hours plus overtime, each counted once (see day_worked_hours).
+        "total_hours": round(float(summary.get("total_hours", 0.0) or 0.0), 1),
         "ot_hours": round(ot_hours, 1),
         "oncall_hours": round(summary.get("oncall_hours", 0.0) or 0.0, 1),
         # OB split into pay-code groups: evening, night, weekend, major holiday

--- a/app/routes/dashboard.py
+++ b/app/routes/dashboard.py
@@ -24,6 +24,7 @@ from app.core.schedule import (
     rotation_start_date,
 )
 from app.core.schedule.ob import compute_day_ob_pay
+from app.core.schedule.summary import day_worked_hours
 from app.core.schedule.wages import (
     KARENS_HOURS,
     calculate_absence_deduction,
@@ -266,7 +267,7 @@ async def read_root(
 
     # Calculate week summary by summing the canonical day dicts. The only rules applied
     # here are the summary's own aggregation rules (OB through the shared compute_day_ob_pay
-    # gate, on-call hours excluded from worked hours, OT hours added), mirroring
+    # gate, worked hours through the shared day_worked_hours helper), mirroring
     # _process_day_for_summary so the week, month and year figures cannot drift apart.
     week_summary = None
     if week_data:
@@ -287,10 +288,7 @@ async def read_root(
             if show_salary:
                 total_pay += sum(day_ob_pay.values())
 
-            shift = day.get("shift")
-            if shift and shift.code != "OC":
-                total_hours += day.get("hours", 0.0)
-            total_hours += day.get("ot_hours", 0.0)
+            total_hours += day_worked_hours(day)
 
         week_summary = {
             "total_hours": total_hours,

--- a/tests/test_dashboard_week_summary.py
+++ b/tests/test_dashboard_week_summary.py
@@ -24,6 +24,7 @@ import app.routes.dashboard as dashboard_module
 from app.auth.auth import create_access_token
 from app.core.schedule import _cached_special_rules, clear_schedule_cache, generate_period_data, ob_rules
 from app.core.schedule.ob import compute_day_ob_pay
+from app.core.schedule.summary import day_worked_hours
 from app.database.database import (
     Absence,
     AbsenceType,
@@ -134,10 +135,7 @@ def _canonical_week_summary(session) -> dict:
         hours, pay, _ = compute_day_ob_pay(day, combined_rules, WAGE)
         ob_hours += sum(hours.values())
         ob_pay += sum(pay.values())
-        shift = day.get("shift")
-        if shift and shift.code != "OC":
-            total_hours += day.get("hours", 0.0)
-        total_hours += day.get("ot_hours", 0.0)
+        total_hours += day_worked_hours(day)
     return {
         "total_hours": round(total_hours, 2),
         "ob_hours": round(ob_hours, 2),
@@ -160,10 +158,13 @@ def test_week_summary_figures(dash_env):
     total_hours 50.5, ob_hours 38.5 and total_pay 2837.50 for this same week: it
     priced OB on the overtime day (which carries no OB anywhere else) and counted
     the OT day's hours from the OT shift type's nominal length.
+
+    total_hours is 4 x 8.5h N3 plus the 8h OT day = 42.0. It read 50.0 until the
+    OT hours stopped being counted twice (once as the day's hours, once as OT).
     """
     client, _, captured = dash_env
     assert _rounded(_week_summary(client, captured)) == {
-        "total_hours": 50.0,
+        "total_hours": 42.0,
         "ob_hours": 34.0,
         "total_pay": 2612.5,
         "oc_pay": 1800.0,

--- a/tests/test_summary_characterization.py
+++ b/tests/test_summary_characterization.py
@@ -30,7 +30,16 @@ from app.core.schedule.summary import (
     _hourly_corrected_gross,
     summarize_month_for_person,
 )
-from app.database.database import Absence, AbsenceType, Base, RotationEra, User, UserRole, WageType
+from app.database.database import (
+    Absence,
+    AbsenceType,
+    Base,
+    OvertimeShift,
+    RotationEra,
+    User,
+    UserRole,
+    WageType,
+)
 
 YEAR = 2026
 MONTH = 3
@@ -195,3 +204,110 @@ def test_summary_reflects_a_sick_day(char_session):
     assert s["sick_days"] == 1
     assert s["absence_deduction"] > 0
     assert s["brutto_pay"] < baseline["brutto_pay"]
+
+
+# --- Overtime hour accounting (issue: OT hours counted twice) -------------------
+#
+# 2026-03-09 is an OFF day for person 1 and 2026-03-25 an N1 day (06:00-14:30),
+# so the two OT variants can be pinned on days with no OB and no on-call.
+OT_FREE_DAY = datetime.date(2026, 3, 9)
+OT_WORK_DAY = datetime.date(2026, 3, 25)
+HOURLY_RATE = 200
+
+
+def _add_ot(session, date, start, end, hours, is_extension):
+    session.add(
+        OvertimeShift(
+            user_id=1,
+            date=date,
+            start_time=datetime.time(*start),
+            end_time=datetime.time(*end),
+            hours=hours,
+            ot_pay=0.0,
+            is_extension=is_extension,
+        )
+    )
+    session.commit()
+    clear_schedule_cache()
+
+
+def _make_hourly(session):
+    user = session.query(User).filter(User.id == 1).first()
+    user.wage_type = WageType.HOURLY
+    user.wage = HOURLY_RATE
+    session.commit()
+    clear_schedule_cache()
+
+
+def _summary(session):
+    return summarize_month_for_person(YEAR, MONTH, PERSON_ID, session=session, wage_user_id=1)
+
+
+def test_monthly_baseline_has_no_overtime(char_session):
+    s = _summary(char_session)
+    assert s["total_hours"] == 144.5
+    assert s["ot_hours"] == 0.0
+    assert s["brutto_pay"] == 44207.0
+
+
+def test_monthly_standalone_ot_day_counts_hours_once(char_session):
+    baseline = _summary(char_session)
+    _add_ot(char_session, OT_FREE_DAY, (8, 0), (16, 0), 8.0, is_extension=False)
+
+    s = _summary(char_session)
+
+    # A standalone (non-extension) OT shift replaces the day's shift with OT,
+    # so its 8 hours are worked hours, counted exactly once.
+    assert s["ot_hours"] == 8.0
+    assert s["total_hours"] == baseline["total_hours"] + 8.0
+    # Monthly pay: the monthly base is untouched, OT is paid at wage/72.
+    assert s["brutto_pay"] == pytest.approx(baseline["brutto_pay"] + 8.0 * WAGE / 72)
+
+
+def test_monthly_extension_ot_counts_shift_and_ot(char_session):
+    baseline = _summary(char_session)
+    _add_ot(char_session, OT_WORK_DAY, (14, 30), (16, 30), 2.0, is_extension=True)
+
+    s = _summary(char_session)
+
+    # An extension keeps the 8.5h shift and adds 2h on top.
+    assert s["ot_hours"] == 2.0
+    assert s["total_hours"] == baseline["total_hours"] + 2.0
+    assert s["brutto_pay"] == pytest.approx(baseline["brutto_pay"] + 2.0 * WAGE / 72)
+
+
+def test_hourly_baseline_pays_scheduled_hours(char_session):
+    _make_hourly(char_session)
+    s = _summary(char_session)
+
+    assert s["total_hours"] == 144.5
+    # Gross = worked hours x hourly rate, plus OB and on-call on top.
+    ob_total = sum(s["ob_pay"].values())
+    assert s["brutto_pay"] == pytest.approx(144.5 * HOURLY_RATE + ob_total + s["oncall_pay"])
+
+
+def test_hourly_standalone_ot_day_is_paid_once(char_session):
+    _make_hourly(char_session)
+    baseline = _summary(char_session)
+    _add_ot(char_session, OT_FREE_DAY, (8, 0), (16, 0), 8.0, is_extension=False)
+
+    s = _summary(char_session)
+
+    # The 8 OT hours are paid through ot_pay only; they must not also be billed
+    # as ordinary worked hours.
+    assert s["ot_hours"] == 8.0
+    assert s["ot_pay"] == pytest.approx(8.0 * HOURLY_RATE)
+    assert s["total_hours"] == baseline["total_hours"] + 8.0
+    assert s["brutto_pay"] == pytest.approx(baseline["brutto_pay"] + 8.0 * HOURLY_RATE)
+
+
+def test_hourly_extension_ot_pays_shift_plus_ot(char_session):
+    _make_hourly(char_session)
+    baseline = _summary(char_session)
+    _add_ot(char_session, OT_WORK_DAY, (14, 30), (16, 30), 2.0, is_extension=True)
+
+    s = _summary(char_session)
+
+    assert s["ot_hours"] == 2.0
+    assert s["total_hours"] == baseline["total_hours"] + 2.0
+    assert s["brutto_pay"] == pytest.approx(baseline["brutto_pay"] + 2.0 * HOURLY_RATE)


### PR DESCRIPTION
**This changes what hourly-wage users are paid. Please read the payout section before merging.**

## The bug

`_apply_ot_display_shift` replaces a day's shift with OT and sets `hours = ot_shift.hours` when `is_extension` is False. `_process_day_for_summary` then added those hours twice:

```python
if shift and shift.code != "OC":
    totals["total_hours"] += hours      # OT is not OC, so this fires
totals["total_hours"] += ot_hours       # and fires again
```

`is_extension` defaults to False, so this is the **normal** overtime case, not an edge case. In the dev database all 25 overtime shifts have `is_extension = 0`.

An 8h standalone overtime shift contributed 16 hours. An extension (8.5h shift plus 2h overtime) was correct at 10.5.

## Hourly users were paid twice for it

For hourly users, `summarize_month_for_person` computes `worked_hours = total_hours - ot_hours` and pays that at the hourly rate, while `get_ot_hourly_rate_from_stored_wage` returns the raw hourly rate for hourly users, so `ot_pay` already paid those hours in full. Measured through `summarize_month_for_person`, seeded rotation, March 2026:

| Case | total_hours | ot_pay | gross delta before | gross delta after |
|---|---|---|---|---|
| MONTHLY, standalone 8h OT | 160.5 | 3333.33 | +3333.33 | +3333.33 (unchanged) |
| MONTHLY, extension 2h OT | 146.5 | 833.33 | +833.33 | +833.33 (unchanged) |
| HOURLY 200 kr/h, standalone 8h OT | 160.5 | 1600.00 | **+3200.00** | **+1600.00** |
| HOURLY, extension 2h OT | 146.5 | 400.00 | +400.00 | +400.00 (unchanged) |

The decisive evidence that this is a bug rather than a deliberate double-rate policy: the two overtime variants disagreed. An extension paid its overtime hours at 1.0x the hourly rate, a standalone shift at 2.0x, same user, same rate function, differing only by `is_extension`.

`get_ot_hourly_rate_from_stored_wage` is correct as written and was not touched. Monthly users get `wage/72`, a supplement on top of a fixed monthly base, so inflated hours never reached monthly pay.

## What changes

- **Hourly users with at least one standalone overtime shift in a month**: gross drops by `standalone_ot_hours x hourly_rate`, exactly the duplicate. Net drops correspondingly. Anything already paid on the old figure was an overpayment of exactly `ot_pay` for those shifts, so it is worth checking historical payslips for the hourly user in production.
- **Hourly users whose overtime is all extensions**: no change.
- **Monthly users**: no pay change at all, gross and net byte-identical. Only displayed hours change.
- **Displayed hours, everyone**: `total_hours` in year, statistics, month and dashboard views, the monthly report and CSV, drops by the standalone overtime hours. The derived `gross_pay / total_hours` and `ob_hours / total_hours` figures move toward their true values with no code change, once the denominator is right.

## The fix

`total_hours` now means hours actually worked, counted once, which is what all four consumers needed and what the substitute path in `period.py` already produced. `day_worked_hours(day)` holds the per-day rule: on-call contributes nothing, an OT-coded day takes its hours from `ot_hours` only, everything else is shift hours plus any extension overtime.

`dashboard.py` had a verbatim copy of the same two-line rule and therefore the same bug; it now calls the shared helper, which is what its own comment about not drifting already claimed.

`_report_row_from_summary` carried a workaround that recomputed hours from the day list, with a comment naming the double count. Absence days carry `hours == 0.0`, verified, so the workaround now equals `summary["total_hours"]` and is gone.

## Tests

756 passed, up from 750. Six new characterization tests cover baseline, standalone OT and extension OT for both monthly and hourly users; two fail against the previous code, exactly on the double count.

`tests/test_dashboard_week_summary.py` needed updating: its `_canonical_week_summary` helper reimplemented the same buggy formula and one pinned golden was `total_hours: 50.0`. It is now `42.0` (4 x 8.5h N3 plus 8h OT), with the reason recorded in the docstring.

## Left alone

`_apply_ot_display_shift` still overwrites `hours` with `ot_shift.hours`. That is what the day and week views render, and changing it would affect display for a smaller gain than fixing the aggregation point where the double add actually happened.