### PR TITLE
Pin the on-call rules with a golden master, then collapse them

### DIFF
--- a/app/core/oncall.py
+++ b/app/core/oncall.py
@@ -13,15 +13,14 @@ ADDITIVE (OB system):
 REPLACEMENT (On-call system):
     - Only ONE rule applies to each time segment
     - Higher priority rules REPLACE lower priority rules completely
-    - Priority order: OC_SPECIAL (6) > OC_HOLIDAY (5) > OC_HOLIDAY_EVE (4) >
-                      OC_WEEKEND (3) > OC_FRIDAY_NIGHT (2) > OC_DEFAULT (1)
+    - Priority order: OC_NATIONALDAGEN (6) > OC_SPECIAL (5) > OC_HOLIDAY (4) >
+                      OC_HOLIDAY_EVE (3) > OC_WEEKEND (2) > OC_WEEKDAY (1)
     - Result: each hour of an on-call shift is compensated at exactly one rate
 
 Example:
-    A 24-hour on-call shift on Christmas Eve (Saturday):
-    - 06:00-07:00: OC_SPECIAL (storhelg) - highest priority
-    - 07:00-06:00: OC_SPECIAL continues (holiday block extends through weekend)
-    Total: 24h at rate 250 → månadslön / 250 = daily pay
+    A 24-hour on-call shift on Christmas Day, which is a Friday:
+    - 00:00-24:00: OC_SPECIAL (storhelg) replaces OC_WEEKDAY and OC_WEEKEND outright
+    Total: 24 h at 192 kr/h
 """
 
 import datetime
@@ -49,6 +48,63 @@ from .time_utils import subtract_covered
 
 # Load base rules from JSON config
 oncall_rules_base = load_oncall_rules()
+
+# Fixed hourly compensation in SEK. data/oncall_rules.json carries the same numbers
+# on its OC_HOLIDAY and OC_SPECIAL entries, but those entries have no days and no
+# specific_dates, so they never match anything: the rules generated below are what
+# actually pays out, and these constants are what they pay.
+RATE_STORHELG = 192
+RATE_RED_DAY = 112
+
+# Replacement priorities. The highest-priority rule covering an hour wins outright.
+PRIORITY_NATIONALDAGEN = 6
+PRIORITY_STORHELG = 5
+PRIORITY_RED_DAY = 4
+
+
+def _generated_rule(
+    code: str,
+    label: str,
+    date: datetime.date,
+    start: str,
+    end: str,
+    rate: int,
+    priority: int,
+) -> OnCallRule:
+    """One generated single-date rule. end "00:00" means midnight the following day."""
+    return OnCallRule(
+        code=code,
+        label=label,
+        specific_dates=[date.isoformat()],
+        start_time=start,
+        end_time=end,
+        fixed_hourly_rate=rate,
+        priority=priority,
+        generated=True,
+    )
+
+
+def _storhelg(date: datetime.date, start: str = "00:00", end: str = "00:00") -> OnCallRule:
+    """Storhelg day at 192 kr/h. Defaults to the full day."""
+    return _generated_rule("OC_SPECIAL", "Beredskap storhelg", date, start, end, RATE_STORHELG, PRIORITY_STORHELG)
+
+
+def _red_day(date: datetime.date, start: str = "00:00", end: str = "24:00") -> OnCallRule:
+    """Public holiday at 112 kr/h. Defaults to the full day."""
+    return _generated_rule("OC_HOLIDAY", "Beredskap röd dag", date, start, end, RATE_RED_DAY, PRIORITY_RED_DAY)
+
+
+def _nationaldagen_rule(date: datetime.date, start: str = "00:00", end: str = "00:00") -> OnCallRule:
+    """Nationaldagen block day. Red day rate, but its own code and top priority."""
+    return _generated_rule(
+        "OC_NATIONALDAGEN",
+        "Beredskap Nationaldagen",
+        date,
+        start,
+        end,
+        RATE_RED_DAY,
+        PRIORITY_NATIONALDAGEN,
+    )
 
 
 def _get_holidays_for_year(year: int) -> set[datetime.date]:
@@ -138,7 +194,7 @@ def _get_storhelg_dates_for_year(year: int) -> set[datetime.date]:
         storhelg.add(d)
         d += datetime.timedelta(days=1)
 
-    # New Year block: Dec 31 18:00 → first weekday after Jan 1
+    # New Year block: Dec 31 (opened at 17:00 on Dec 30) → first weekday after Jan 1
     # We add both Dec 31 and all days until first weekday
     storhelg.add(nyarsafton(year))
     new_year_end = first_weekday_after(nyarsdagen(year + 1))
@@ -154,7 +210,7 @@ def _get_storhelg_dates_for_year(year: int) -> set[datetime.date]:
         storhelg.add(d)
         d += datetime.timedelta(days=1)
 
-    # Easter block: Skärtorsdag 18:00 → first weekday after Annandag påsk
+    # Easter block: Skärtorsdag 17:00 → first weekday after Annandag påsk
     easter_start = skartorsdagen(year)
     easter_end = first_weekday_after(annandagpask(year))
     d = easter_start
@@ -183,308 +239,75 @@ def build_oncall_rules_for_year(year: int) -> list[OnCallRule]:
     1. Static rules from oncall_rules.json (weekday-based)
     2. Dynamically generated rules for specific holiday dates
 
-    Returns list sorted by priority (used for replacement logic).
+    Emission order is part of the contract: calculate_oncall_pay_for_period keeps the
+    first rule it sees per code. See tests/test_oncall_rules_golden.py.
     """
-    rules: list[OnCallRule] = []
-
-    for rule in oncall_rules_base:
-        rules.append(rule)
+    rules: list[OnCallRule] = list(oncall_rules_base)
 
     holidays = _get_holidays_for_year(year)
     storhelg_dates = _get_storhelg_dates_for_year(year)
 
