### PR TITLE
Remove the three inert on-call rules

### DIFF
--- a/app/core/oncall.py
+++ b/app/core/oncall.py
@@ -14,8 +14,12 @@ REPLACEMENT (On-call system):
     - Only ONE rule applies to each time segment
     - Higher priority rules REPLACE lower priority rules completely
     - Priority order: OC_NATIONALDAGEN (6) > OC_SPECIAL (5) > OC_HOLIDAY (4) >
-                      OC_HOLIDAY_EVE (3) > OC_WEEKEND (2) > OC_WEEKDAY (1)
+                      OC_WEEKEND (2) > OC_WEEKDAY (1)
     - Result: each hour of an on-call shift is compensated at exactly one rate
+
+The eve of a holiday is not a separate rule: the generated OC_HOLIDAY (or
+OC_NATIONALDAGEN) rule for a holiday starts at 17:00 the day before, which is
+what the agreement specifies.
 
 Example:
     A 24-hour on-call shift on Christmas Day, which is a Friday:
@@ -24,6 +28,7 @@ Example:
 """
 
 import datetime
+import logging
 from functools import lru_cache
 
 from .holidays import (
@@ -46,13 +51,15 @@ from .models import OnCallRule
 from .storage import load_oncall_rules
 from .time_utils import subtract_covered
 
-# Load base rules from JSON config
+logger = logging.getLogger(__name__)
+
+# Load base rules from JSON config. These are the weekday and weekend rules only;
+# holiday and storhelg rules are generated per year below, because they depend on
+# dates that move.
 oncall_rules_base = load_oncall_rules()
 
-# Fixed hourly compensation in SEK. data/oncall_rules.json carries the same numbers
-# on its OC_HOLIDAY and OC_SPECIAL entries, but those entries have no days and no
-# specific_dates, so they never match anything: the rules generated below are what
-# actually pays out, and these constants are what they pay.
+# Fixed hourly compensation in SEK for the generated holiday rules. Change them
+# here: the JSON file no longer carries holiday entries to edit by mistake.
 RATE_STORHELG = 192
 RATE_RED_DAY = 112
 
@@ -702,6 +709,13 @@ def apply_oncall_hours_override(
             # Look up rate from rules
             rule = next((r for r in oncall_rules if r.code == code), None)
             if rule is None:
+                # A stored override naming a code no rule defines would otherwise be
+                # dropped without a trace, silently reducing the day's pay.
+                logger.warning(
+                    "Ignoring on-call override for unknown code %s (%s h): no rule defines it",
+                    code,
+                    h,
+                )
                 continue
             override_val = overrides.get(code)
             if override_val is not None:

--- a/data/oncall_rules.json
+++ b/data/oncall_rules.json
@@ -58,41 +58,5 @@
         "priority": 2,
         "spans_to_next_day": false,
         "generated": false
-    },
-    {
-        "code": "OC_HOLIDAY_EVE",
-        "label": "Beredskap helgdagsafton",
-        "description": "Afton före röd dag (från 18:00)",
-        "specific_dates": [],
-        "start_time": "18:00",
-        "end_time": "07:00",
-        "fixed_hourly_rate": 97,
-        "priority": 3,
-        "spans_to_next_day": true,
-        "generated": true
-    },
-    {
-        "code": "OC_HOLIDAY",
-        "label": "Beredskap röd dag",
-        "description": "Röd dag (helgdag)",
-        "specific_dates": [],
-        "start_time": "00:00",
-        "end_time": "24:00",
-        "fixed_hourly_rate": 112,
-        "priority": 4,
-        "spans_to_next_day": false,
-        "generated": true
-    },
-    {
-        "code": "OC_SPECIAL",
-        "label": "Beredskap storhelg",
-        "description": "Storhelg (jul, nyår, påsk, midsommar) - fram till första vardagen",
-        "specific_dates": [],
-        "start_time": "00:00",
-        "end_time": "24:00",
-        "fixed_hourly_rate": 192,
-        "priority": 5,
-        "spans_to_next_day": false,
-        "generated": true
     }
 ]

--- a/tests/test_oncall_rules_golden.py
+++ b/tests/test_oncall_rules_golden.py
@@ -69,9 +69,6 @@ weekdays[4]          OC_WEEKEND        17:00-07:00 rate=None fixed=97 prio=2 spa
 weekdays[5]          OC_WEEKEND_SAT    00:00-24:00 rate=None fixed=97 prio=2 spans=False gen=False
 weekdays[6]          OC_WEEKEND_SUN    00:00-24:00 rate=None fixed=97 prio=2 spans=False gen=False
 weekdays[0]          OC_WEEKEND_MON    00:00-07:00 rate=None fixed=97 prio=2 spans=False gen=False
-weekdays[]           OC_HOLIDAY_EVE    18:00-07:00 rate=None fixed=97 prio=3 spans=True gen=True
-weekdays[]           OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
-weekdays[]           OC_SPECIAL        00:00-24:00 rate=None fixed=192 prio=5 spans=False gen=True
 2026-06-05 Fri  OC_NATIONALDAGEN  17:00-00:00 rate=None fixed=112 prio=6 spans=False gen=True
 2026-06-06 Sat  OC_NATIONALDAGEN  00:00-00:00 rate=None fixed=112 prio=6 spans=False gen=True
 2026-06-07 Sun  OC_NATIONALDAGEN  00:00-00:00 rate=None fixed=112 prio=6 spans=False gen=True
@@ -121,9 +118,6 @@ weekdays[4]          OC_WEEKEND        17:00-07:00 rate=None fixed=97 prio=2 spa
 weekdays[5]          OC_WEEKEND_SAT    00:00-24:00 rate=None fixed=97 prio=2 spans=False gen=False
 weekdays[6]          OC_WEEKEND_SUN    00:00-24:00 rate=None fixed=97 prio=2 spans=False gen=False
 weekdays[0]          OC_WEEKEND_MON    00:00-07:00 rate=None fixed=97 prio=2 spans=False gen=False
-weekdays[]           OC_HOLIDAY_EVE    18:00-07:00 rate=None fixed=97 prio=3 spans=True gen=True
-weekdays[]           OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
-weekdays[]           OC_SPECIAL        00:00-24:00 rate=None fixed=192 prio=5 spans=False gen=True
 2027-06-05 Sat  OC_NATIONALDAGEN  17:00-00:00 rate=None fixed=112 prio=6 spans=False gen=True
 2027-06-06 Sun  OC_NATIONALDAGEN  00:00-00:00 rate=None fixed=112 prio=6 spans=False gen=True
 2027-06-07 Mon  OC_NATIONALDAGEN  00:00-07:00 rate=None fixed=112 prio=6 spans=False gen=True
@@ -171,9 +165,6 @@ weekdays[4]          OC_WEEKEND        17:00-07:00 rate=None fixed=97 prio=2 spa
 weekdays[5]          OC_WEEKEND_SAT    00:00-24:00 rate=None fixed=97 prio=2 spans=False gen=False
 weekdays[6]          OC_WEEKEND_SUN    00:00-24:00 rate=None fixed=97 prio=2 spans=False gen=False
 weekdays[0]          OC_WEEKEND_MON    00:00-07:00 rate=None fixed=97 prio=2 spans=False gen=False
-weekdays[]           OC_HOLIDAY_EVE    18:00-07:00 rate=None fixed=97 prio=3 spans=True gen=True
-weekdays[]           OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
-weekdays[]           OC_SPECIAL        00:00-24:00 rate=None fixed=192 prio=5 spans=False gen=True
 2028-06-05 Mon  OC_NATIONALDAGEN  17:00-00:00 rate=None fixed=112 prio=6 spans=False gen=True
 2028-06-06 Tue  OC_NATIONALDAGEN  00:00-00:00 rate=None fixed=112 prio=6 spans=False gen=True
 2028-06-07 Wed  OC_NATIONALDAGEN  00:00-07:00 rate=None fixed=112 prio=6 spans=False gen=True
@@ -218,9 +209,6 @@ weekdays[4]          OC_WEEKEND        17:00-07:00 rate=None fixed=97 prio=2 spa
 weekdays[5]          OC_WEEKEND_SAT    00:00-24:00 rate=None fixed=97 prio=2 spans=False gen=False
 weekdays[6]          OC_WEEKEND_SUN    00:00-24:00 rate=None fixed=97 prio=2 spans=False gen=False
 weekdays[0]          OC_WEEKEND_MON    00:00-07:00 rate=None fixed=97 prio=2 spans=False gen=False
-weekdays[]           OC_HOLIDAY_EVE    18:00-07:00 rate=None fixed=97 prio=3 spans=True gen=True
-weekdays[]           OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
-weekdays[]           OC_SPECIAL        00:00-24:00 rate=None fixed=192 prio=5 spans=False gen=True
 2035-06-05 Tue  OC_NATIONALDAGEN  17:00-00:00 rate=None fixed=112 prio=6 spans=False gen=True
 2035-06-06 Wed  OC_NATIONALDAGEN  00:00-00:00 rate=None fixed=112 prio=6 spans=False gen=True
 2035-06-07 Thu  OC_NATIONALDAGEN  00:00-07:00 rate=None fixed=112 prio=6 spans=False gen=True
@@ -265,9 +253,6 @@ weekdays[4]          OC_WEEKEND        17:00-07:00 rate=None fixed=97 prio=2 spa
 weekdays[5]          OC_WEEKEND_SAT    00:00-24:00 rate=None fixed=97 prio=2 spans=False gen=False
 weekdays[6]          OC_WEEKEND_SUN    00:00-24:00 rate=None fixed=97 prio=2 spans=False gen=False
 weekdays[0]          OC_WEEKEND_MON    00:00-07:00 rate=None fixed=97 prio=2 spans=False gen=False
-weekdays[]           OC_HOLIDAY_EVE    18:00-07:00 rate=None fixed=97 prio=3 spans=True gen=True
-weekdays[]           OC_HOLIDAY        00:00-24:00 rate=None fixed=112 prio=4 spans=False gen=True
-weekdays[]           OC_SPECIAL        00:00-24:00 rate=None fixed=192 prio=5 spans=False gen=True
 2038-06-05 Sat  OC_NATIONALDAGEN  17:00-00:00 rate=None fixed=112 prio=6 spans=False gen=True
 2038-06-06 Sun  OC_NATIONALDAGEN  00:00-00:00 rate=None fixed=112 prio=6 spans=False gen=True
 2038-06-07 Mon  OC_NATIONALDAGEN  00:00-07:00 rate=None fixed=112 prio=6 spans=False gen=True
@@ -317,16 +302,17 @@ def test_golden_master_matches():
     assert _dump_all() == GOLDEN.splitlines()
 
 
-def test_inert_base_rules_are_exactly_the_known_three():
+def test_no_inert_rules():
     """A rule with neither days nor specific_dates matches nothing and can never pay out.
 
