### PR TITLE
fix(rates): allow four decimals in vacation rate inputs

### DIFF
--- a/app/templates/rates_form.html
+++ b/app/templates/rates_form.html
@@ -217,7 +217,7 @@
             {% for key, label, default, pct in vac_fields %}
             <div>
                 <label class="rate-vac-label">{{ label }} (std: {{ pct }})</label>
-                <input type="number" step="0.001" name="rate_vac_{{ key }}" min="0" max="1"
+                <input type="number" step="0.0001" name="rate_vac_{{ key }}" min="0" max="1"
                        value="{{ custom_rates.get('vacation', {}).get(key, '') }}"
                        placeholder="{{ default }}"
                        class="input rate-input--full">


### PR DESCRIPTION
The vacation rate fields use fractions (0.008, 0.005, 0.046), so a step of 0.001 makes the browser reject or round the defaults. Set step to 0.0001 so the standard values are enterable.