### PR TITLE
docs(changelog): keep tooling-only changes out of the user release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,13 @@ number is bumped by the pull request that follows a release, not by every
 change. `scripts/release.sh` refuses to tag when the tag, `pyproject.toml` and
 `VERSIONS` disagree.
 
-## [1.4.1] - Unreleased
+A version number exists so a user can match what they see to a release note, so
+a change with no user-facing behaviour does not get one. Those land under
+`## [Unreleased]` here with no bump and no `VERSIONS` entry, and ship either with
+`./scripts/release.sh --notag` or alongside the next version that does have
+something to tell users about, whose pull request renames the heading.
+
+## [Unreleased]
 
 ### Fixed
 - The deploy shipped the previous release and reported success when a release tag was repointed. `deploy.sh` fetched with `git fetch --tags`, which refuses to move a tag the host already has and says so as a warning rather than an error, so the `git checkout "$TAG"` that follows resolved the stale local tag. The service restarted, the health check passed and the deploy went green with prod still on the old commit. Fetching with `--force` is the whole fix; the warning is easy to miss in a log that is otherwise all pip output

--- a/app/routes/changelog.py
+++ b/app/routes/changelog.py
@@ -16,17 +16,6 @@ router = APIRouter()
 
 VERSIONS = [
     {
-        "version": "1.4.1",
-        "date": "2026-08-05",
-        "entries": [
-            {
-                "type": "fix",
-                "sv": "En release kunde rapporteras som lyckad utan att appen faktiskt uppdaterades, så versionsnumret här nere stod kvar på det gamla trots att nyheterna var släppta. Det gick att hända om releasetaggen behövde flyttas i efterhand",
-                "en": "A release could report success without the app actually updating, so the version number down here stayed on the old one even though the new features had shipped. This could happen when a release tag had to be moved after the fact",
-            },
-        ],
-    },
-    {
         "version": "1.4.0",
         "date": "2026-08-05",
         "entries": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "periodical"
 # Keep in sync with the first entry of VERSIONS in app/routes/changelog.py,
 # which is the authoritative version and what /health reports.
-version = "1.4.1"
+version = "1.4.0"
 description = "Rotation scheduling and OB pay calculation"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"


### PR DESCRIPTION
## What

#325 gave the deploy and release script fixes a version of their own, 1.4.1, with a `VERSIONS` entry. That put deploy plumbing in front of users under a note stretched to find a user-facing angle ("a release could report success without the app actually updating"), which is true but not something a user has any use for.

A version number exists so a user can match what they see to a release note. A change that produces no note does not need one.

- `VERSIONS` 1.4.1 entry removed, `pyproject.toml` back to 1.4.0. The two stay in sync, so `release.sh` is happy.
- The section here becomes `## [Unreleased]`, keeping the three developer-facing entries, which do belong in this file.
- The convention at the top of `CHANGELOG.md` now says what to do with a change that has nothing to tell users, since it previously only described the bump-after-release case and left this one to be improvised.

## Shipping these

`./scripts/release.sh --notag`, or they ride along with the next version that does have user-facing content, whose pull request renames the heading.

## Testing

Changelog and version tests pass, ruff clean, `pyproject.toml` and `VERSIONS` both read 1.4.0.