-    # Nationaldagen gets special treatment: extended like storhelg but at red day rate (112 kr)
+    # Nationaldagen gets the same time windows a red day would get, but its own code
+    # and a priority above storhelg so nothing else can claim those hours.
     nationaldagen_block = _get_nationaldagen_block(year)
     nat_day = nationaldagen(year)
-
-    # Get first weekday after Nationaldagen
-    first_weekday = first_weekday_after(nat_day)
+    nat_eve = nat_day - datetime.timedelta(days=1)
+    nat_first_weekday = first_weekday_after(nat_day)
 
     for date in sorted(nationaldagen_block):
-        # Determine start and end times based on which day it is
-        if date == nat_day - datetime.timedelta(days=1):
-            # Day before Nationaldagen: start at 17:00
-            start_time = "17:00"
-            end_time = "00:00"
-            specific_dates = [date.isoformat()]
-            spans = False
-        elif date == first_weekday - datetime.timedelta(days=1):
-            # Last day before first weekday: full day (00:00-24:00)
-            start_time = "00:00"
-            end_time = "00:00"
-            specific_dates = [date.isoformat()]
-            spans = False
-        else:
-            # Nationaldagen itself and intermediate days: full day
-            start_time = "00:00"
-            end_time = "00:00"
-            specific_dates = [date.isoformat()]
-            spans = False
+        # The eve opens at 17:00; Nationaldagen itself and any day up to the first
+        # weekday is a full day.
+        rules.append(_nationaldagen_rule(date, start="17:00" if date == nat_eve else "00:00"))
 
-        rules.append(
-            OnCallRule(
-                code="OC_NATIONALDAGEN",
-                label="Beredskap Nationaldagen",
-                specific_dates=specific_dates,
-                start_time=start_time,
-                end_time=end_time,
-                fixed_hourly_rate=112,
-                priority=6,  # Higher than everything including storhelg to override weekend rules
-                generated=True,
-                spans_to_next_day=spans,
-            )
-        )
+    if nat_first_weekday not in nationaldagen_block:
+        rules.append(_nationaldagen_rule(nat_first_weekday, end="07:00"))
 
-    # Add separate rule for first weekday morning (00:00-07:00)
-    if first_weekday not in nationaldagen_block:
-        rules.append(
-            OnCallRule(
-                code="OC_NATIONALDAGEN",
-                label="Beredskap Nationaldagen",
-                specific_dates=[first_weekday.isoformat()],
-                start_time="00:00",
-                end_time="07:00",
-                fixed_hourly_rate=112,
-                priority=6,
-                generated=True,
-                spans_to_next_day=False,
-            )
-        )
-
-    # Add day-before rules for julafton and midsommarafton (start at 17:00)
-    julafton_date = julafton(year)
-    day_before_jul = julafton_date - datetime.timedelta(days=1)
-    if day_before_jul not in storhelg_dates:
-        rules.append(
-            OnCallRule(
-                code="OC_SPECIAL",
-                label="Beredskap storhelg",
-                specific_dates=[day_before_jul.isoformat()],
-                start_time="17:00",
-                end_time="00:00",
-                fixed_hourly_rate=192,
-                priority=5,
-                generated=True,
-            )
-        )
-
-    midsommar_date = midsommarafton(year)
-    day_before_midsommar = midsommar_date - datetime.timedelta(days=1)
-    if day_before_midsommar not in storhelg_dates:
-        rules.append(
-            OnCallRule(
-                code="OC_SPECIAL",
-                label="Beredskap storhelg",
-                specific_dates=[day_before_midsommar.isoformat()],
-                start_time="17:00",
-                end_time="00:00",
-                fixed_hourly_rate=192,
-                priority=5,
-                generated=True,
-            )
-        )
-
-    # Add day-before rule for nyårsafton (30/12 from 17:00)
-    nyarsafton_date = nyarsafton(year)
-    day_before_nyar = nyarsafton_date - datetime.timedelta(days=1)
-    if day_before_nyar not in storhelg_dates:
-        rules.append(
-            OnCallRule(
-                code="OC_SPECIAL",
-                label="Beredskap storhelg",
-                specific_dates=[day_before_nyar.isoformat()],
-                start_time="17:00",
-                end_time="00:00",
-                fixed_hourly_rate=192,
-                priority=5,
-                generated=True,
-            )
-        )
+    # Each storhelg block opens at 17:00 on the day before its first full day.
+    for eve in (
+        julafton(year) - datetime.timedelta(days=1),
+        midsommarafton(year) - datetime.timedelta(days=1),
+        nyarsafton(year) - datetime.timedelta(days=1),
+    ):
+        if eve not in storhelg_dates:
+            rules.append(_storhelg(eve, start="17:00"))
 
     for date in sorted(storhelg_dates):
-        if date == skartorsdagen(year):
-            start_time = "17:00"  # Skärtorsdag (day before långfredag) starts at 17:00
-        elif (
-            date == julafton(year)
-            or date == midsommarafton(year)
-            or date == nyarsafton(year)
-            or date == nyarsafton(year - 1)
-        ):
-            start_time = "00:00"  # Full day since day before already starts at 17:00
-        else:
-            start_time = "00:00"
-        rules.append(
-            OnCallRule(
-                code="OC_SPECIAL",
-                label="Beredskap storhelg",
-                specific_dates=[date.isoformat()],
-                start_time=start_time,
-                end_time="00:00",
-                fixed_hourly_rate=192,
-                priority=5,
-                generated=True,
-            )
-        )
+        # Skärtorsdag is the one storhelg day that is itself the opening day, so it
+        # starts at 17:00 rather than getting a separate eve rule above.
+        rules.append(_storhelg(date, start="17:00" if date == skartorsdagen(year) else "00:00"))
 