-    Three entries in data/oncall_rules.json are templates rather than live rules: they
-    ship with empty specific_dates, and the generator emits its own rules with the rate
-    hardcoded instead of reading these. Editing their fixed_hourly_rate in the JSON
-    therefore changes nothing. Pinned here so the situation cannot quietly grow.
+    data/oncall_rules.json used to carry three such templates (OC_HOLIDAY_EVE,
+    OC_HOLIDAY, OC_SPECIAL). They were a trap: they held a fixed_hourly_rate, which is
+    exactly where someone would go to change a holiday rate, and editing it did nothing
+    because the generator hardcodes its own. They are gone; this keeps them gone.
     """
-    inert = [r.code for r in build_oncall_rules_for_year(2026) if not r.days and not r.specific_dates]
-    assert inert == ["OC_HOLIDAY_EVE", "OC_HOLIDAY", "OC_SPECIAL"], inert
+    for year in GOLDEN_YEARS:
+        inert = [r.code for r in build_oncall_rules_for_year(year) if not r.days and not r.specific_dates]
+        assert inert == [], f"{year}: {inert}"
 
 
 def test_label_is_a_function_of_code():
@@ -341,11 +327,36 @@ def test_label_is_a_function_of_code():
         "OC_WEEKEND_SAT": "Beredskap helg l\u00f6rdag",
         "OC_WEEKEND_SUN": "Beredskap helg s\u00f6ndag",
         "OC_WEEKEND_MON": "Beredskap helg m\u00e5ndag",
-        "OC_HOLIDAY_EVE": "Beredskap helgdagsafton",
         "OC_HOLIDAY": "Beredskap r\u00f6d dag",
         "OC_SPECIAL": "Beredskap storhelg",
         "OC_NATIONALDAGEN": "Beredskap Nationaldagen",
     }
+
+
+def test_holiday_codes_survive_without_their_base_rules():
+    """The day view's manual override form is built from these codes, and
+    apply_oncall_hours_override looks a code's rate up in the same list.
+
+    Removing the inert OC_HOLIDAY and OC_SPECIAL base rules is only safe because the
+    generator emits both codes every year regardless. If a year ever produced neither,
+    the override field would vanish and a stored value would be dropped.
+    """
+    for year in GOLDEN_YEARS:
+        codes = {r.code for r in build_oncall_rules_for_year(year)}
+        assert {"OC_HOLIDAY", "OC_SPECIAL", "OC_NATIONALDAGEN"} <= codes, f"{year}: {sorted(codes)}"
+
+
+def test_holiday_eves_are_covered_by_the_holiday_rule():
+    """OC_HOLIDAY_EVE was removed, not replaced: the agreement runs a holiday from
+    17:00 the day before, and the generated rule already starts there."""
+    rules = build_oncall_rules_for_year(2026)
+    by_date = {r.specific_dates[0]: r for r in rules if r.specific_dates}
+    # Trettondagsafton, Valborg, Alla helgons afton, Kristi himmelsfards afton.
+    for eve in ("2026-01-05", "2026-04-30", "2026-10-30", "2026-05-13"):
+        rule = by_date[eve]
+        assert rule.code == "OC_HOLIDAY", (eve, rule.code)
+        assert rule.start_time == "17:00", (eve, rule.start_time)
+        assert rule.fixed_hourly_rate == 112, (eve, rule.fixed_hourly_rate)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`data/oncall_rules.json` carried `OC_HOLIDAY_EVE`, `OC_HOLIDAY` and `OC_SPECIAL` with no `days` and an empty `specific_dates`, so nothing could ever match them.

They were a trap rather than dead weight: each held a `fixed_hourly_rate` (97, 112, 192), which is exactly where someone would go to change a holiday rate, and editing it changed nothing because `build_oncall_rules_for_year` hardcodes its own constants.

## They were less inert than they looked

Two consumers take a code and look it up in the whole rule list, so deleting an entry is not automatically safe:

- `schedule_personal.py` builds the day view's **manual override form** from every distinct code in the list, so every code becomes a fillable field.
- `apply_oncall_hours_override` resolves a stored override's rate the same way, and `continue`s if no rule defines the code, which silently drops those hours.

That made two of the three safe and the third worth a closer look:

| Code | Generated per year | Verdict |
|---|---|---|
| `OC_HOLIDAY` | 15 | Base entry redundant, code stays in the list |
| `OC_SPECIAL` | 24 | Base entry redundant, code stays in the list |
| `OC_HOLIDAY_EVE` | **0** | Base entry was the only source |

`OC_HOLIDAY_EVE` turned out to be the most worth removing. Its purpose is already covered: the agreement runs a holiday **from 17:00 the day before**, and the generated `OC_HOLIDAY` rule for each holiday already starts at 17:00 with the red-day rate. The base entry said **18:00 and 97 kr**, so it was not merely redundant, it was wrong on both the boundary and the rate. Anyone who filled that field in got a holiday eve priced as an ordinary weekend.

Verified for 2026: trettondagsafton, Valborg, alla helgons afton and Kristi himmelsfärds afton all resolve to `OC_HOLIDAY`, `17:00`, `112 kr`. Pinned in a new test.

## Proof nothing else moved

The golden master lost **exactly 15 lines** (three rules across five pinned years) and **gained none**. Zero generated rules changed.

Checked against the existing data: the override form still offers all eight meaningful codes, and both stored overrides in the dev database compute identical pay before and after.

## Tests

`test_inert_base_rules_are_exactly_the_known_three` becomes `test_no_inert_rules`, which is a stronger invariant: no rule may have neither `days` nor `specific_dates`, in any pinned year. Two new tests pin the reasoning above, so a future change that stops generating `OC_HOLIDAY` for some year fails loudly instead of quietly removing an override field.

761 passed, up from 759. `ruff` clean.

## One defensive fix

`apply_oncall_hours_override` now logs a warning when it drops an override for an unknown code. It reduced the day's pay silently before, which is precisely how a mistake of this shape would go unnoticed.