### PR TITLE
chore(ruff): leave markdown code blocks alone

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,11 @@ include = ["app", "app.*"]
 [tool.ruff]
 line-length = 120
 target-version = "py311"
+# Ruff 0.16 formats Python inside markdown code blocks. Docs use those blocks to show
+# a call argument or a wide dict spread over lines for readability, and reformatting
+# collapses them onto one 120-column line or reads a keyword argument as an
+# assignment. The prose is not compiled; leave it alone.
+extend-exclude = ["*.md"]
 
 [tool.ruff.lint]
 select = ["E", "W", "F", "I", "B", "UP"]


### PR DESCRIPTION
Unblocks #322.

Ruff 0.16 formats Python inside markdown code blocks, so bumping the pin fails the lint job on `DEPLOYMENT.md`, `docs/CORS.md`, `docs/LOGGING.md` and `docs/SENTRY.md`.

The reformatting makes those docs worse rather than better:

```python
# before, readable in docs
add_breadcrumb(
    message="User exported data",
    category="action",
    level="info",
    data={"format": "csv", "rows": 1000}
)
# after ruff 0.16
add_breadcrumb(message="User exported data", category="action", level="info", data={"format": "csv", "rows": 1000})
```

`SENTRY.md` also has `traces_sample_rate=0.1` read as an assignment and rewritten with spaces around the equals sign, even though the block is showing a function argument.

`extend-exclude = ["*.md"]` keeps ruff to the code it actually lints. Verified with both versions:

```
uvx ruff@0.16.1 format --check .   164 files already formatted
uvx ruff@0.16.1 check .            All checks passed!
ruff 0.15.22 (current pin)         unchanged, both green
```

Inert until the pin moves, since 0.15.22 does not look at markdown at all. Merge this first, then #322 goes green on a rebase.