-    # Add rules for first weekday morning (00:00-07:00) after each storhelg block
-    # Christmas: first weekday after Dec 26
-    christmas_first_weekday = first_weekday_after(datetime.date(year, 12, 26))
-    if christmas_first_weekday not in storhelg_dates:
-        rules.append(
-            OnCallRule(
-                code="OC_SPECIAL",
-                label="Beredskap storhelg",
-                specific_dates=[christmas_first_weekday.isoformat()],
-                start_time="00:00",
-                end_time="07:00",
-                fixed_hourly_rate=192,
-                priority=5,
-                generated=True,
-            )
-        )
+    # Each storhelg block runs until 07:00 on the first weekday after it.
+    for block_end in (
+        first_weekday_after(datetime.date(year, 12, 26)),
+        first_weekday_after(nyarsdagen(year)),
+        first_weekday_after(annandagpask(year)),
+        first_weekday_after(midsommarafton(year) + datetime.timedelta(days=1)),
+    ):
+        if block_end not in storhelg_dates:
+            rules.append(_storhelg(block_end, end="07:00"))
 
-    # New Year: first weekday after Jan 1 (current year)
-    newyear_first_weekday = first_weekday_after(nyarsdagen(year))
-    if newyear_first_weekday not in storhelg_dates:
-        rules.append(
-            OnCallRule(
-                code="OC_SPECIAL",
-                label="Beredskap storhelg",
-                specific_dates=[newyear_first_weekday.isoformat()],
-                start_time="00:00",
-                end_time="07:00",
-                fixed_hourly_rate=192,
-                priority=5,
-                generated=True,
-            )
-        )
+    # Regular holidays: everything the storhelg and Nationaldagen blocks did not claim.
+    claimed = holidays | storhelg_dates | nationaldagen_block
+    for date in sorted(holidays - storhelg_dates - nationaldagen_block):
+        rules.append(_red_day(date))
 
-    # Easter: first weekday after Annandag påsk
-    easter_first_weekday = first_weekday_after(annandagpask(year))
-    if easter_first_weekday not in storhelg_dates:
-        rules.append(
-            OnCallRule(
-                code="OC_SPECIAL",
-                label="Beredskap storhelg",
-                specific_dates=[easter_first_weekday.isoformat()],
-                start_time="00:00",
-                end_time="07:00",
-                fixed_hourly_rate=192,
-                priority=5,
-                generated=True,
-            )
-        )
-
-    # Midsummer: first weekday after Midsommardagen
-    midsummer_day = midsommarafton(year) + datetime.timedelta(days=1)
-    midsummer_first_weekday = first_weekday_after(midsummer_day)
-    if midsummer_first_weekday not in storhelg_dates:
-        rules.append(
-            OnCallRule(
-                code="OC_SPECIAL",
-                label="Beredskap storhelg",
-                specific_dates=[midsummer_first_weekday.isoformat()],
-                start_time="00:00",
-                end_time="07:00",
-                fixed_hourly_rate=192,
-                priority=5,
-                generated=True,
-            )
-        )
-
-    # Regular holidays exclude storhelg and Nationaldagen block
-    regular_holidays = holidays - storhelg_dates - nationaldagen_block
-    for date in sorted(regular_holidays):
-        # Full day at holiday rate
-        rules.append(
-            OnCallRule(
-                code="OC_HOLIDAY",
-                label="Beredskap röd dag",
-                specific_dates=[date.isoformat()],
-                start_time="00:00",
-                end_time="24:00",
-                fixed_hourly_rate=112,
-                priority=4,
-                generated=True,
-            )
-        )
-
-        # Check if holiday falls on Fri-Sun for extended block
-        weekday = date.weekday()  # 0=Mon, 4=Fri, 5=Sat, 6=Sun
-
-        # Eve before holiday: 17:00-24:00 at holiday rate (112 kr)
         eve = date - datetime.timedelta(days=1)
-        if eve not in holidays and eve not in storhelg_dates and eve not in nationaldagen_block:
-            rules.append(
-                OnCallRule(
-                    code="OC_HOLIDAY",
-                    label="Beredskap röd dag",
-                    specific_dates=[eve.isoformat()],
-                    start_time="17:00",
-                    end_time="24:00",
-                    fixed_hourly_rate=112,
-                    priority=4,
-                    generated=True,
-                )
-            )
+        if eve not in claimed:
+            rules.append(_red_day(eve, start="17:00"))
 
-        # If holiday falls on Fri-Sun, extend to first weekday morning (like storhelg)
-        if weekday >= 4:  # Friday, Saturday, or Sunday
-            # Extend to first weekday after this holiday
-            first_weekday = first_weekday_after(date)
+        if date.weekday() >= 4:
+            # Friday to Sunday: the block runs over the weekend, like a storhelg block.
+            block_end = first_weekday_after(date)
             current = date + datetime.timedelta(days=1)
-
-            # Add full days until day before first weekday
-            while current < first_weekday:
-                if current not in holidays and current not in storhelg_dates and current not in nationaldagen_block:
-                    rules.append(
-                        OnCallRule(
-                            code="OC_HOLIDAY",
-                            label="Beredskap röd dag",
-                            specific_dates=[current.isoformat()],
-                            start_time="00:00",
-                            end_time="24:00",
-                            fixed_hourly_rate=112,
-                            priority=4,
-                            generated=True,
-                        )
-                    )
+            while current < block_end:
+                if current not in claimed:
+                    rules.append(_red_day(current))
                 current += datetime.timedelta(days=1)
