### PR TITLE
fix(report): build monthly report rows per employment segment

### DIFF
--- a/app/core/schedule/period.py
+++ b/app/core/schedule/period.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import time as dt_time
 from typing import NamedTuple
 
-from app.core.constants import MAX_PERSONS, PERSON_IDS, placeholder_person_name
+from app.core.constants import PERSON_IDS, placeholder_person_name
 from app.core.oncall import _cached_oncall_rules as get_oncall_rules
 from app.core.oncall import calculate_oncall_pay, calculate_oncall_pay_for_period
 from app.core.time_utils import parse_ot_times
@@ -1002,9 +1002,7 @@ def mask_days_to_employment(
     return masked
 
 
-def build_substitute_month_summaries(
-    year: int, month: int, session, include_overtime: bool = False, exclude_linked_attributed: bool = False
-) -> list[dict]:
+def build_substitute_month_summaries(year: int, month: int, session, include_overtime: bool = False) -> list[dict]:
     """Build per-substitute month summaries (schedule only, no salary) for the month view.
 
     Each summary mirrors the shape produced by summarize_month_for_person enough for
@@ -1016,14 +1014,9 @@ def build_substitute_month_summaries(
     renders as a day shift). With include_overtime=True, overtime-only substitutes are also
     included so their hours appear in the report totals (used by the report).
 
-    exclude_linked_attributed (issue #290, report double-count guard): with True,
-    worked/overtime days of a LINKED substitute that the linked user's own report
-    row already counts (dates where the canonical before-employment injection
-    renders them) are excluded here, and a row left with no activity is dropped.
-    Absence days and on-call standby stay on the substitute row (the user row
-    does not count them). Team month views keep the default (False): there the
-    user's column is masked to their tenure, so the substitute column is the
-    only place the activity appears.
+    A linked substitute's activity (issue #290) is always counted here in full: every
+    consumer masks a user's own column/row to their tenure, so a pre-employment
+    substitute day appears on the substitute's row only and is never double counted.
     """
     start_date = datetime.date(year, month, 1)
     end_date = datetime.date(year, month, calendar.monthrange(year, month)[1])
@@ -1038,38 +1031,6 @@ def build_substitute_month_summaries(
     absence_by_date = _fetch_substitute_absences_by_date(session, sub_ids, start_date, end_date)
     shift_types = get_shift_types()
     settings = get_settings()
-
-    # Report guard: collect the (substitute_id, date) days attributed to the
-    # linked user's row. The predicate mirrors the canonical injection exactly:
-    # the position's before-employment resolution (_resolve_day_person) decides
-    # whether the personal row rendered the day.
-    excluded_days: set[tuple[int, datetime.date]] = set()
-    linked_user_names: dict[int, str] = {}
-    if exclude_linked_attributed and session:
-        from app.database.database import User
-
-        for sub in substitutes:
-            if not sub.user_id:
-                continue
-            user = session.query(User).filter(User.id == sub.user_id).first()
-            if user is None:
-                continue
-            linked_user_names[sub.id] = user.name
-            position = user.rotation_person_id
-            if not (1 <= position <= MAX_PERSONS):
-                continue
-            current = start_date
-            while current <= end_date:
-                key = (sub.id, current)
-                entry = shift_map.get(key)
-                # Only days the user row counts can double-count: a worked
-                # shift or overtime, with no absence overriding it.
-                counted = key in ot_by_date or (entry is not None and entry.shift_code in ("N1", "N2", "N3"))
-                if counted and key not in absence_by_date:
-                    _, attributed = _resolve_day_person(session, position, current, None)
-                    if attributed:
-                        excluded_days.add(key)
-                current += datetime.timedelta(days=1)
 
     # OB rules for the month (same rules agents use); covers any year in range.
     combined_ob_rules: list = []
@@ -1086,25 +1047,15 @@ def build_substitute_month_summaries(
         ob_hours: dict[str, float] = {}
         current = start_date
         while current <= end_date:
-            # A day attributed to the linked user's report row renders and counts
-            # as OFF here (empty maps); absence days are never excluded.
-            excluded = (sub.id, current) in excluded_days
-            day = _build_substitute_day(
-                current,
-                sub,
-                {} if excluded else shift_map,
-                shift_types,
-                absence_by_date,
-                {} if excluded else ot_by_date,
-            )
+            day = _build_substitute_day(current, sub, shift_map, shift_types, absence_by_date, ot_by_date)
             days.append(day)
 
-            # Counting reads raw data, not the displayed shift, so that a day shown as OT
-            # is still counted by its underlying scheduled shift (e.g. OC + OT same day).
+            # Counting reads raw data, not the displayed shift, so that an on-call day
+            # worked as overtime still counts its standby hours (OC + OT same day).
             absence = absence_by_date.get((sub.id, current))
-            entry = None if excluded else shift_map.get((sub.id, current))
+            entry = shift_map.get((sub.id, current))
             code = entry.shift_code if entry else None
-            ot_entries_today = [] if excluded else ot_by_date.get((sub.id, current), [])
+            ot_entries_today = ot_by_date.get((sub.id, current), [])
             day_ot_hours = sum(o.hours or 0.0 for o in ot_entries_today)
             month_ot_hours += day_ot_hours
 
@@ -1128,7 +1079,10 @@ def build_substitute_month_summaries(
                     _, oc_details = _compute_oncall_pay(oc_shift, current, 0, {}, settings, None)
                 day["oncall_details"] = oc_details
                 oncall_hours += oc_details.get("total_hours", 0.0)
-            elif code in ("N1", "N2", "N3"):
+            elif code in ("N1", "N2", "N3") and not ot_entries_today:
+                # Substitute overtime is never an extension: it replaces the scheduled
+                # shift (see _build_substitute_day), so the day counts as OT only and
+                # its hours are not added on top (same rule as day_worked_hours).
                 hours, start, end = calculate_shift_hours(current, code)
                 worked_hours += hours
                 num_shifts += 1
@@ -1142,20 +1096,12 @@ def build_substitute_month_summaries(
 
         ot_hours = month_ot_hours
         counts = absence_counts.get(sub.id, {})
-        if exclude_linked_attributed:
-            has_remaining_activity = (
-                num_shifts > 0 or worked_hours > 0 or ot_hours > 0 or oncall_hours > 0 or any(counts.values())
-            )
-            if not has_remaining_activity:
-                # Fully attributed to the linked user's row: hide the row.
-                continue
         summaries.append(
             {
                 "person_id": f"sub-{sub.id}",
                 "substitute_id": sub.id,
                 "person_name": sub.name,
                 "linked_user_id": sub.user_id,
-                "linked_user_name": linked_user_names.get(sub.id),
                 "days": days,
                 "ob_pay": {},
                 "ob_hours": ob_hours,

--- a/app/core/schedule/summary.py
+++ b/app/core/schedule/summary.py
@@ -1548,10 +1548,66 @@ def _report_row_from_summary(summary: dict, is_substitute: bool) -> dict:
     }
 
 
-def build_month_report(year: int, month: int, session, fetch_tax_table: bool = False) -> list[dict]:
-    """Build one report row per agent (rotation positions 1-10) plus substitutes.
+def build_month_position_summaries(
+    year: int, month: int, session, fetch_tax_table: bool = False, user_wages: dict | None = None
+) -> list[dict]:
+    """Month summaries for rotation positions 1-10, one per holder segment.
 
-    Reuses summarize_month_for_person for agents and build_substitute_month_summaries
+    Follows PersonHistory the same way the team month view does: a position that
+    changes hands mid-month yields one summary per holder, each masked to their own
+    tenure, and a position vacant for the whole month yields none. Positions with no
+    history at all keep the legacy single unmasked summary.
+
+    Masking is what keeps a departing holder's row free of days that are not theirs,
+    including a successor's pre-employment linked-substitute days (issue #290): those
+    stay on the substitute's own row.
+    """
+    import calendar
+    import datetime as dt
+
+    from app.core.schedule.person_history import get_position_holder_segments, has_position_history
+
+    if user_wages is None:
+        user_wages = get_all_user_wages(session)
+    month_start = dt.date(year, month, 1)
+    month_end = dt.date(year, month, calendar.monthrange(year, month)[1])
+
+    summaries = []
+    for pid in range(1, 11):
+        segments = get_position_holder_segments(session, pid, month_start, month_end) if session else []
+        if not segments:
+            if session and has_position_history(session, pid):
+                continue  # Vacant for the whole month: no row.
+            segments = [None]  # Legacy position without history: one unmasked row.
+
+        # One row per segment. A user who held two DIFFERENT positions during the
+        # month (a mid-month swap) therefore gets one row per position rather than
+        # the single merged column the team month view builds.
+        for seg in segments:
+            month_days = generate_month_data(year, month, pid, session=session, user_wages=user_wages)
+            if seg is not None:
+                month_days = mask_days_to_employment(month_days, seg["from_date"], seg["to_date"])
+            summary = summarize_month_for_person(
+                year,
+                month,
+                pid,
+                session=session,
+                user_wages=user_wages,
+                year_days=month_days,
+                fetch_tax_table=fetch_tax_table,
+                payment_year=year,
+            )
+            if seg is not None:
+                summary["person_name"] = seg["name"]
+            summaries.append(summary)
+
+    return summaries
+
+
+def build_month_report(year: int, month: int, session, fetch_tax_table: bool = False) -> list[dict]:
+    """Build one report row per position holder (rotation positions 1-10) plus substitutes.
+
+    Reuses build_month_position_summaries for agents and build_substitute_month_summaries
     for substitutes, returning a flat list of rows ready for the report table / CSV.
     The report tracks time only, so tax lookups are skipped by default.
     """
@@ -1559,26 +1615,14 @@ def build_month_report(year: int, month: int, session, fetch_tax_table: bool = F
 
     user_wages = get_all_user_wages(session)
 
-    rows = []
-    for pid in range(1, 11):
-        month_days = generate_month_data(year, month, pid, session=session, user_wages=user_wages)
-        summary = summarize_month_for_person(
-            year,
-            month,
-            pid,
-            session=session,
-            user_wages=user_wages,
-            year_days=month_days,
-            fetch_tax_table=fetch_tax_table,
-            payment_year=year,
+    rows = [
+        _report_row_from_summary(summary, is_substitute=False)
+        for summary in build_month_position_summaries(
+            year, month, session, fetch_tax_table=fetch_tax_table, user_wages=user_wages
         )
-        rows.append(_report_row_from_summary(summary, is_substitute=False))
+    ]
 
-    # exclude_linked_attributed: a linked substitute's worked/OT days already
-    # count in the linked user's row above (issue #290 double-count guard).
-    for sub_summary in build_substitute_month_summaries(
-        year, month, session, include_overtime=True, exclude_linked_attributed=True
-    ):
+    for sub_summary in build_substitute_month_summaries(year, month, session, include_overtime=True):
         rows.append(_report_row_from_summary(sub_summary, is_substitute=True))
 
     return rows

--- a/app/routes/reports.py
+++ b/app/routes/reports.py
@@ -184,9 +184,9 @@ async def admin_report_xlsx(
 ):
     """Download the monthly report as an Excel workbook.
 
-    The first sheet is the consolidated report (same columns as the CSV). Each agent
-    (rotation positions 1-10) then gets its own sheet, formatted exactly like the
-    per-person month export.
+    The first sheet is the consolidated report (same columns as the CSV). Each holder
+    of a rotation position during the month then gets its own sheet, formatted exactly
+    like the per-person month export.
     """
     if not _has_report_access(current_user, token):
         raise HTTPException(status_code=403, detail="Åtkomst nekad")
@@ -194,7 +194,7 @@ async def admin_report_xlsx(
     from openpyxl.styles import Alignment, Font, PatternFill
 
     from app.core.schedule import build_substitute_month_summaries
-    from app.core.schedule.summary import summarize_month_for_person
+    from app.core.schedule.summary import build_month_position_summaries
     from app.routes.excel_shared import REPORT_COL_HEADERS, autofit_columns, populate_month_sheet
 
     year, month = _resolve_year_month(year, month)
@@ -216,20 +216,17 @@ async def admin_report_xlsx(
         ws.append([row.get(key, "") for key, _ in CSV_COLUMNS])
     autofit_columns(ws)
 
-    # One sheet per agent (rotation positions 1-10), identical to the /month/{id} export.
+    # One sheet per position holder, identical to the /month/{id} export. Same rows
+    # as the summary sheet, so a mid-month person change gets one tab per holder.
     used_titles = {ws.title}
-    for pid in range(1, 11):
-        summary = summarize_month_for_person(year, month, pid, session=db, payment_year=year)
-        title = _safe_sheet_title(summary.get("person_name") or f"Agent {pid}", used_titles)
+    for summary in build_month_position_summaries(year, month, db):
+        title = _safe_sheet_title(summary.get("person_name") or f"Agent {summary.get('person_id')}", used_titles)
         used_titles.add(title)
         agent_ws = wb.create_sheet(title=title)
         populate_month_sheet(agent_ws, summary, year, month, headers=REPORT_COL_HEADERS, split_oncall_overtime=False)
 
     # One sheet per substitute with activity in the month, same layout as the agent tabs.
-    # Linked substitutes' attributed days live on the user's own sheet (issue #290).
-    for sub_summary in build_substitute_month_summaries(
-        year, month, db, include_overtime=True, exclude_linked_attributed=True
-    ):
+    for sub_summary in build_substitute_month_summaries(year, month, db, include_overtime=True):
         title = _safe_sheet_title(sub_summary.get("person_name") or "Vikarie", used_titles)
         used_titles.add(title)
         sub_ws = wb.create_sheet(title=title)

--- a/tests/test_substitute_account_link.py
+++ b/tests/test_substitute_account_link.py
@@ -287,13 +287,15 @@ def test_month_grid_summary_includes_substitute_days(env):
 
 
 # ---------------------------------------------------------------------------
-# Report double-count guard (issue #290, plan step 5)
+# Report rows follow employment segments (issue #290 double-count guard,
+# reworked: rows are masked to each holder's tenure instead)
 # ---------------------------------------------------------------------------
 
 
 def test_report_attributes_linked_substitute_once(env):
-    """A linked substitute's pre-employment worked day counts in the user's
-    report row; the fully attributed substitute row is hidden."""
+    """A linked substitute's pre-employment worked day counts on the substitute
+    row only. The position has no row at all in a month before the holder starts,
+    so the day cannot be double counted."""
     _, session = env
     sub = _seed_linked_user(session, uid=1)
     day = datetime.date(2026, 3, 10)
@@ -301,13 +303,71 @@ def test_report_attributes_linked_substitute_once(env):
     session.commit()
 
     rows = build_month_report(2026, 3, session)
-    user_row = next(r for r in rows if r["person_id"] == 1 and not r["is_substitute"])
-    hours, _, _ = calculate_shift_hours(day, "N2")
-    assert user_row["total_hours"] == pytest.approx(round(hours, 1))
-    assert user_row["num_shifts"] == 1
+    assert [r for r in rows if r["person_id"] == 1 and not r["is_substitute"]] == [], (
+        "position 1 is vacant in March (holder starts in June): no agent row"
+    )
 
-    sub_rows = [r for r in rows if r["is_substitute"] and r.get("substitute_id") == sub.id]
-    assert sub_rows == [], "fully attributed substitute row must be hidden from the report"
+    hours, _, _ = calculate_shift_hours(day, "N2")
+    sub_row = next(r for r in rows if r["is_substitute"] and r["substitute_id"] == sub.id)
+    assert sub_row["total_hours"] == pytest.approx(round(hours, 1))
+    assert sub_row["num_shifts"] == 1
+
+
+def test_report_row_masked_to_departing_holder_tenure(env):
+    """A position handed over mid-month yields one row per holder, each counting
+    only its own tenure: the outgoing holder's row never absorbs the successor's
+    pre-employment substitute days."""
+    _, session = env
+    # Position 1: user 1 leaves after 2026-03-04, user 2 takes over 2026-04-01
+    # and works as a linked substitute in March before starting.
+    _make_user(session, 1, 1)
+    _make_user(session, 2, None)
+    session.add_all(
+        [
+            PersonHistory(
+                user_id=1,
+                person_id=1,
+                name="User 1",
+                username="u1",
+                is_active=0,
+                effective_from=datetime.date(2026, 1, 2),
+                effective_to=datetime.date(2026, 3, 4),
+            ),
+            PersonHistory(
+                user_id=2,
+                person_id=1,
+                name="User 2",
+                username="u2",
+                is_active=1,
+                effective_from=datetime.date(2026, 4, 1),
+            ),
+        ]
+    )
+    sub = Substitute(name="Sommarvikarie", is_active=1, user_id=2, hourly_wage=_SUB_WAGE)
+    session.add(sub)
+    session.commit()
+    day = datetime.date(2026, 3, 10)  # after user 1 left, before user 2 starts
+    session.add(SubstituteShift(substitute_id=sub.id, date=day, shift_code="N2"))
+    session.commit()
+
+    rows = build_month_report(2026, 3, session)
+    hours, _, _ = calculate_shift_hours(day, "N2")
+
+    sub_row = next(r for r in rows if r["is_substitute"] and r["substitute_id"] == sub.id)
+    assert sub_row["num_shifts"] == 1
+    assert sub_row["total_hours"] == pytest.approx(round(hours, 1))
+    # The successor is not employed in March, so position 1 has only one row.
+    position_rows = [r for r in rows if r["person_id"] == 1]
+    assert [r["person_name"] for r in position_rows] == ["User 1"]
+
+    # The outgoing holder's row is identical with and without the substitute
+    # shift: none of it leaks onto their row.
+    outgoing = position_rows[0]
+    session.query(SubstituteShift).delete()
+    session.commit()
+    clear_schedule_cache()
+    rows_without_sub = build_month_report(2026, 3, session)
+    assert outgoing == next(r for r in rows_without_sub if r["person_name"] == "User 1")
 
 
 def test_report_keeps_unlinked_substitute_row(env):
@@ -328,9 +388,9 @@ def test_report_keeps_unlinked_substitute_row(env):
     assert sub_row["num_shifts"] == 1
 
 
-def test_report_partial_attribution_keeps_remaining_days(env):
-    """Attributed worked days leave the substitute row, but activity the user
-    row does not count (an absence day) stays on the substitute row."""
+def test_report_keeps_worked_and_absence_days_on_substitute_row(env):
+    """A linked substitute's worked days and absence days both stay on the
+    substitute row, whatever the linked user's employment dates are."""
     _, session = env
     sub = _seed_linked_user(session, uid=1)
     worked = datetime.date(2026, 3, 10)
@@ -340,19 +400,16 @@ def test_report_partial_attribution_keeps_remaining_days(env):
     session.commit()
 
     rows = build_month_report(2026, 3, session)
-    user_row = next(r for r in rows if r["person_id"] == 1 and not r["is_substitute"])
     hours, _, _ = calculate_shift_hours(worked, "N2")
-    assert user_row["total_hours"] == pytest.approx(round(hours, 1))
-
-    sub_row = next(r for r in rows if r["is_substitute"] and r.get("substitute_id") == sub.id)
+    sub_row = next(r for r in rows if r["is_substitute"] and r["substitute_id"] == sub.id)
     assert sub_row["sick_days"] == 1
-    assert sub_row["total_hours"] == 0.0
-    assert sub_row["num_shifts"] == 0
+    assert sub_row["total_hours"] == pytest.approx(round(hours, 1))
+    assert sub_row["num_shifts"] == 1
 
 
 def test_report_ot_plus_shift_same_day_counts_once(env):
-    """OT and a scheduled shift on the same attributed date count once (as OT)
-    in the user's row, mirroring the canonical injection priority."""
+    """OT and a scheduled shift on the same substitute day count once (as OT):
+    substitute overtime replaces the scheduled shift, it is never an extension."""
     _, session = env
     sub = _seed_linked_user(session, uid=1)
     day = datetime.date(2026, 3, 10)
@@ -371,12 +428,10 @@ def test_report_ot_plus_shift_same_day_counts_once(env):
     session.commit()
 
     rows = build_month_report(2026, 3, session)
-    user_row = next(r for r in rows if r["person_id"] == 1 and not r["is_substitute"])
-    assert user_row["ot_hours"] == pytest.approx(8.5)
-    assert user_row["total_hours"] == pytest.approx(8.5)
-
-    sub_rows = [r for r in rows if r["is_substitute"] and r.get("substitute_id") == sub.id]
-    assert sub_rows == []
+    sub_row = next(r for r in rows if r["is_substitute"] and r["substitute_id"] == sub.id)
+    assert sub_row["ot_hours"] == pytest.approx(8.5)
+    assert sub_row["total_hours"] == pytest.approx(8.5)
+    assert sub_row["num_shifts"] == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

On `/admin/report`, a substitute linked to a user account could lose almost all of their shifts. For August 2026, Omar (Vikarie) showed 1 shift while he actually worked 12 plus one on-call day.

The monthly report built **one row per rotation position** and named it after whoever held that position on the 1st of the month. Position 5 was Isak's until 4 Aug; his successor Omar starts 1 Sep and works as a linked substitute in between. The double-count guard from issue #290 then dropped Omar's worked days from the substitute row, on the assumption that "the linked user's row already counts them". That row was the position 5 row, labelled **Isak**.

Result: Isak's row reported 12 shifts / 102 h, of which 11 shifts were Omar's substitute work, and Omar's own row kept only the single shift that fell inside Isak's tenure.

## Fix

Report rows now follow `PersonHistory` segments and are masked to each holder's tenure, the same rule the team month view already uses (`schedule_all.py`):

- a position that changes hands mid-month yields one row per holder, each counting only its own days;
- a position vacant for the whole month yields no row;
- positions without any history keep their legacy single unmasked row.

With masking in place, a successor's pre-employment days can never land on the outgoing holder's row, so the report guard is unnecessary and is removed along with `exclude_linked_attributed` (about 50 lines in `period.py`). A linked substitute's activity stays on the substitute row.

The Excel export builds its per-person sheets from the same summaries, so a mid-month person change now gets one tab per holder instead of one tab per position.

## Also fixed

Substitute overtime on a day that also has a scheduled shift was counted twice (both the shift hours and the OT hours, and two shifts). Substitute overtime replaces the scheduled shift for display and is never an extension, so the day now counts once, matching `day_worked_hours` on the agent path. This already affected unlinked substitutes; removing the guard made it reachable for linked ones too.

## Result (August 2026, dev data)

| Row | Before | After |
| --- | --- | --- |
| Isak | 12 shifts / 102.0 h | 1 shift / 8.5 h |
| Omar (Vikarie) | 1 shift / 8.5 h | 12 shifts / 102.0 h |

All other rows unchanged.

## Known gap, not addressed

Absence day counts are not segment scoped: `get_absence_deductions_for_month` queries the whole calendar month per `user_id`, so a departing holder's row can still show absence days registered after their last day. That is a separate defect in the absence aggregation, not in the row split.

## Testing

- `tests/test_substitute_account_link.py`: the three tests that encoded the old attribution rule were rewritten for the new contract, plus a new test covering a mid-month handover where the successor works as a linked substitute before starting.
- Full suite: 903 passed, 32 skipped.
- Verified manually against the dev database via the HTML report, the CSV export and the xlsx export.
