### PR TITLE
Fix extension hours silently staying at 0 past midnight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ change. `scripts/release.sh` refuses to tag when the tag, `pyproject.toml` and
 ### Added
 - The manual overtime form in the personal day view has one quick-fill button per standard shift (N1, N2, N3). Clicking one sets start time, end time and hours; all three fields stay editable afterwards. The times come from `get_shift_types()` rather than the template, so they follow `data/shift_types.json`, and the hours are computed client-side with a midnight wrap so the night shift yields 8.5 rather than a negative number
 
+### Fixed
+- The extension form in the day view computed hours as end minus start with no midnight wrap, so staying past midnight after an evening shift (22:30, home 00:30) gave a negative difference that the guard discarded. The hours field stayed at 0 and `min="0.01"` then blocked submission with nothing on screen explaining why. A negative difference now wraps by 24h; an unchanged end time still yields 0 rather than a full day. Server side is unaffected: `POST /overtime/add` prices from the submitted hours, not from the times
+
 ## [1.2.0] - 2026-07-22
 
 ### Added

--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -24,6 +24,11 @@ VERSIONS = [
                 "sv": "När du lägger till inkallad övertid i dagvyn finns nu en knapp för varje ordinarie pass: Dagpass, Kvällspass och Nattpass. Ett klick fyller i starttid, sluttid och antal timmar åt dig, så du slipper skriva dem för hand. Blev passet längre eller kortare ändrar du bara i fälten efteråt",
                 "en": "When you add called-in overtime in the day view there is now a button for each regular shift: day, evening and night. One click fills in the start time, end time and number of hours for you, so you no longer have to type them by hand. If the shift ran longer or shorter, just edit the fields afterwards",
             },
+            {
+                "type": "fix",
+                "sv": "Stannade du kvar över midnatt efter ett kvällspass gick förlängningen inte att spara: antalet timmar räknades ut som ett negativt tal, fältet blev kvar på noll och knappen gjorde ingenting utan att förklara varför. Nu räknas timmarna rätt över dygnsgränsen, så 22:30 till 00:30 ger 2 timmar",
+                "en": "Staying past midnight after an evening shift made the extension impossible to save: the number of hours came out negative, the field stayed at zero, and the button did nothing without saying why. Hours now count correctly across midnight, so 22:30 to 00:30 gives 2 hours",
+            },
         ],
     },
     {

--- a/app/templates/day.html
+++ b/app/templates/day.html
@@ -238,6 +238,8 @@
                             var sm = parseInt(start.split(':')[0]) * 60 + parseInt(start.split(':')[1]);
                             var em = parseInt(end.split(':')[0]) * 60 + parseInt(end.split(':')[1]);
                             var diff = em - sm;
+                            // Stayed past midnight (an evening shift ending 22:30, home 00:30)
+                            if (diff < 0) diff += 24 * 60;
                             if (diff > 0) hoursInput.value = (diff / 60).toFixed(2);
                         }
                         endInput.addEventListener('change', updateHours);


### PR DESCRIPTION
## The bug

The extension form in the day view ("stannade kvar till") derives the hours field from the two times:

```js
var diff = em - sm;
if (diff > 0) hoursInput.value = (diff / 60).toFixed(2);
```

Stay past midnight after an evening shift that ends 22:30 and enter 00:30 as the actual end, and `diff` is -1320. The guard drops it, the hours field stays at 0, and `min="0.01"` then blocks submission with no visible explanation. The user either gives up or types the hours by hand.

## The fix

Wrap a negative difference by 24 hours. A negative difference is the only ambiguous case: an unchanged end time still yields 0, so an accidental submit does not become a 24 hour day.

Server side needs no change. `POST /overtime/add` prices from the submitted `hours` (`app/routes/overtime.py:63`), not from the times, and `end_time < start_time` is already a normal stored state (N3 is 22:00-06:30).

## Not tested

There is no JS test setup in this repo and the logic is three lines, so this ships without one. The cases to check by hand in the day view: N2 (22:30) extended to 00:30 gives 2.00, N1 (14:30) extended to 16:00 gives 1.50, and an unchanged end time stays 0.

## Changelog

Deliberately not added here. The topmost VERSIONS block on main is the tagged 1.2.0, and #319 already opens 1.3.0. Once that lands, this note belongs in the 1.3.0 block with no further version bump.