-
-            # Add first weekday morning (00:00-07:00)
-            if (
-                first_weekday not in holidays
-                and first_weekday not in storhelg_dates
-                and first_weekday not in nationaldagen_block
-            ):
-                rules.append(
-                    OnCallRule(
-                        code="OC_HOLIDAY",
-                        label="Beredskap röd dag",
-                        specific_dates=[first_weekday.isoformat()],
-                        start_time="00:00",
-                        end_time="07:00",
-                        fixed_hourly_rate=112,
-                        priority=4,
-                        generated=True,
-                    )
-                )
         else:
-            # Weekday holiday: only add morning after (00:00-07:00)
-            day_after = date + datetime.timedelta(days=1)
-            if day_after not in holidays and day_after not in storhelg_dates and day_after not in nationaldagen_block:
-                rules.append(
-                    OnCallRule(
-                        code="OC_HOLIDAY",
-                        label="Beredskap röd dag",
-                        specific_dates=[day_after.isoformat()],
-                        start_time="00:00",
-                        end_time="07:00",
-                        fixed_hourly_rate=112,
-                        priority=4,
-                        generated=True,
-                    )
-                )
+            block_end = date + datetime.timedelta(days=1)
+
+        if block_end not in claimed:
+            rules.append(_red_day(block_end, end="07:00"))
 
     return rules
 

