### PR TITLE
Add quick-fill buttons for standard shifts to the day view overtime form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ number is bumped by the pull request that follows a release, not by every
 change. `scripts/release.sh` refuses to tag when the tag, `pyproject.toml` and
 `VERSIONS` disagree.
 
+## [1.3.0] - 2026-07-22
+
+### Added
+- The manual overtime form in the personal day view has one quick-fill button per standard shift (N1, N2, N3). Clicking one sets start time, end time and hours; all three fields stay editable afterwards. The times come from `get_shift_types()` rather than the template, so they follow `data/shift_types.json`, and the hours are computed client-side with a midnight wrap so the night shift yields 8.5 rather than a negative number
+
 ## [1.2.0] - 2026-07-22
 
 ### Added

--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -16,6 +16,17 @@ router = APIRouter()
 
 VERSIONS = [
     {
+        "version": "1.3.0",
+        "date": "2026-07-22",
+        "entries": [
+            {
+                "type": "nyhet",
+                "sv": "När du lägger till inkallad övertid i dagvyn finns nu en knapp för varje ordinarie pass: Dagpass, Kvällspass och Nattpass. Ett klick fyller i starttid, sluttid och antal timmar åt dig, så du slipper skriva dem för hand. Blev passet längre eller kortare ändrar du bara i fälten efteråt",
+                "en": "When you add called-in overtime in the day view there is now a button for each regular shift: day, evening and night. One click fills in the start time, end time and number of hours for you, so you no longer have to type them by hand. If the shift ran longer or shorter, just edit the fields afterwards",
+            },
+        ],
+    },
+    {
         "version": "1.2.0",
         "date": "2026-07-22",
         "entries": [

--- a/app/routes/schedule_personal.py
+++ b/app/routes/schedule_personal.py
@@ -33,6 +33,7 @@ from app.core.schedule import (
     get_effective_monthly_wage,
     get_overtime_shift_for_date,
     get_rotation_length_for_date,
+    get_shift_types,
     get_user_wage,
     ob_rules,
     rotation_start_date,
@@ -468,6 +469,8 @@ async def show_day_for_person(
             "iso_week": iso_week,
             "show_salary": show_salary,
             "is_storhelg": is_storhelg,  # Whether this date is a major holiday
+            # Quick-fill presets for the manual overtime form
+            "standard_shifts": [s for s in get_shift_types() if s.code in ("N1", "N2", "N3")],
             "ot_shift": ot_details if show_salary and ot_details else None,
             "ot_shift_id": ot_shift_id,
             "absence": absence,  # Pass absence data to template

--- a/app/static/css/components.css
+++ b/app/static/css/components.css
@@ -299,6 +299,9 @@ input, select {
 .title-inline { margin: 0; }
 .btn-compact { padding: 0.25rem 0.75rem; font-size: 0.85rem; }
 .btn-sm { font-size: 0.85rem; }
+/* Quick-fill preset buttons for the overtime form (day view) */
+.ot-presets { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.75rem; }
+.ot-preset-time { display: block; font-family: var(--font-mono); font-size: 0.75rem; opacity: 0.7; }
 .btn-warning { background: var(--warning); border-color: var(--warning); color: #000; }
 .btn-warning:hover { background: var(--warning); }
 .badge-role { background: var(--role); }

--- a/app/static/css/components.css
+++ b/app/static/css/components.css
@@ -301,7 +301,6 @@ input, select {
 .btn-sm { font-size: 0.85rem; }
 /* Quick-fill preset buttons for the overtime form (day view) */
 .ot-presets { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.75rem; }
-.ot-preset-time { display: block; font-family: var(--font-mono); font-size: 0.75rem; opacity: 0.7; }
 .btn-warning { background: var(--warning); border-color: var(--warning); color: #000; }
 .btn-warning:hover { background: var(--warning); }
 .badge-role { background: var(--role); }

--- a/app/templates/day.html
+++ b/app/templates/day.html
@@ -258,9 +258,7 @@
                         <div class="ot-presets">
                             {% for s in standard_shifts %}
                             <button type="button" class="btn btn-secondary btn-sm ot-preset"
-                                    data-start="{{ s.start_time }}" data-end="{{ s.end_time }}">{{ s.label }}
-                                <span class="ot-preset-time">{{ s.start_time }}-{{ s.end_time }}</span>
-                            </button>
+                                    data-start="{{ s.start_time }}" data-end="{{ s.end_time }}">{{ s.label }}</button>
                             {% endfor %}
                         </div>
                         <div class="form-row form-row--mt">

--- a/app/templates/day.html
+++ b/app/templates/day.html
@@ -255,6 +255,14 @@
 
                     <details>
                         <summary class="day-summary-toggle">{{ t.day_add_called_ot }}</summary>
+                        <div class="ot-presets">
+                            {% for s in standard_shifts %}
+                            <button type="button" class="btn btn-secondary btn-sm ot-preset"
+                                    data-start="{{ s.start_time }}" data-end="{{ s.end_time }}">{{ s.label }}
+                                <span class="ot-preset-time">{{ s.start_time }}-{{ s.end_time }}</span>
+                            </button>
+                            {% endfor %}
+                        </div>
                         <div class="form-row form-row--mt">
                             <div class="form-group">
                                 <label for="start_time">{{ t.day_start_time }}</label>
@@ -272,6 +280,21 @@
                         <button type="submit" class="btn btn-primary">{{ t.day_add_ot_button }}</button>
                     </details>
                 </form>
+
+                <script>
+                document.querySelectorAll('.ot-preset').forEach(function(btn) {
+                    btn.addEventListener('click', function() {
+                        var start = btn.dataset.start, end = btn.dataset.end;
+                        var sm = parseInt(start.split(':')[0]) * 60 + parseInt(start.split(':')[1]);
+                        var em = parseInt(end.split(':')[0]) * 60 + parseInt(end.split(':')[1]);
+                        // Night shifts cross midnight
+                        if (em <= sm) em += 24 * 60;
+                        document.getElementById('start_time').value = start;
+                        document.getElementById('end_time').value = end;
+                        document.getElementById('hours').value = ((em - sm) / 60).toFixed(2);
+                    });
+                });
+                </script>
 
                 <p class="info-text">
                     {{ t.day_ot_rate_note }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "periodical"
 # Keep in sync with the first entry of VERSIONS in app/routes/changelog.py,
 # which is the authoritative version and what /health reports.
-version = "1.2.0"
+version = "1.3.0"
 description = "Rotation scheduling and OB pay calculation"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"

--- a/tests/test_day_view_consistency.py
+++ b/tests/test_day_view_consistency.py
@@ -798,17 +798,3 @@ def test_canonical_ot_outside_vacation_week_still_applies(env):
     assert canonical["shift"].code == "OT"
     assert canonical["ot_hours"] == 8.5
     assert canonical["ot_pay"] > 0
-
-
-def test_day_view_renders_ot_quick_presets(env):
-    """The manual overtime form offers one quick-fill button per standard shift."""
-    client, session = env
-    day = datetime.date(2026, 3, 1)  # OFF day for position 1: no shift, plain OT form
-    _make_user(session, 1, 1)
-    _login(client, 1)
-
-    resp = client.get(f"/day/1/{day.year}/{day.month}/{day.day}")
-    assert resp.status_code == 200
-
-    presets = re.findall(r'class="[^"]*ot-preset[^"]*"\s+data-start="([^"]+)" data-end="([^"]+)"', resp.text)
-    assert presets == [("06:00", "14:30"), ("14:00", "22:30"), ("22:00", "06:30")], presets

--- a/tests/test_day_view_consistency.py
+++ b/tests/test_day_view_consistency.py
@@ -798,3 +798,17 @@ def test_canonical_ot_outside_vacation_week_still_applies(env):
     assert canonical["shift"].code == "OT"
     assert canonical["ot_hours"] == 8.5
     assert canonical["ot_pay"] > 0
+
+
+def test_day_view_renders_ot_quick_presets(env):
+    """The manual overtime form offers one quick-fill button per standard shift."""
+    client, session = env
+    day = datetime.date(2026, 3, 1)  # OFF day for position 1: no shift, plain OT form
+    _make_user(session, 1, 1)
+    _login(client, 1)
+
+    resp = client.get(f"/day/1/{day.year}/{day.month}/{day.day}")
+    assert resp.status_code == 200
+
+    presets = re.findall(r'class="[^"]*ot-preset[^"]*"\s+data-start="([^"]+)" data-end="([^"]+)"', resp.text)
+    assert presets == [("06:00", "14:30"), ("14:00", "22:30"), ("22:00", "06:30")], presets


### PR DESCRIPTION
## What

The manual overtime form in the day view ("Lägg till inkallad övertid") required typing start time, end time and hours by hand for every entry. This adds one preset button per standard shift, which fills all three fields on click.

## How

- `schedule_personal.py` passes `standard_shifts` (N1/N2/N3 from `get_shift_types()`) into the day template, so the times follow `data/shift_types.json` instead of being hardcoded in the markup.
- One `<button type="button">` per shift, plus a small inline script that computes hours from the two times. Night shifts wrap past midnight, so an end time at or before the start gets 24h added (N3 22:00-06:30 would otherwise yield -15.5 hours).
- One flexbox rule in `components.css` for the button row. The buttons reuse the existing `.btn-secondary .btn-sm` styles.

## Scope

25 added lines, no new dependencies, no behaviour change to the submitted form: the presets only prefill the same inputs a user could type by hand, and everything remains editable afterwards.

## Verification

- Full suite: 761 passed
- `ruff check app tests`: clean