--- a/tests/test_oncall_rules_golden.py
+++ b/tests/test_oncall_rules_golden.py
@@ -1,0 +1,352 @@
+"""Golden master for build_oncall_rules_for_year.
+
+This function generates the on-call (jour/beredskap) compensation rules that drive
+real money: 192 kr/h for storhelg, 112 kr/h for a red day, 97/75 kr/h otherwise.
+The golden master pins every field of every rule, in emission order, so that a
+refactor or a rate change has to show exactly what moved.
+
+Years chosen to exercise the moveable feasts, since every storhelg block except
+Christmas and New Year hangs off Easter or Midsummer:
+- 2026: reference year (Nationaldagen on a Saturday, Christmas Eve on a Thursday)
+- 2027: early Easter (28 Mar), Nationaldagen on a Sunday
+- 2028: leap year
+- 2035: earliest Easter in the modern range (25 Mar), Kristi himmelsfard lands
+        the day after Forsta maj's morning-after rule
+- 2038: latest possible Easter (25 Apr), Nationaldagen on a Sunday
+
+To regenerate after an intentional change:
+    venv/bin/python3 -m pytest tests/test_oncall_rules_golden.py -q
+then run this module directly to print the new block:
+    venv/bin/python3 tests/test_oncall_rules_golden.py
+and paste the output over GOLDEN below, reviewing every changed line.
+"""
+
+import datetime
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# ruff: noqa: E402
+from app.core.oncall import build_oncall_rules_for_year
+
+GOLDEN_YEARS = (2026, 2027, 2028, 2035, 2038)
+
+
+def _format_rule(rule) -> str:
+    """One stable, human-diffable line per rule, with every field the model carries."""
+    if rule.specific_dates:
+        # Generated rules always carry exactly one date; assert rather than hide it.
+        assert len(rule.specific_dates) == 1, rule
+        day = datetime.date.fromisoformat(rule.specific_dates[0])
+        when = f"{day.isoformat()} {day:%a}"
+    else:
+        days = ",".join(str(d) for d in (rule.days or []))
+        when = f"weekdays[{days}]".ljust(19)
+    return (
+        f"{when}  {rule.code:<17} {rule.start_time}-{rule.end_time} "
+        f"rate={rule.rate} fixed={rule.fixed_hourly_rate} prio={rule.priority} "
+        f"spans={rule.spans_to_next_day} gen={rule.generated}"
+    )
+
+
+def _dump(year: int) -> list[str]:
+    """Rules for a year as text lines, in emission order (order is load-bearing)."""
+    return [f"# {year}"] + [_format_rule(r) for r in build_oncall_rules_for_year(year)]
+
+
+def _dump_all() -> list[str]:
+    lines: list[str] = []
+    for year in GOLDEN_YEARS:
+        lines.extend(_dump(year))
+    return lines
+
+
+GOLDEN = """\
+# 2026
+weekdays[0,1,2,3,4]  OC_WEEKDAY        00:00-24:00 rate=None fixed=75 prio=1 spans=False gen=False
+weekdays[4]          OC_WEEKEND        17:00-07:00 rate=None fixed=97 prio=2 spans=True gen=False
+weekdays[5]          OC_WEEKEND_SAT    00:00-24:00 rate=None fixed=97 prio=2 spans=False gen=False
+weekdays[6]          OC_WEEKEND_SUN    00:00-24:00 rate=None fixed=97 prio=2 spans=False gen=False
+weekdays[0]          OC_WEEKEND_MON    00:00-07:00 rate=None fixed=97 prio=2 spans=False gen=False
+weekdays[]           OC_HOLIDAY_EVE    18:00-07:00 rate=None fixed=97 prio=3 spans=True gen=True
+weekdays[]           OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+weekdays[]           OC_SPECIAL        00:00-24:00 rate=None fixed=192 prio=5 spans=False gen=True
+2026-06-05 Fri  OC_NATIONALDAGEN  17:00-00:00 rate=None fixed=112 prio=6 spans=False gen=True
+2026-06-06 Sat  OC_NATIONALDAGEN  00:00-00:00 rate=None fixed=112 prio=6 spans=False gen=True
+2026-06-07 Sun  OC_NATIONALDAGEN  00:00-00:00 rate=None fixed=112 prio=6 spans=False gen=True
+2026-06-08 Mon  OC_NATIONALDAGEN  00:00-07:00 rate=None fixed=112 prio=6 spans=False gen=True
+2026-12-23 Wed  OC_SPECIAL        17:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2026-06-18 Thu  OC_SPECIAL        17:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2026-12-30 Wed  OC_SPECIAL        17:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2026-01-01 Thu  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2026-04-02 Thu  OC_SPECIAL        17:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2026-04-03 Fri  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2026-04-04 Sat  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2026-04-05 Sun  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2026-04-06 Mon  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2026-06-19 Fri  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2026-06-20 Sat  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2026-06-21 Sun  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2026-12-24 Thu  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2026-12-25 Fri  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2026-12-26 Sat  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2026-12-27 Sun  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2026-12-31 Thu  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2027-01-01 Fri  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2027-01-02 Sat  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2027-01-03 Sun  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2026-12-28 Mon  OC_SPECIAL        00:00-07:00 rate=None fixed=192 prio=5 spans=False gen=True
+2026-01-02 Fri  OC_SPECIAL        00:00-07:00 rate=None fixed=192 prio=5 spans=False gen=True
+2026-04-07 Tue  OC_SPECIAL        00:00-07:00 rate=None fixed=192 prio=5 spans=False gen=True
+2026-06-22 Mon  OC_SPECIAL        00:00-07:00 rate=None fixed=192 prio=5 spans=False gen=True
+2026-01-06 Tue  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2026-01-05 Mon  OC_HOLIDAY        17:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2026-01-07 Wed  OC_HOLIDAY        00:00-07:00 rate=None fixed=112 prio=4 spans=False gen=True
+2026-05-01 Fri  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2026-04-30 Thu  OC_HOLIDAY        17:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2026-05-02 Sat  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2026-05-03 Sun  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2026-05-04 Mon  OC_HOLIDAY        00:00-07:00 rate=None fixed=112 prio=4 spans=False gen=True
+2026-05-14 Thu  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2026-05-13 Wed  OC_HOLIDAY        17:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2026-05-15 Fri  OC_HOLIDAY        00:00-07:00 rate=None fixed=112 prio=4 spans=False gen=True
+2026-10-31 Sat  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2026-10-30 Fri  OC_HOLIDAY        17:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2026-11-01 Sun  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2026-11-02 Mon  OC_HOLIDAY        00:00-07:00 rate=None fixed=112 prio=4 spans=False gen=True
+# 2027
+weekdays[0,1,2,3,4]  OC_WEEKDAY        00:00-24:00 rate=None fixed=75 prio=1 spans=False gen=False
+weekdays[4]          OC_WEEKEND        17:00-07:00 rate=None fixed=97 prio=2 spans=True gen=False
+weekdays[5]          OC_WEEKEND_SAT    00:00-24:00 rate=None fixed=97 prio=2 spans=False gen=False
+weekdays[6]          OC_WEEKEND_SUN    00:00-24:00 rate=None fixed=97 prio=2 spans=False gen=False
+weekdays[0]          OC_WEEKEND_MON    00:00-07:00 rate=None fixed=97 prio=2 spans=False gen=False
+weekdays[]           OC_HOLIDAY_EVE    18:00-07:00 rate=None fixed=97 prio=3 spans=True gen=True
+weekdays[]           OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+weekdays[]           OC_SPECIAL        00:00-24:00 rate=None fixed=192 prio=5 spans=False gen=True
+2027-06-05 Sat  OC_NATIONALDAGEN  17:00-00:00 rate=None fixed=112 prio=6 spans=False gen=True
+2027-06-06 Sun  OC_NATIONALDAGEN  00:00-00:00 rate=None fixed=112 prio=6 spans=False gen=True
+2027-06-07 Mon  OC_NATIONALDAGEN  00:00-07:00 rate=None fixed=112 prio=6 spans=False gen=True
+2027-12-23 Thu  OC_SPECIAL        17:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2027-06-24 Thu  OC_SPECIAL        17:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2027-12-30 Thu  OC_SPECIAL        17:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2027-01-01 Fri  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2027-01-02 Sat  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2027-01-03 Sun  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2027-03-25 Thu  OC_SPECIAL        17:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2027-03-26 Fri  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2027-03-27 Sat  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2027-03-28 Sun  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2027-03-29 Mon  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2027-06-25 Fri  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2027-06-26 Sat  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2027-06-27 Sun  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2027-12-24 Fri  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2027-12-25 Sat  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2027-12-26 Sun  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2027-12-31 Fri  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2028-01-01 Sat  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2028-01-02 Sun  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2027-12-27 Mon  OC_SPECIAL        00:00-07:00 rate=None fixed=192 prio=5 spans=False gen=True
+2027-01-04 Mon  OC_SPECIAL        00:00-07:00 rate=None fixed=192 prio=5 spans=False gen=True
+2027-03-30 Tue  OC_SPECIAL        00:00-07:00 rate=None fixed=192 prio=5 spans=False gen=True
+2027-06-28 Mon  OC_SPECIAL        00:00-07:00 rate=None fixed=192 prio=5 spans=False gen=True
+2027-01-06 Wed  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2027-01-05 Tue  OC_HOLIDAY        17:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2027-01-07 Thu  OC_HOLIDAY        00:00-07:00 rate=None fixed=112 prio=4 spans=False gen=True
+2027-05-01 Sat  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2027-04-30 Fri  OC_HOLIDAY        17:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2027-05-02 Sun  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2027-05-03 Mon  OC_HOLIDAY        00:00-07:00 rate=None fixed=112 prio=4 spans=False gen=True
+2027-05-06 Thu  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2027-05-05 Wed  OC_HOLIDAY        17:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2027-05-07 Fri  OC_HOLIDAY        00:00-07:00 rate=None fixed=112 prio=4 spans=False gen=True
+2027-11-06 Sat  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2027-11-05 Fri  OC_HOLIDAY        17:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2027-11-07 Sun  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2027-11-08 Mon  OC_HOLIDAY        00:00-07:00 rate=None fixed=112 prio=4 spans=False gen=True
+# 2028
+weekdays[0,1,2,3,4]  OC_WEEKDAY        00:00-24:00 rate=None fixed=75 prio=1 spans=False gen=False
+weekdays[4]          OC_WEEKEND        17:00-07:00 rate=None fixed=97 prio=2 spans=True gen=False
+weekdays[5]          OC_WEEKEND_SAT    00:00-24:00 rate=None fixed=97 prio=2 spans=False gen=False
+weekdays[6]          OC_WEEKEND_SUN    00:00-24:00 rate=None fixed=97 prio=2 spans=False gen=False
+weekdays[0]          OC_WEEKEND_MON    00:00-07:00 rate=None fixed=97 prio=2 spans=False gen=False
+weekdays[]           OC_HOLIDAY_EVE    18:00-07:00 rate=None fixed=97 prio=3 spans=True gen=True
+weekdays[]           OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+weekdays[]           OC_SPECIAL        00:00-24:00 rate=None fixed=192 prio=5 spans=False gen=True
+2028-06-05 Mon  OC_NATIONALDAGEN  17:00-00:00 rate=None fixed=112 prio=6 spans=False gen=True
+2028-06-06 Tue  OC_NATIONALDAGEN  00:00-00:00 rate=None fixed=112 prio=6 spans=False gen=True
+2028-06-07 Wed  OC_NATIONALDAGEN  00:00-07:00 rate=None fixed=112 prio=6 spans=False gen=True
+2028-12-23 Sat  OC_SPECIAL        17:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2028-06-22 Thu  OC_SPECIAL        17:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2028-12-30 Sat  OC_SPECIAL        17:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2028-01-01 Sat  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2028-01-02 Sun  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2028-04-13 Thu  OC_SPECIAL        17:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2028-04-14 Fri  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2028-04-15 Sat  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2028-04-16 Sun  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2028-04-17 Mon  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2028-06-23 Fri  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2028-06-24 Sat  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2028-06-25 Sun  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2028-12-24 Sun  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2028-12-25 Mon  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2028-12-26 Tue  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2028-12-31 Sun  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2029-01-01 Mon  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2028-12-27 Wed  OC_SPECIAL        00:00-07:00 rate=None fixed=192 prio=5 spans=False gen=True
+2028-01-03 Mon  OC_SPECIAL        00:00-07:00 rate=None fixed=192 prio=5 spans=False gen=True
+2028-04-18 Tue  OC_SPECIAL        00:00-07:00 rate=None fixed=192 prio=5 spans=False gen=True
+2028-06-26 Mon  OC_SPECIAL        00:00-07:00 rate=None fixed=192 prio=5 spans=False gen=True
+2028-01-06 Thu  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2028-01-05 Wed  OC_HOLIDAY        17:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2028-01-07 Fri  OC_HOLIDAY        00:00-07:00 rate=None fixed=112 prio=4 spans=False gen=True
+2028-05-01 Mon  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2028-04-30 Sun  OC_HOLIDAY        17:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2028-05-02 Tue  OC_HOLIDAY        00:00-07:00 rate=None fixed=112 prio=4 spans=False gen=True
+2028-05-25 Thu  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2028-05-24 Wed  OC_HOLIDAY        17:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2028-05-26 Fri  OC_HOLIDAY        00:00-07:00 rate=None fixed=112 prio=4 spans=False gen=True
+2028-11-04 Sat  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2028-11-03 Fri  OC_HOLIDAY        17:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2028-11-05 Sun  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2028-11-06 Mon  OC_HOLIDAY        00:00-07:00 rate=None fixed=112 prio=4 spans=False gen=True
+# 2035
+weekdays[0,1,2,3,4]  OC_WEEKDAY        00:00-24:00 rate=None fixed=75 prio=1 spans=False gen=False
+weekdays[4]          OC_WEEKEND        17:00-07:00 rate=None fixed=97 prio=2 spans=True gen=False
+weekdays[5]          OC_WEEKEND_SAT    00:00-24:00 rate=None fixed=97 prio=2 spans=False gen=False
+weekdays[6]          OC_WEEKEND_SUN    00:00-24:00 rate=None fixed=97 prio=2 spans=False gen=False
+weekdays[0]          OC_WEEKEND_MON    00:00-07:00 rate=None fixed=97 prio=2 spans=False gen=False
+weekdays[]           OC_HOLIDAY_EVE    18:00-07:00 rate=None fixed=97 prio=3 spans=True gen=True
+weekdays[]           OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+weekdays[]           OC_SPECIAL        00:00-24:00 rate=None fixed=192 prio=5 spans=False gen=True
+2035-06-05 Tue  OC_NATIONALDAGEN  17:00-00:00 rate=None fixed=112 prio=6 spans=False gen=True
+2035-06-06 Wed  OC_NATIONALDAGEN  00:00-00:00 rate=None fixed=112 prio=6 spans=False gen=True
+2035-06-07 Thu  OC_NATIONALDAGEN  00:00-07:00 rate=None fixed=112 prio=6 spans=False gen=True
+2035-12-23 Sun  OC_SPECIAL        17:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2035-06-21 Thu  OC_SPECIAL        17:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2035-12-30 Sun  OC_SPECIAL        17:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2035-01-01 Mon  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2035-03-22 Thu  OC_SPECIAL        17:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2035-03-23 Fri  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2035-03-24 Sat  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2035-03-25 Sun  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2035-03-26 Mon  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2035-06-22 Fri  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2035-06-23 Sat  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2035-06-24 Sun  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2035-12-24 Mon  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2035-12-25 Tue  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2035-12-26 Wed  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2035-12-31 Mon  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2036-01-01 Tue  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2035-12-27 Thu  OC_SPECIAL        00:00-07:00 rate=None fixed=192 prio=5 spans=False gen=True
+2035-01-02 Tue  OC_SPECIAL        00:00-07:00 rate=None fixed=192 prio=5 spans=False gen=True
+2035-03-27 Tue  OC_SPECIAL        00:00-07:00 rate=None fixed=192 prio=5 spans=False gen=True
+2035-06-25 Mon  OC_SPECIAL        00:00-07:00 rate=None fixed=192 prio=5 spans=False gen=True
+2035-01-06 Sat  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2035-01-05 Fri  OC_HOLIDAY        17:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2035-01-07 Sun  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2035-01-08 Mon  OC_HOLIDAY        00:00-07:00 rate=None fixed=112 prio=4 spans=False gen=True
+2035-05-01 Tue  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2035-04-30 Mon  OC_HOLIDAY        17:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2035-05-02 Wed  OC_HOLIDAY        00:00-07:00 rate=None fixed=112 prio=4 spans=False gen=True
+2035-05-03 Thu  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2035-05-02 Wed  OC_HOLIDAY        17:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2035-05-04 Fri  OC_HOLIDAY        00:00-07:00 rate=None fixed=112 prio=4 spans=False gen=True
+2035-11-03 Sat  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2035-11-02 Fri  OC_HOLIDAY        17:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2035-11-04 Sun  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2035-11-05 Mon  OC_HOLIDAY        00:00-07:00 rate=None fixed=112 prio=4 spans=False gen=True
+# 2038
+weekdays[0,1,2,3,4]  OC_WEEKDAY        00:00-24:00 rate=None fixed=75 prio=1 spans=False gen=False
+weekdays[4]          OC_WEEKEND        17:00-07:00 rate=None fixed=97 prio=2 spans=True gen=False
+weekdays[5]          OC_WEEKEND_SAT    00:00-24:00 rate=None fixed=97 prio=2 spans=False gen=False
+weekdays[6]          OC_WEEKEND_SUN    00:00-24:00 rate=None fixed=97 prio=2 spans=False gen=False
+weekdays[0]          OC_WEEKEND_MON    00:00-07:00 rate=None fixed=97 prio=2 spans=False gen=False
+weekdays[]           OC_HOLIDAY_EVE    18:00-07:00 rate=None fixed=97 prio=3 spans=True gen=True
+weekdays[]           OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+weekdays[]           OC_SPECIAL        00:00-24:00 rate=None fixed=192 prio=5 spans=False gen=True
+2038-06-05 Sat  OC_NATIONALDAGEN  17:00-00:00 rate=None fixed=112 prio=6 spans=False gen=True
+2038-06-06 Sun  OC_NATIONALDAGEN  00:00-00:00 rate=None fixed=112 prio=6 spans=False gen=True
+2038-06-07 Mon  OC_NATIONALDAGEN  00:00-07:00 rate=None fixed=112 prio=6 spans=False gen=True
+2038-12-23 Thu  OC_SPECIAL        17:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2038-06-24 Thu  OC_SPECIAL        17:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2038-12-30 Thu  OC_SPECIAL        17:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2038-01-01 Fri  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2038-01-02 Sat  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2038-01-03 Sun  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2038-04-22 Thu  OC_SPECIAL        17:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2038-04-23 Fri  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2038-04-24 Sat  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2038-04-25 Sun  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2038-04-26 Mon  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2038-06-25 Fri  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2038-06-26 Sat  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2038-06-27 Sun  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2038-12-24 Fri  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2038-12-25 Sat  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2038-12-26 Sun  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2038-12-31 Fri  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2039-01-01 Sat  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2039-01-02 Sun  OC_SPECIAL        00:00-00:00 rate=None fixed=192 prio=5 spans=False gen=True
+2038-12-27 Mon  OC_SPECIAL        00:00-07:00 rate=None fixed=192 prio=5 spans=False gen=True
+2038-01-04 Mon  OC_SPECIAL        00:00-07:00 rate=None fixed=192 prio=5 spans=False gen=True
+2038-04-27 Tue  OC_SPECIAL        00:00-07:00 rate=None fixed=192 prio=5 spans=False gen=True
+2038-06-28 Mon  OC_SPECIAL        00:00-07:00 rate=None fixed=192 prio=5 spans=False gen=True
+2038-01-06 Wed  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2038-01-05 Tue  OC_HOLIDAY        17:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2038-01-07 Thu  OC_HOLIDAY        00:00-07:00 rate=None fixed=112 prio=4 spans=False gen=True
+2038-05-01 Sat  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2038-04-30 Fri  OC_HOLIDAY        17:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2038-05-02 Sun  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2038-05-03 Mon  OC_HOLIDAY        00:00-07:00 rate=None fixed=112 prio=4 spans=False gen=True
+2038-06-03 Thu  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2038-06-02 Wed  OC_HOLIDAY        17:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2038-06-04 Fri  OC_HOLIDAY        00:00-07:00 rate=None fixed=112 prio=4 spans=False gen=True
+2038-11-06 Sat  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2038-11-05 Fri  OC_HOLIDAY        17:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2038-11-07 Sun  OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
+2038-11-08 Mon  OC_HOLIDAY        00:00-07:00 rate=None fixed=112 prio=4 spans=False gen=True
+"""
+
+
+def test_golden_master_matches():
+    """The full rule set for the pinned years is byte-for-byte what it was."""
+    assert _dump_all() == GOLDEN.splitlines()
+
+
+def test_inert_base_rules_are_exactly_the_known_three():
+    """A rule with neither days nor specific_dates matches nothing and can never pay out.
+
+    Three entries in data/oncall_rules.json are templates rather than live rules: they
+    ship with empty specific_dates, and the generator emits its own rules with the rate
+    hardcoded instead of reading these. Editing their fixed_hourly_rate in the JSON
+    therefore changes nothing. Pinned here so the situation cannot quietly grow.
+    """
+    inert = [r.code for r in build_oncall_rules_for_year(2026) if not r.days and not r.specific_dates]
+    assert inert == ["OC_HOLIDAY_EVE", "OC_HOLIDAY", "OC_SPECIAL"], inert
+
+
+def test_label_is_a_function_of_code():
+    """Labels are left out of the golden lines above, so pin the code to label map here."""
+    labels = {}
+    for year in GOLDEN_YEARS:
+        for rule in build_oncall_rules_for_year(year):
+            assert labels.setdefault(rule.code, rule.label) == rule.label, rule.code
+    assert labels == {
+        "OC_WEEKDAY": "Beredskap vardag",
+        "OC_WEEKEND": "Beredskap helg",
+        "OC_WEEKEND_SAT": "Beredskap helg l\u00f6rdag",
+        "OC_WEEKEND_SUN": "Beredskap helg s\u00f6ndag",
+        "OC_WEEKEND_MON": "Beredskap helg m\u00e5ndag",
+        "OC_HOLIDAY_EVE": "Beredskap helgdagsafton",
+        "OC_HOLIDAY": "Beredskap r\u00f6d dag",
+        "OC_SPECIAL": "Beredskap storhelg",
+        "OC_NATIONALDAGEN": "Beredskap Nationaldagen",
+    }
+
+
+if __name__ == "__main__":
+    print("\n".join(_dump_all()))


### PR DESCRIPTION
`build_oncall_rules_for_year` generates the on-call (jour) compensation rules: 15 near-identical `OnCallRule(...)` literals, roughly 315 lines, driving real money, with **zero test coverage**. Only the small interval helpers were tested.

Golden master first, refactor second, in separate commits.

## Equivalence

Stronger than the golden master alone: `model_dump()` of the old and new implementations was diffed field by field and in emission order for **every year from 1990 to 2120**. Zero differences. (Independently re-run and confirmed outside the authoring session.)

The golden master itself pins every field of every rule, one human-readable line each, for 2026, 2027 (early Easter), 2028 (leap), 2035 (earliest possible Easter, 25 Mar) and 2038 (latest, 25 Apr), so a future rate change shows up as a readable diff.

## The literals were consistent, but the golden master found four things

Coverage was verified independently: every day of 2020-2040 sums to exactly 24.0 h, and each storhelg and red-day block runs unbroken from eve 17:00 to first-weekday 07:00. No wrong rate, no empty interval, no gap. The findings are about redundancy and stale documentation, with one exception that needs a human.

**1. Storhelg eves start at 17:00 in code but the documentation says 18:00.** `_get_storhelg_dates_for_year`'s comments said "Dec 31 18:00" and "Skärtorsdag 18:00", and the dead `OC_HOLIDAY_EVE` JSON rule says 18:00, while every emitted rule uses 17:00. That hour is the difference between 192 and 75 kr, roughly 117 kr per storhelg eve, four eves a year, per person on call.

The comments were changed to match the code, not the reverse, because the repo does not say which one Handelns tjänstemannaavtal actually mandates. **This needs checking against the agreement.** If 18:00 is correct, the fix is now a two-character edit in three places instead of eight.

**2. Three of the eight rules in `data/oncall_rules.json` can never fire.** `OC_HOLIDAY_EVE`, `OC_HOLIDAY` and `OC_SPECIAL` have `days: null` and empty `specific_dates`, so nothing ever matches them. They are templates. The trap is that they carry `fixed_hourly_rate` 97, 112 and 192, which is exactly where someone would go to change the storhelg rate, and editing them changes nothing. Now pinned by a test and flagged in a comment next to the new constants.

**3. `OC_NATIONALDAGEN` is a 60-line duplicate of the generic red-day path.** Checked every year 2020-2080: the bespoke block emits identical dates, times and rate (112) to what the `regular_holidays` loop would emit, including the Fri-Sun weekend extension. Only the breakdown code, label and an inert priority differ. **Not deleted**: the code is user-visible in the pay breakdown and is the key of `day_pay_override.oncall_hours_override`, so collapsing it would silently reinterpret stored overrides. Worth a product decision.

**4. The module docstring's priority table was wrong in every row**, listing two rules that do not exist and being off by one because it predated `OC_NATIONALDAGEN`, and its worked example quoted the legacy `salary / 250` divisor. Corrected.

Also noted, not changed: `calculate_oncall_pay_for_period` dedupes candidate rules by `rule.code` and keeps the first. Across a year or block boundary there are several distinct `OC_SPECIAL` rules with different dates, so later ones get dropped. Harmless today only because both call sites pass a window confined to one calendar day. If that window is ever widened it becomes a pay bug.

## The two suspected dead branches

Both are dead in effect, but the first was described wrongly in the original review. The Nationaldagen if/elif/else does **not** have three identical arms: the first sets `start_time = "17:00"` and is taken once a year. The elif and else are identical, and the elif is genuinely reached, 101 times over 2000-2100, with no effect. The storhelg elif/else claim holds exactly, taken 303 times, both arms identical. Both removed.

A third class the review missed was kept deliberately: seven `if X not in storhelg_dates` guards that are true in all 101 years by construction. They are cheap and they are the only thing standing between a future holiday-definition change and a duplicate rule.

## Refactor

`RATE_STORHELG`, `RATE_RED_DAY` and the three priorities became module constants, replacing values hardcoded at 8, 6 and 5 sites. `_generated_rule()` plus named wrappers `_storhelg()`, `_red_day()` and `_nationaldagen_rule()` mean every call site now reads as date plus times. Three day-before blocks became one loop, four morning-after blocks another, and the triple membership tests one `claimed` set.

The function goes from **312 lines to 79**, the module from 911 to 734. CRLF line endings preserved (734 of 734).

## Tests

759 passed, up from 756.